### PR TITLE
Random waveform injection improvements

### DIFF
--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -27,7 +27,6 @@ class RandomWaveformInjection(torch.nn.Module):
         highpass: Optional[float] = None,
         prob: float = 1.0,
         trigger_offset: float = 0,
-        fixed: bool = False,
         **polarizations: np.ndarray,
     ) -> None:
         """Randomly inject gravitational waveforms into time domain data
@@ -127,7 +126,6 @@ class RandomWaveformInjection(torch.nn.Module):
             )
         self.prob = prob
         self.trigger_offset = int(trigger_offset * sample_rate)
-        self.fixed = fixed
 
         # store ifo geometries
         self.ifos = ifos
@@ -443,7 +441,6 @@ class RandomWaveformInjection(torch.nn.Module):
                 kernel_size=X.shape[-1],
                 max_center_offset=self.trigger_offset,
                 coincident=True,
-                fixed=self.fixed,
             )
             X[mask] += waveforms
 

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -398,6 +398,7 @@ class RandomWaveformInjection(torch.nn.Module):
             **polarizations,
         )
 
+        
         if self.snr is not None:
             target_snrs = self._sample_source_param(self.snr, idx, N)
             rescaled_responses = gw.reweight_snrs(
@@ -408,15 +409,15 @@ class RandomWaveformInjection(torch.nn.Module):
                 highpass=self.mask,
             )
 
-            extrinsic_params = torch.column_stack((dec, psi, phi, target_snrs))
+            sampled_params = torch.column_stack((dec, psi, phi, target_snrs))
         else:
-            extrinsic_params = torch.column_stack((dec, psi, phi))
+            sampled_params = torch.column_stack((dec, psi, phi))
             rescaled_responses = ifo_responses 
         
         if self.intrinsic_parameters is not None: 
             intrinsic_parameters = self.intrinsic_parameters[idx]
-            sampled_params = torch.column_stack([extrinsic_params, intrinsic_parameters])
-        
+            sampled_params = torch.column_stack([sampled_params, intrinsic_parameters])
+       
         return rescaled_responses, sampled_params
 
     def forward(
@@ -441,6 +442,6 @@ class RandomWaveformInjection(torch.nn.Module):
             )
             X[mask] += waveforms
         
-            indices = torch.where(mask) 
+            indices = torch.where(mask)[0]
 
         return X, indices, sampled_params

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import Callable as CallableType
-from typing import Optional, Tuple, Union, Iterable
+from typing import Iterable, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -34,9 +34,10 @@ class RandomWaveformInjection(torch.nn.Module):
         Transform that uses a bank of gravitational waveform
         polarizations and source parameters to generate interferometer
         responses which are randomly injected into background timeseries
-        data. The `forward` method returns the combined background and injections
-        tensor, the indices at which these injections where made, and the parameters
-        used to generate the injections. 
+        data. The `forward` method returns the
+        combined background and injections tensor,
+        the indices at which these injections where made,
+        and the parameters used to generate the injections.
 
         Before this module can be used, it must be fit to the background
         PSDs of the interferometers whose responses to the raw gravitational
@@ -63,7 +64,7 @@ class RandomWaveformInjection(torch.nn.Module):
         Args:
             sample_rate:
                 Rate at which data used at call-time will be sampled.
-            ifos: 
+            ifos:
                 Interferometers onto which polarizations will be projected.
             dec:
                 Source parameter specifying the declination of each
@@ -83,12 +84,11 @@ class RandomWaveformInjection(torch.nn.Module):
             snr:
                 Source parameter specifying the desired signal to noise
                 ratio of each injection. See description above about how
-                this can be specified. If left as `None`, no SNR reweighting will   
-                be performed.  
-            intrinsic_parameters: 
-                Tensor of shape (n_pols, n_params) representing the intrinsic parameters 
-                used to produce the passed polarizations. 
-                
+                this can be specified. If left as `None`, no SNR reweighting
+                will be performed.
+            intrinsic_parameters:
+                Tensor containing the intrinsic parameters
+                used to produce the passed polarizations.
             highpass:
                 Frequency below which PSD data will not contribute
                 to the SNR calculation. If left as `None`, SNR will
@@ -126,13 +126,13 @@ class RandomWaveformInjection(torch.nn.Module):
             )
         self.prob = prob
         self.trigger_offset = int(trigger_offset * sample_rate)
-        
-        # store ifo geometries 
+
+        # store ifo geometries
         self.ifos = ifos
         tensors, vertices = gw.get_ifo_geometry(*ifos)
         self.tensors = torch.nn.Parameter(tensors, requires_grad=False)
         self.vertices = torch.nn.Parameter(vertices, requires_grad=False)
-        
+
         # make sure we have the same number of waveforms
         # for all the different polarizations
         num_waveforms = waveform_size = None
@@ -151,7 +151,7 @@ class RandomWaveformInjection(torch.nn.Module):
             self.polarizations[polarization] = torch.nn.Parameter(
                 torch.Tensor(tensor), requires_grad=False
             )
-        
+
         self.intrinsic_parameters = None
         if intrinsic_parameters is not None:
             if len(intrinsic_parameters) != num_waveforms:
@@ -161,15 +161,17 @@ class RandomWaveformInjection(torch.nn.Module):
                         len(intrinsic_parameters), num_waveforms
                     )
                 )
-            self.intrinsic_parameters = torch.nn.Parameter(torch.Tensor(intrinsic_parameters), requires_grad=False)
-             
+            self.intrinsic_parameters = torch.nn.Parameter(
+                torch.Tensor(intrinsic_parameters), requires_grad=False
+            )
+
         # confirm that the source parameters all either
         # are a callable or have a length equal to the
         # number of waveforms
         names = ["dec", "psi", "phi", "snr"]
 
         for name, param in zip(names, [dec, psi, phi, snr]):
-           
+
             if not isinstance(param, Callable) and param is not None:
                 try:
                     length = len(param)
@@ -258,12 +260,10 @@ class RandomWaveformInjection(torch.nn.Module):
                 the inverse of the length of `self.polarizations` in
                 seconds.
         """
-        
+
         if self.snr is None:
-            raise TypeError(
-                "Cannot fit to backgrounds if snr is None" 
-            )
-        
+            raise TypeError("Cannot fit to backgrounds if snr is None")
+
         sample_rate = sample_rate or self.sample_rate
         psds = []
         for ifo, background in backgrounds.items():
@@ -387,7 +387,7 @@ class RandomWaveformInjection(torch.nn.Module):
         phi = self._sample_source_param(self.phi, idx, N)
 
         polarizations = {k: v[idx] for k, v in self.polarizations.items()}
-       
+
         ifo_responses = gw.compute_observed_strain(
             dec,
             psi,
@@ -398,7 +398,6 @@ class RandomWaveformInjection(torch.nn.Module):
             **polarizations,
         )
 
-        
         if self.snr is not None:
             target_snrs = self._sample_source_param(self.snr, idx, N)
             rescaled_responses = gw.reweight_snrs(
@@ -412,23 +411,26 @@ class RandomWaveformInjection(torch.nn.Module):
             sampled_params = torch.column_stack((dec, psi, phi, target_snrs))
         else:
             sampled_params = torch.column_stack((dec, psi, phi))
-            rescaled_responses = ifo_responses 
-        
-        if self.intrinsic_parameters is not None: 
+            rescaled_responses = ifo_responses
+
+        if self.intrinsic_parameters is not None:
             intrinsic_parameters = self.intrinsic_parameters[idx]
-            sampled_params = torch.column_stack([sampled_params, intrinsic_parameters])
-       
+            sampled_params = torch.column_stack(
+                [sampled_params, intrinsic_parameters]
+            )
+
         return rescaled_responses, sampled_params
 
     def forward(
-        self, X: gw.WaveformTensor,
+        self,
+        X: gw.WaveformTensor,
     ) -> gw.WaveformTensor:
         """Sample waveforms and inject them into random batch elements
 
         Batch elements from `X` will be selected at random for
         injection. Returns the tensor `X` with random injections,
         the indices where injections were done, and the parameters
-        of the injections. 
+        of the injections.
         """
         if self.training:
             mask = torch.rand(size=X.shape[:1]) < self.prob
@@ -441,7 +443,7 @@ class RandomWaveformInjection(torch.nn.Module):
                 coincident=True,
             )
             X[mask] += waveforms
-        
+
             indices = torch.where(mask)[0]
 
         return X, indices, sampled_params

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -416,7 +416,7 @@ class RandomWaveformInjection(torch.nn.Module):
         if self.intrinsic_parameters is not None:
             intrinsic_parameters = self.intrinsic_parameters[idx]
             sampled_params = torch.column_stack(
-                [sampled_params, intrinsic_parameters]
+                [intrinsic_parameters, sampled_params]
             )
 
         return rescaled_responses, sampled_params

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -443,7 +443,7 @@ class RandomWaveformInjection(torch.nn.Module):
                 kernel_size=X.shape[-1],
                 max_center_offset=self.trigger_offset,
                 coincident=True,
-                self.fixed,
+                fixed=self.fixed,
             )
             X[mask] += waveforms
 

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -27,6 +27,7 @@ class RandomWaveformInjection(torch.nn.Module):
         highpass: Optional[float] = None,
         prob: float = 1.0,
         trigger_offset: float = 0,
+        fixed: bool = False,
         **polarizations: np.ndarray,
     ) -> None:
         """Randomly inject gravitational waveforms into time domain data
@@ -126,6 +127,7 @@ class RandomWaveformInjection(torch.nn.Module):
             )
         self.prob = prob
         self.trigger_offset = int(trigger_offset * sample_rate)
+        self.fixed = fixed
 
         # store ifo geometries
         self.ifos = ifos
@@ -441,6 +443,7 @@ class RandomWaveformInjection(torch.nn.Module):
                 kernel_size=X.shape[-1],
                 max_center_offset=self.trigger_offset,
                 coincident=True,
+                self.fixed,
             )
             X[mask] += waveforms
 

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import Callable as CallableType
-from typing import Iterable, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -18,7 +18,7 @@ class RandomWaveformInjection(torch.nn.Module):
     def __init__(
         self,
         sample_rate: float,
-        ifos: Iterable[str],
+        ifos: List[str],
         dec: SourceParameter,
         psi: SourceParameter,
         phi: SourceParameter,

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import Callable as CallableType
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, Iterable
 
 import numpy as np
 import torch
@@ -18,6 +18,7 @@ class RandomWaveformInjection(torch.nn.Module):
     def __init__(
         self,
         sample_rate: float,
+        ifos: Iterable[str],
         dec: SourceParameter,
         psi: SourceParameter,
         phi: SourceParameter,
@@ -33,8 +34,9 @@ class RandomWaveformInjection(torch.nn.Module):
         Transform that uses a bank of gravitational waveform
         polarizations and source parameters to generate interferometer
         responses which are randomly injected into background timeseries
-        data. If a target tensor is provided at call time, its value at
-        all the batch elements on which an injection is performed is set to 1.
+        data. The `forward` method returns the combined background and injections
+        tensor, the indices at which these injections where made, and the parameters
+        used to generate the injections. 
 
         Before this module can be used, it must be fit to the background
         PSDs of the interferometers whose responses to the raw gravitational
@@ -59,6 +61,10 @@ class RandomWaveformInjection(torch.nn.Module):
         on its own.
 
         Args:
+            sample_rate:
+                Rate at which data used at call-time will be sampled.
+            ifos: 
+                Interferometers onto which polarizations will be projected.
             dec:
                 Source parameter specifying the declination of each
                 source in radians relative to the celestial north.
@@ -77,9 +83,12 @@ class RandomWaveformInjection(torch.nn.Module):
             snr:
                 Source parameter specifying the desired signal to noise
                 ratio of each injection. See description above about how
-                this can be specified.
-            sample_rate:
-                Rate at which data used at call-time will be sampled.
+                this can be specified. If left as `None`, no SNR reweighting will   
+                be performed.  
+            intrinsic_parameters: 
+                Tensor of shape (n_pols, n_params) representing the intrinsic parameters 
+                used to produce the passed polarizations. 
+                
             highpass:
                 Frequency below which PSD data will not contribute
                 to the SNR calculation. If left as `None`, SNR will
@@ -117,7 +126,13 @@ class RandomWaveformInjection(torch.nn.Module):
             )
         self.prob = prob
         self.trigger_offset = int(trigger_offset * sample_rate)
-
+        
+        # store ifo geometries 
+        self.ifos = ifos
+        tensors, vertices = gw.get_ifo_geometry(*ifos)
+        self.tensors = torch.nn.Parameter(tensors, requires_grad=False)
+        self.vertices = torch.nn.Parameter(vertices, requires_grad=False)
+        
         # make sure we have the same number of waveforms
         # for all the different polarizations
         num_waveforms = waveform_size = None
@@ -136,16 +151,18 @@ class RandomWaveformInjection(torch.nn.Module):
             self.polarizations[polarization] = torch.nn.Parameter(
                 torch.Tensor(tensor), requires_grad=False
             )
-
+        
+        self.intrinsic_parameters = None
         if intrinsic_parameters is not None:
-            if len(intrisic_parameters) != num_waveforms:
+            if len(intrinsic_parameters) != num_waveforms:
                 raise ValueError(
                     "Waveform parameters has {} waveforms "
                     "associated with it, expected {}".format(
                         len(intrinsic_parameters), num_waveforms
                     )
-            self.intrinsic_parameters = torch.nn.Parameter(torch.Tensor(intrinsic_parameter, requires_grad=False)
-        
+                )
+            self.intrinsic_parameters = torch.nn.Parameter(torch.Tensor(intrinsic_parameters), requires_grad=False)
+             
         # confirm that the source parameters all either
         # are a callable or have a length equal to the
         # number of waveforms
@@ -187,7 +204,7 @@ class RandomWaveformInjection(torch.nn.Module):
 
         # initialize a bunch of properties we're
         # going to have to fit later
-        self.background = self.tensors = self.vertices = None
+        self.background = None
 
     def to(self, device):
         super().to(device)
@@ -241,12 +258,12 @@ class RandomWaveformInjection(torch.nn.Module):
                 the inverse of the length of `self.polarizations` in
                 seconds.
         """
-
-        ifos = list(backgrounds)
-        tensors, vertices = gw.get_ifo_geometry(*ifos)
-        self.tensors = torch.nn.Parameter(tensors, requires_grad=False)
-        self.vertices = torch.nn.Parameter(vertices, requires_grad=False)
-
+        
+        if self.snr is None:
+            raise TypeError(
+                "Cannot fit to backgrounds if snr is None" 
+            )
+        
         sample_rate = sample_rate or self.sample_rate
         psds = []
         for ifo, background in backgrounds.items():
@@ -370,8 +387,7 @@ class RandomWaveformInjection(torch.nn.Module):
         phi = self._sample_source_param(self.phi, idx, N)
 
         polarizations = {k: v[idx] for k, v in self.polarizations.items()}
-        parameters = self.parameters[idx]
-        
+       
         ifo_responses = gw.compute_observed_strain(
             dec,
             psi,
@@ -392,22 +408,26 @@ class RandomWaveformInjection(torch.nn.Module):
                 highpass=self.mask,
             )
 
-            sampled_params = (dec, psi, phi, target_snrs)
+            extrinsic_params = torch.column_stack((dec, psi, phi, target_snrs))
         else:
-            sampled_params = (dec, psi, phi)
+            extrinsic_params = torch.column_stack((dec, psi, phi))
             rescaled_responses = ifo_responses 
+        
+        if self.intrinsic_parameters is not None: 
+            intrinsic_parameters = self.intrinsic_parameters[idx]
+            sampled_params = torch.column_stack([extrinsic_params, intrinsic_parameters])
         
         return rescaled_responses, sampled_params
 
     def forward(
-        self, X: gw.WaveformTensor, y: Optional[gw.ScalarTensor] = None,
+        self, X: gw.WaveformTensor,
     ) -> gw.WaveformTensor:
         """Sample waveforms and inject them into random batch elements
 
         Batch elements from `X` will be selected at random for
-        injection. If `y` is specified, it will be assumed to
-        be a target tensor and the corresponding rows of `y`
-        will be set to `1`.
+        injection. Returns the tensor `X` with random injections,
+        the indices where injections were done, and the parameters
+        of the injections. 
         """
         if self.training:
             mask = torch.rand(size=X.shape[:1]) < self.prob
@@ -421,10 +441,6 @@ class RandomWaveformInjection(torch.nn.Module):
             )
             X[mask] += waveforms
         
-            if y is not None:
-                y[mask] = 1
+            indices = torch.where(mask) 
 
-        if y is not None:
-            return X, y
-        
-        return X
+        return X, indices, sampled_params

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -159,6 +159,7 @@ def sample_kernels(
     N: Optional[int] = None,
     max_center_offset: Optional[int] = None,
     coincident: bool = True,
+    fixed: bool = True,
 ) -> BatchTimeSeriesTensor:
     """Randomly sample kernels from a single or multichannel timeseries
 
@@ -229,11 +230,29 @@ def sample_kernels(
         )
 
     if X.ndim == 1:
+        if fixed: 
+            raise ValueError(   
+                "Can't sample kernels with fixed location"
+                "when X has 1 dimension"
+            )
         idx = torch.randint(len(X) - kernel_size, size=(N,))
         return slice_kernels(X, idx, kernel_size)
 
     center = int(X.shape[-1] // 2)
-    if max_center_offset is None:
+
+    if fixed:
+        # if taking kernels whose center is 
+        # specified location from sample center
+        if max_center_offset is None:
+            raise ValueError(
+                "Must specify max center offset when sampling"
+                "kernels with a fixed offset from center"
+            ) 
+        # randint will always sample min_val
+        min_val = max_center_offset
+        max_val = max_center_offset + 1
+    elif max_center_offset is None:
+        
         # sample uniformly from all of X's time dimension
         min_val, max_val = 0, X.shape[-1] - kernel_size
     elif max_center_offset >= 0:

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -159,7 +159,6 @@ def sample_kernels(
     N: Optional[int] = None,
     max_center_offset: Optional[int] = None,
     coincident: bool = True,
-    fixed: bool = True,
 ) -> BatchTimeSeriesTensor:
     """Randomly sample kernels from a single or multichannel timeseries
 
@@ -230,29 +229,13 @@ def sample_kernels(
         )
 
     if X.ndim == 1:
-        if fixed: 
-            raise ValueError(   
-                "Can't sample kernels with fixed location"
-                "when X has 1 dimension"
-            )
         idx = torch.randint(len(X) - kernel_size, size=(N,))
         return slice_kernels(X, idx, kernel_size)
 
     center = int(X.shape[-1] // 2)
 
-    if fixed:
-        # if taking kernels whose center is 
-        # specified location from sample center
-        if max_center_offset is None:
-            raise ValueError(
-                "Must specify max center offset when sampling"
-                "kernels with a fixed offset from center"
-            ) 
-        # randint will always sample min_val
-        min_val = max_center_offset
-        max_val = max_center_offset + 1
-    elif max_center_offset is None:
-        
+    if max_center_offset is None:
+
         # sample uniformly from all of X's time dimension
         min_val, max_val = 0, X.shape[-1] - kernel_size
     elif max_center_offset >= 0:

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,14 +20,6 @@ test = ["pytest (>=7.0)", "pytest-doctestplus (>=0.12)", "pytest-astropy-header 
 test_all = ["pytest (>=7.0)", "pytest-doctestplus (>=0.12)", "pytest-astropy-header (>=0.2.1)", "pytest-astropy (>=0.9)", "pytest-xdist", "objgraph", "ipython (>=4.2)", "coverage", "skyfield (>=1.20)", "sgp4 (>=2.3)"]
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -36,14 +28,14 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "bilby"
-version = "1.2.0"
+version = "1.2.1"
 description = "A user-friendly Bayesian inference library"
 category = "main"
 optional = false
@@ -69,7 +61,7 @@ mcmc = ["scikit-learn", "nflows"]
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -114,6 +106,24 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "contourpy"
+version = "1.0.5"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = ">=1.16"
+
+[package.extras]
+test-no-codebase = ["pillow", "matplotlib", "pytest"]
+test-minimal = ["pytest"]
+test = ["isort", "flake8", "pillow", "matplotlib", "pytest"]
+docs = ["sphinx-rtd-theme", "sphinx", "docutils (<0.18)"]
+bokeh = ["selenium", "bokeh"]
+
+[[package]]
 name = "corner"
 version = "2.2.1"
 description = "Make some beautiful corner plots"
@@ -132,7 +142,7 @@ test = ["pytest (>=3.6)", "pytest-cov (>=2.6.1)", "black", "isort", "toml"]
 
 [[package]]
 name = "cryptography"
-version = "37.0.4"
+version = "38.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -145,7 +155,7 @@ cffi = ">=1.12"
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
-sdist = ["setuptools_rust (>=0.11.4)"]
+sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
@@ -178,19 +188,20 @@ python-versions = "*"
 
 [[package]]
 name = "dqsegdb2"
-version = "1.1.2"
+version = "1.1.3"
 description = "Simplified python interface to DQSEGDB"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-igwn-auth-utils = {version = ">=0.2.2", extras = ["requests"]}
+igwn-auth-utils = ">=0.3.1"
 ligo-segments = ">=1.0.0"
 
 [package.extras]
 test = ["requests-mock (>=1.5.0)", "pytest-cov (>=2.5.1)", "pytest (>=2.9.2)"]
 lint = ["flake8-bandit", "flake8 (>=3.7.0)"]
+docs = ["sphinx-immaterial", "sphinx-automodapi", "sphinx"]
 
 [[package]]
 name = "dynesty"
@@ -208,7 +219,7 @@ six = "*"
 
 [[package]]
 name = "emcee"
-version = "3.1.2"
+version = "3.1.3"
 description = "The Python ensemble sampling toolkit for MCMC"
 category = "main"
 optional = false
@@ -235,7 +246,7 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pyt
 
 [[package]]
 name = "fonttools"
-version = "4.37.1"
+version = "4.37.4"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
@@ -257,14 +268,14 @@ woff = ["zopfli (>=0.1.4)", "brotlicffi (>=0.8.0)", "brotli (>=1.0.1)"]
 
 [[package]]
 name = "gwdatafind"
-version = "1.1.1"
+version = "1.1.2"
 description = "The GWDataFind data discovery client"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-igwn-auth-utils = {version = ">=0.2.0", extras = ["requests"]}
+igwn-auth-utils = ">=0.3.1"
 ligo-segments = "*"
 
 [package.extras]
@@ -284,8 +295,8 @@ python-versions = ">=3.5"
 requests = ">=1.0.0"
 
 [package.extras]
-test = ["requests-mock (>=1.5.0)", "pytest-socket", "pytest-cov", "pytest (>=2.7.0)"]
-docs = ["sphinx-rtd-theme", "sphinx-automodapi", "sphinx"]
+docs = ["sphinx", "sphinx-automodapi", "sphinx-rtd-theme"]
+test = ["pytest (>=2.7.0)", "pytest-cov", "pytest-socket", "requests-mock (>=1.5.0)"]
 
 [[package]]
 name = "gwpy"
@@ -328,7 +339,7 @@ numpy = ">=1.14.5"
 
 [[package]]
 name = "identify"
-version = "2.5.3"
+version = "2.5.6"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -339,7 +350,7 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -347,7 +358,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "igwn-auth-utils"
-version = "0.2.3"
+version = "0.3.1"
 description = "Authorisation utilities for IGWN"
 category = "main"
 optional = false
@@ -355,13 +366,12 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 cryptography = ">=2.3"
-requests = {version = ">=2.14", optional = true, markers = "extra == \"requests\""}
-safe-netrc = {version = ">=1.0.0", optional = true, markers = "extra == \"requests\""}
+requests = ">=2.14"
+safe-netrc = ">=1.0.0"
 scitokens = ">=1.7.0"
 
 [package.extras]
 test = ["safe-netrc (>=1.0.0)", "requests-mock", "requests (>=2.14)", "pytest-cov", "pytest (>=3.9.1)"]
-requests = ["safe-netrc (>=1.0.0)", "requests (>=2.14)"]
 lint = ["flake8-bandit", "flake8 (>=3.7.0)"]
 docs = ["sphinx-immaterial-igwn", "sphinx (>=4.0.0)"]
 
@@ -383,7 +393,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "lalsuite"
-version = "7.7"
+version = "7.10"
 description = "LIGO Scientific Collaboration Algorithm Library - minimal Python package"
 category = "dev"
 optional = false
@@ -438,22 +448,23 @@ six = "*"
 
 [[package]]
 name = "matplotlib"
-version = "3.5.3"
+version = "3.6.0"
 description = "Python plotting package"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
+contourpy = ">=1.0.1"
 cycler = ">=0.10"
 fonttools = ">=4.22.0"
 kiwisolver = ">=1.0.1"
-numpy = ">=1.17"
+numpy = ">=1.19"
 packaging = ">=20.0"
 pillow = ">=6.2.0"
 pyparsing = ">=2.2.1"
 python-dateutil = ">=2.7"
-setuptools_scm = ">=4,<7"
+setuptools_scm = ">=7"
 
 [[package]]
 name = "nodeenv"
@@ -468,7 +479,7 @@ setuptools = "*"
 
 [[package]]
 name = "numpy"
-version = "1.23.2"
+version = "1.23.3"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -487,7 +498,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.4.4"
+version = "1.5.0"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -495,16 +506,14 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
-    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
-    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
 
 [[package]]
 name = "pillow"
@@ -591,31 +600,31 @@ test = ["pytest", "pytest-doctestplus (>=0.7)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.4.0"
+version = "2.5.0"
 description = "JSON Web Token implementation in Python"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-crypto = ["cryptography (>=3.3.1)"]
-dev = ["sphinx", "sphinx-rtd-theme", "zope-interface", "cryptography (>=3.3.1)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope-interface"]
+crypto = ["cryptography (>=3.3.1)", "types-cryptography (>=3.3.21)"]
+dev = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1)", "types-cryptography (>=3.3.21)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "pre-commit"]
+docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pyopenssl"
-version = "22.0.0"
+version = "22.1.0"
 description = "Python wrapper module around the OpenSSL library"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-cryptography = ">=35.0"
+cryptography = ">=38.0.0,<39"
 
 [package.extras]
-docs = ["sphinx", "sphinx-rtd-theme"]
+docs = ["sphinx (!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
 test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
@@ -639,14 +648,13 @@ python-versions = ">=3.6, <4"
 
 [[package]]
 name = "pytest"
-version = "7.1.2"
+version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
@@ -671,7 +679,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2022.2.1"
+version = "2022.4"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -724,42 +732,44 @@ numpy = ">=1.18.5,<1.25.0"
 
 [[package]]
 name = "scitokens"
-version = "1.7.0"
+version = "1.7.2"
 description = "SciToken reference implementation library"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 
 [package.dependencies]
 cryptography = "*"
 PyJWT = ">=1.6.1"
+setuptools = "*"
 six = "*"
 
 [[package]]
 name = "setuptools"
-version = "65.3.0"
+version = "65.4.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)", "sphinx-notfound-page (==0.8.3)", "sphinx-hoverxref (<2)", "pygments-github-lexers (==0.0.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-reredirects", "sphinxcontrib-towncrier", "furo"]
+docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)", "sphinx-notfound-page (==0.8.3)", "sphinx-hoverxref (<2)", "pygments-github-lexers (==0.0.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-reredirects", "sphinxcontrib-towncrier", "furo"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-enabler (>=1.3)", "pytest-perf", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "wheel", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "jaraco.path (>=3.2.0)", "build", "filelock (>=3.4.0)", "pip-run (>=8.8)", "ini2toml[lite] (>=0.9)", "tomli-w (>=1.0.0)", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy (>=0.9.1)"]
 testing-integration = ["pytest", "pytest-xdist", "pytest-enabler", "virtualenv (>=13.0.0)", "tomli", "wheel", "jaraco.path (>=3.2.0)", "jaraco.envs (>=2.2)", "build", "filelock (>=3.4.0)"]
 
 [[package]]
 name = "setuptools-scm"
-version = "6.4.2"
+version = "7.0.5"
 description = "the blessed package to manage your versions by scm tags"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 packaging = ">=20.0"
 setuptools = "*"
 tomli = ">=1.0.0"
+typing-extensions = "*"
 
 [package.extras]
 test = ["pytest (>=6.2)", "virtualenv (>20)"]
@@ -814,7 +824,7 @@ typeguard = ">=2.11.1"
 
 [[package]]
 name = "tqdm"
-version = "4.64.0"
+version = "4.64.1"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = false
@@ -864,7 +874,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.16.4"
+version = "20.16.5"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -882,7 +892,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "39157ef15532d8834c71b67360135d6bfd59cfe5cfa29874ac8ca3b120d8ea74"
+content-hash = "87d7f7c1c8f159a80e4a2146299e86ac514423d1b96327269ec398af75a5849f"
 
 [metadata.files]
 astropy = [
@@ -905,20 +915,9 @@ astropy = [
     {file = "astropy-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:f54d3537e987c33244435fb155f9087e130abae4126d06b003171c15dbff6ed6"},
     {file = "astropy-5.1.tar.gz", hash = "sha256:1db1b2c7eddfc773ca66fa33bd07b25d5b9c3b5eee2b934e0ca277fa5b1b7b7e"},
 ]
-atomicwrites = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
-attrs = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
-]
-bilby = [
-    {file = "bilby-1.2.0.tar.gz", hash = "sha256:3582356c9f5ead6ef67b1beceddd55e35509b1da5634fd04f100bfff0567bbba"},
-]
-certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
-]
+attrs = []
+bilby = []
+certifi = []
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
     {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
@@ -989,42 +988,17 @@ cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
-charset-normalizer = [
-    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
-    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
-]
+charset-normalizer = []
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
+contourpy = []
 corner = [
     {file = "corner-2.2.1-py3-none-any.whl", hash = "sha256:a187860e62e71e5be33088383314588edb98d1c6ac2614bf107561cb1f6581b3"},
     {file = "corner-2.2.1.tar.gz", hash = "sha256:d39f1d9ad31093bb2aa06d80b23573e51ad7130af4c4af0931fca745a64751e5"},
 ]
-cryptography = [
-    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884"},
-    {file = "cryptography-37.0.4-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8"},
-    {file = "cryptography-37.0.4-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280"},
-    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3"},
-    {file = "cryptography-37.0.4-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59"},
-    {file = "cryptography-37.0.4-cp36-abi3-win32.whl", hash = "sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157"},
-    {file = "cryptography-37.0.4-cp36-abi3-win_amd64.whl", hash = "sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327"},
-    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b"},
-    {file = "cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282"},
-    {file = "cryptography-37.0.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a"},
-    {file = "cryptography-37.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab"},
-    {file = "cryptography-37.0.4.tar.gz", hash = "sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82"},
-]
+cryptography = []
 cycler = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
@@ -1033,43 +1007,22 @@ dill = [
     {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
     {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
-distlib = [
-    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
-    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
-]
-dqsegdb2 = [
-    {file = "dqsegdb2-1.1.2-py3-none-any.whl", hash = "sha256:eb21d6511738366071d35a65ec840fdf586730daa37a75babdb1f86915618dc6"},
-    {file = "dqsegdb2-1.1.2.tar.gz", hash = "sha256:badfd113b861590b49b7105e05d438d2f3b62594bf5a742a7504038f31730fc0"},
-]
+distlib = []
+dqsegdb2 = []
 dynesty = [
     {file = "dynesty-1.0.1-py2.py3-none-any.whl", hash = "sha256:98e381308f9a280bdb8d186b7dd333edf71583117a9f06605b845541d60dfb5b"},
     {file = "dynesty-1.0.1-py3.6.egg", hash = "sha256:5fcdfc522d7770ae2f33603b7cb4f4c585bb7f9d1882f6081daa09dcf464af5f"},
     {file = "dynesty-1.0.1.tar.gz", hash = "sha256:ddaeae35d359abb4cbb1c277500acab55b54ef4fb14932caacb4b8a6f719f7af"},
 ]
-emcee = [
-    {file = "emcee-3.1.2-py2.py3-none-any.whl", hash = "sha256:88a816b09932048c58d3ff8a8ce8d8171ef0926314a887ebb45748979a8aa518"},
-    {file = "emcee-3.1.2.tar.gz", hash = "sha256:7f668b1a0db8f591b5cff26e8671c98c943417e1508dae8c752170883f4c0981"},
-]
-filelock = [
-    {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
-    {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
-]
-fonttools = [
-    {file = "fonttools-4.37.1-py3-none-any.whl", hash = "sha256:fff6b752e326c15756c819fe2fe7ceab69f96a1dbcfe8911d0941cdb49905007"},
-    {file = "fonttools-4.37.1.zip", hash = "sha256:4606e1a88ee1f6699d182fea9511bd9a8a915d913eab4584e5226da1180fcce7"},
-]
-gwdatafind = [
-    {file = "gwdatafind-1.1.1-py3-none-any.whl", hash = "sha256:66135c76f215f6e52522bc73c67098ee28635dcee9c907b683e5097d014525af"},
-    {file = "gwdatafind-1.1.1.tar.gz", hash = "sha256:5d23ff803731e263ab07dfd8e382bf1cd5fa1d055298398511ccc87c3e09a52c"},
-]
+emcee = []
+filelock = []
+fonttools = []
+gwdatafind = []
 gwosc = [
     {file = "gwosc-0.6.1-py3-none-any.whl", hash = "sha256:387d47ec5b2b6ab74106a463e67e4270e58c6324dc5c75e1440a8768ee1e6f42"},
     {file = "gwosc-0.6.1.tar.gz", hash = "sha256:cfe0d65aa92827e3d50652c9abcccc846449a42512b1a2a19007b30f98bf1e26"},
 ]
-gwpy = [
-    {file = "gwpy-2.1.5-py2.py3-none-any.whl", hash = "sha256:544908c43ddcd1a8253424b3ad619d8a817c26f6be5cfce14503250716fb2733"},
-    {file = "gwpy-2.1.5.tar.gz", hash = "sha256:687015973b84c0d628fa7b245ff8f6a2a7a6008aee6860f17167c87ee8394521"},
-]
+gwpy = []
 h5py = [
     {file = "h5py-3.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d77af42cb751ad6cc44f11bae73075a07429a5cf2094dfde2b1e716e059b3911"},
     {file = "h5py-3.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:63beb8b7b47d0896c50de6efb9a1eaa81dbe211f3767e7dd7db159cea51ba37a"},
@@ -1092,78 +1045,15 @@ h5py = [
     {file = "h5py-3.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:9e2ad2aa000f5b1e73b5dfe22f358ca46bf1a2b6ca394d9659874d7fc251731a"},
     {file = "h5py-3.7.0.tar.gz", hash = "sha256:3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3"},
 ]
-identify = [
-    {file = "identify-2.5.3-py2.py3-none-any.whl", hash = "sha256:25851c8c1370effb22aaa3c987b30449e9ff0cece408f810ae6ce408fdd20893"},
-    {file = "identify-2.5.3.tar.gz", hash = "sha256:887e7b91a1be152b0d46bbf072130235a8117392b9f1828446079a816a05ef44"},
-]
-idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
-]
-igwn-auth-utils = [
-    {file = "igwn-auth-utils-0.2.3.tar.gz", hash = "sha256:17ea61ef47dd642a572e887f37f5181613d8882ed4b917b1279cdb188859de3c"},
-    {file = "igwn_auth_utils-0.2.3-py3-none-any.whl", hash = "sha256:8c26e62f59673e7bc67304768706fdae029cbd4516b9885061d417c331766710"},
-]
+identify = []
+idna = []
+igwn-auth-utils = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
-kiwisolver = [
-    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2f5e60fabb7343a836360c4f0919b8cd0d6dbf08ad2ca6b9cf90bf0c76a3c4f6"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:10ee06759482c78bdb864f4109886dff7b8a56529bc1609d4f1112b93fe6423c"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c79ebe8f3676a4c6630fd3f777f3cfecf9289666c84e775a67d1d358578dc2e3"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:abbe9fa13da955feb8202e215c4018f4bb57469b1b78c7a4c5c7b93001699938"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7577c1987baa3adc4b3c62c33bd1118c3ef5c8ddef36f0f2c950ae0b199e100d"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8ad8285b01b0d4695102546b342b493b3ccc6781fc28c8c6a1bb63e95d22f09"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ed58b8acf29798b036d347791141767ccf65eee7f26bde03a71c944449e53de"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a68b62a02953b9841730db7797422f983935aeefceb1679f0fc85cbfbd311c32"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-win32.whl", hash = "sha256:e92a513161077b53447160b9bd8f522edfbed4bd9759e4c18ab05d7ef7e49408"},
-    {file = "kiwisolver-1.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fe20f63c9ecee44560d0e7f116b3a747a5d7203376abeea292ab3152334d004"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:62ac9cc684da4cf1778d07a89bf5f81b35834cb96ca523d3a7fb32509380cbf6"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41dae968a94b1ef1897cb322b39360a0812661dba7c682aa45098eb8e193dbdf"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02f79693ec433cb4b5f51694e8477ae83b3205768a6fb48ffba60549080e295b"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d0611a0a2a518464c05ddd5a3a1a0e856ccc10e67079bb17f265ad19ab3c7597"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:db5283d90da4174865d520e7366801a93777201e91e79bacbac6e6927cbceede"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1041feb4cda8708ce73bb4dcb9ce1ccf49d553bf87c3954bdfa46f0c3f77252c"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-win32.whl", hash = "sha256:a553dadda40fef6bfa1456dc4be49b113aa92c2a9a9e8711e955618cd69622e3"},
-    {file = "kiwisolver-1.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:03baab2d6b4a54ddbb43bba1a3a2d1627e82d205c5cf8f4c924dc49284b87166"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:841293b17ad704d70c578f1f0013c890e219952169ce8a24ebc063eecf775454"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f4f270de01dd3e129a72efad823da90cc4d6aafb64c410c9033aba70db9f1ff0"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f9f39e2f049db33a908319cf46624a569b36983c7c78318e9726a4cb8923b26c"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c97528e64cb9ebeff9701e7938653a9951922f2a38bd847787d4a8e498cc83ae"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d1573129aa0fd901076e2bfb4275a35f5b7aa60fbfb984499d661ec950320b0"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad881edc7ccb9d65b0224f4e4d05a1e85cf62d73aab798943df6d48ab0cd79a1"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b428ef021242344340460fa4c9185d0b1f66fbdbfecc6c63eff4b7c29fad429d"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2e407cb4bd5a13984a6c2c0fe1845e4e41e96f183e5e5cd4d77a857d9693494c"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-win32.whl", hash = "sha256:75facbe9606748f43428fc91a43edb46c7ff68889b91fa31f53b58894503a191"},
-    {file = "kiwisolver-1.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bce61af018b0cb2055e0e72e7d65290d822d3feee430b7b8203d8a855e78766"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8c808594c88a025d4e322d5bb549282c93c8e1ba71b790f539567932722d7bd8"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0a71d85ecdd570ded8ac3d1c0f480842f49a40beb423bb8014539a9f32a5897"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b533558eae785e33e8c148a8d9921692a9fe5aa516efbdff8606e7d87b9d5824"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:efda5fc8cc1c61e4f639b8067d118e742b812c930f708e6667a5ce0d13499e29"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7c43e1e1206cd421cd92e6b3280d4385d41d7166b3ed577ac20444b6995a445f"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc8d3bd6c72b2dd9decf16ce70e20abcb3274ba01b4e1c96031e0c4067d1e7cd"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4ea39b0ccc4f5d803e3337dd46bcce60b702be4d86fd0b3d7531ef10fd99a1ac"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:968f44fdbf6dd757d12920d63b566eeb4d5b395fd2d00d29d7ef00a00582aac9"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-win32.whl", hash = "sha256:da7e547706e69e45d95e116e6939488d62174e033b763ab1496b4c29b76fabea"},
-    {file = "kiwisolver-1.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:ba59c92039ec0a66103b1d5fe588fa546373587a7d68f5c96f743c3396afc04b"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:91672bacaa030f92fc2f43b620d7b337fd9a5af28b0d6ed3f77afc43c4a64b5a"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:787518a6789009c159453da4d6b683f468ef7a65bbde796bcea803ccf191058d"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da152d8cdcab0e56e4f45eb08b9aea6455845ec83172092f09b0e077ece2cf7a"},
-    {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ecb1fa0db7bf4cff9dac752abb19505a233c7f16684c5826d1f11ebd9472b871"},
-    {file = "kiwisolver-1.4.4.tar.gz", hash = "sha256:d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955"},
-]
-lalsuite = [
-    {file = "lalsuite-7.7-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:0b57446820f2c322ce3fb70797e26c3a04b27d049c17162260f69cf2d0189653"},
-    {file = "lalsuite-7.7-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:f58cab4670f6e65d84bb3a36e2b5f0cf60a2d03cbd7e51c57739286cb7c446c7"},
-    {file = "lalsuite-7.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a4a3da2e57a442223704f618dcd6635d35db02213e1628d708e823bf64b193c"},
-    {file = "lalsuite-7.7-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b2ed084c1ff03354091428bab1cb9171277f9820af11e14d1f9ec7cd28974f0b"},
-    {file = "lalsuite-7.7-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:16294498a225078b08a1119d37730b9b89d23f5aa7a1e5082d1b9142f67abc59"},
-    {file = "lalsuite-7.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73e38afe81204fc2324dcafe34ddd4de6399a38bee34518897c73d39277e5bcc"},
-    {file = "lalsuite-7.7-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:733c920cf4cc513e79dd10681cf5d017a5dea0df6d0e9a68120833f246ecec3a"},
-    {file = "lalsuite-7.7-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8643b21cce1aea73876a6a78058e93d64df163e627edfe52d84da75b5899a178"},
-    {file = "lalsuite-7.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1a1fb9a10835db241570f67c69b6a0be36fa413cc9e99d45ede7f1b19224ede"},
-]
+kiwisolver = []
+lalsuite = []
 ligo-segments = [
     {file = "ligo-segments-1.4.0.tar.gz", hash = "sha256:e072a844713c5b02efdcaf5bfe4c3a8cd9ef225b08cfd3202a4e185e0f71f5dc"},
 ]
@@ -1174,104 +1064,17 @@ ligotimegps = [
 lscsoft-glue = [
     {file = "lscsoft-glue-3.0.1.tar.gz", hash = "sha256:a242f29537f18957dbb07e6d9d20d7ebddc86c8325d4fa9e192cfa61a7c6ffbd"},
 ]
-matplotlib = [
-    {file = "matplotlib-3.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a206a1b762b39398efea838f528b3a6d60cdb26fe9d58b48265787e29cd1d693"},
-    {file = "matplotlib-3.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd45a6f3e93a780185f70f05cf2a383daed13c3489233faad83e81720f7ede24"},
-    {file = "matplotlib-3.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d62880e1f60e5a30a2a8484432bcb3a5056969dc97258d7326ad465feb7ae069"},
-    {file = "matplotlib-3.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ab29589cef03bc88acfa3a1490359000c18186fc30374d8aa77d33cc4a51a4a"},
-    {file = "matplotlib-3.5.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2886cc009f40e2984c083687251821f305d811d38e3df8ded414265e4583f0c5"},
-    {file = "matplotlib-3.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c995f7d9568f18b5db131ab124c64e51b6820a92d10246d4f2b3f3a66698a15b"},
-    {file = "matplotlib-3.5.3-cp310-cp310-win32.whl", hash = "sha256:6bb93a0492d68461bd458eba878f52fdc8ac7bdb6c4acdfe43dba684787838c2"},
-    {file = "matplotlib-3.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:2e6d184ebe291b9e8f7e78bbab7987d269c38ea3e062eace1fe7d898042ef804"},
-    {file = "matplotlib-3.5.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ea6aef5c4338e58d8d376068e28f80a24f54e69f09479d1c90b7172bad9f25b"},
-    {file = "matplotlib-3.5.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:839d47b8ead7ad9669aaacdbc03f29656dc21f0d41a6fea2d473d856c39c8b1c"},
-    {file = "matplotlib-3.5.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3b4fa56159dc3c7f9250df88f653f085068bcd32dcd38e479bba58909254af7f"},
-    {file = "matplotlib-3.5.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:94ff86af56a3869a4ae26a9637a849effd7643858a1a04dd5ee50e9ab75069a7"},
-    {file = "matplotlib-3.5.3-cp37-cp37m-win32.whl", hash = "sha256:35a8ad4dddebd51f94c5d24bec689ec0ec66173bf614374a1244c6241c1595e0"},
-    {file = "matplotlib-3.5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:43e9d3fa077bf0cc95ded13d331d2156f9973dce17c6f0c8b49ccd57af94dbd9"},
-    {file = "matplotlib-3.5.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:22227c976ad4dc8c5a5057540421f0d8708c6560744ad2ad638d48e2984e1dbc"},
-    {file = "matplotlib-3.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf618a825deb6205f015df6dfe6167a5d9b351203b03fab82043ae1d30f16511"},
-    {file = "matplotlib-3.5.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9befa5954cdbc085e37d974ff6053da269474177921dd61facdad8023c4aeb51"},
-    {file = "matplotlib-3.5.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3840c280ebc87a48488a46f760ea1c0c0c83fcf7abbe2e6baf99d033fd35fd8"},
-    {file = "matplotlib-3.5.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dacddf5bfcec60e3f26ec5c0ae3d0274853a258b6c3fc5ef2f06a8eb23e042be"},
-    {file = "matplotlib-3.5.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b428076a55fb1c084c76cb93e68006f27d247169f056412607c5c88828d08f88"},
-    {file = "matplotlib-3.5.3-cp38-cp38-win32.whl", hash = "sha256:874df7505ba820e0400e7091199decf3ff1fde0583652120c50cd60d5820ca9a"},
-    {file = "matplotlib-3.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:b28de401d928890187c589036857a270a032961411934bdac4cf12dde3d43094"},
-    {file = "matplotlib-3.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3211ba82b9f1518d346f6309df137b50c3dc4421b4ed4815d1d7eadc617f45a1"},
-    {file = "matplotlib-3.5.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6fe807e8a22620b4cd95cfbc795ba310dc80151d43b037257250faf0bfcd82bc"},
-    {file = "matplotlib-3.5.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5c096363b206a3caf43773abebdbb5a23ea13faef71d701b21a9c27fdcef72f4"},
-    {file = "matplotlib-3.5.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bcdfcb0f976e1bac6721d7d457c17be23cf7501f977b6a38f9d38a3762841f7"},
-    {file = "matplotlib-3.5.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e64ac9be9da6bfff0a732e62116484b93b02a0b4d4b19934fb4f8e7ad26ad6a"},
-    {file = "matplotlib-3.5.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:73dd93dc35c85dece610cca8358003bf0760d7986f70b223e2306b4ea6d1406b"},
-    {file = "matplotlib-3.5.3-cp39-cp39-win32.whl", hash = "sha256:879c7e5fce4939c6aa04581dfe08d57eb6102a71f2e202e3314d5fbc072fd5a0"},
-    {file = "matplotlib-3.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:ab8d26f07fe64f6f6736d635cce7bfd7f625320490ed5bfc347f2cdb4fae0e56"},
-    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:99482b83ebf4eb6d5fc6813d7aacdefdd480f0d9c0b52dcf9f1cc3b2c4b3361a"},
-    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f814504e459c68118bf2246a530ed953ebd18213dc20e3da524174d84ed010b2"},
-    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57f1b4e69f438a99bb64d7f2c340db1b096b41ebaa515cf61ea72624279220ce"},
-    {file = "matplotlib-3.5.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d2484b350bf3d32cae43f85dcfc89b3ed7bd2bcd781ef351f93eb6fb2cc483f9"},
-    {file = "matplotlib-3.5.3.tar.gz", hash = "sha256:339cac48b80ddbc8bfd05daae0a3a73414651a8596904c2a881cfd1edb65f26c"},
-]
+matplotlib = []
 nodeenv = [
     {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
     {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
 ]
-numpy = [
-    {file = "numpy-1.23.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e603ca1fb47b913942f3e660a15e55a9ebca906857edfea476ae5f0fe9b457d5"},
-    {file = "numpy-1.23.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:633679a472934b1c20a12ed0c9a6c9eb167fbb4cb89031939bfd03dd9dbc62b8"},
-    {file = "numpy-1.23.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17e5226674f6ea79e14e3b91bfbc153fdf3ac13f5cc54ee7bc8fdbe820a32da0"},
-    {file = "numpy-1.23.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc02c0235b261925102b1bd586579b7158e9d0d07ecb61148a1799214a4afd5"},
-    {file = "numpy-1.23.2-cp310-cp310-win32.whl", hash = "sha256:df28dda02c9328e122661f399f7655cdcbcf22ea42daa3650a26bce08a187450"},
-    {file = "numpy-1.23.2-cp310-cp310-win_amd64.whl", hash = "sha256:8ebf7e194b89bc66b78475bd3624d92980fca4e5bb86dda08d677d786fefc414"},
-    {file = "numpy-1.23.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dc76bca1ca98f4b122114435f83f1fcf3c0fe48e4e6f660e07996abf2f53903c"},
-    {file = "numpy-1.23.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ecfdd68d334a6b97472ed032b5b37a30d8217c097acfff15e8452c710e775524"},
-    {file = "numpy-1.23.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5593f67e66dea4e237f5af998d31a43e447786b2154ba1ad833676c788f37cde"},
-    {file = "numpy-1.23.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac987b35df8c2a2eab495ee206658117e9ce867acf3ccb376a19e83070e69418"},
-    {file = "numpy-1.23.2-cp311-cp311-win32.whl", hash = "sha256:d98addfd3c8728ee8b2c49126f3c44c703e2b005d4a95998e2167af176a9e722"},
-    {file = "numpy-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:8ecb818231afe5f0f568c81f12ce50f2b828ff2b27487520d85eb44c71313b9e"},
-    {file = "numpy-1.23.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:909c56c4d4341ec8315291a105169d8aae732cfb4c250fbc375a1efb7a844f8f"},
-    {file = "numpy-1.23.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8247f01c4721479e482cc2f9f7d973f3f47810cbc8c65e38fd1bbd3141cc9842"},
-    {file = "numpy-1.23.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8b97a8a87cadcd3f94659b4ef6ec056261fa1e1c3317f4193ac231d4df70215"},
-    {file = "numpy-1.23.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd5b7ccae24e3d8501ee5563e82febc1771e73bd268eef82a1e8d2b4d556ae66"},
-    {file = "numpy-1.23.2-cp38-cp38-win32.whl", hash = "sha256:9b83d48e464f393d46e8dd8171687394d39bc5abfe2978896b77dc2604e8635d"},
-    {file = "numpy-1.23.2-cp38-cp38-win_amd64.whl", hash = "sha256:dec198619b7dbd6db58603cd256e092bcadef22a796f778bf87f8592b468441d"},
-    {file = "numpy-1.23.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4f41f5bf20d9a521f8cab3a34557cd77b6f205ab2116651f12959714494268b0"},
-    {file = "numpy-1.23.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:806cc25d5c43e240db709875e947076b2826f47c2c340a5a2f36da5bb10c58d6"},
-    {file = "numpy-1.23.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9d84a24889ebb4c641a9b99e54adb8cab50972f0166a3abc14c3b93163f074"},
-    {file = "numpy-1.23.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c403c81bb8ffb1c993d0165a11493fd4bf1353d258f6997b3ee288b0a48fce77"},
-    {file = "numpy-1.23.2-cp39-cp39-win32.whl", hash = "sha256:cf8c6aed12a935abf2e290860af8e77b26a042eb7f2582ff83dc7ed5f963340c"},
-    {file = "numpy-1.23.2-cp39-cp39-win_amd64.whl", hash = "sha256:5e28cd64624dc2354a349152599e55308eb6ca95a13ce6a7d5679ebff2962913"},
-    {file = "numpy-1.23.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:806970e69106556d1dd200e26647e9bee5e2b3f1814f9da104a943e8d548ca38"},
-    {file = "numpy-1.23.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bd879d3ca4b6f39b7770829f73278b7c5e248c91d538aab1e506c628353e47f"},
-    {file = "numpy-1.23.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:be6b350dfbc7f708d9d853663772a9310783ea58f6035eec649fb9c4371b5389"},
-    {file = "numpy-1.23.2.tar.gz", hash = "sha256:b78d00e48261fbbd04aa0d7427cf78d18401ee0abd89c7559bbf422e5b1c7d01"},
-]
+numpy = []
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
-pandas = [
-    {file = "pandas-1.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:799e6a25932df7e6b1f8dabf63de064e2205dc309abb75956126a0453fd88e97"},
-    {file = "pandas-1.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd1d69a387f7d5e1a5a06a87574d9ef2433847c0e78113ab51c84d3a8bcaeaa"},
-    {file = "pandas-1.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:94f2ed1fd51e545ebf71da1e942fe1822ee01e10d3dd2a7276d01351333b7c6b"},
-    {file = "pandas-1.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4591cadd06fbbbd16fafc2de6e840c1aaefeae3d5864b688004777ef1bbdede3"},
-    {file = "pandas-1.4.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0022fe6a313df1c4869b5edc012d734c6519a6fffa3cf70930f32e6a1078e49"},
-    {file = "pandas-1.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:785e878a6e6d8ddcdb8c181e600855402750052497d7fc6d6b508894f6b8830b"},
-    {file = "pandas-1.4.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c4bb8b0ab9f94207d07e401d24baebfc63057246b1a5e0cd9ee50df85a656871"},
-    {file = "pandas-1.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:51c424ca134fdaeac9a4acd719d1ab48046afc60943a489028f0413fdbe9ef1c"},
-    {file = "pandas-1.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ce35f947202b0b99c660221d82beb91d2e6d553d55a40b30128204e3e2c63848"},
-    {file = "pandas-1.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee6f1848148ed3204235967613b0a32be2d77f214e9623f554511047705c1e04"},
-    {file = "pandas-1.4.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7cc960959be28d064faefc0cb2aef854d46b827c004ebea7e79b5497ed83e7d"},
-    {file = "pandas-1.4.4-cp38-cp38-win32.whl", hash = "sha256:9d805bce209714b1c1fa29bfb1e42ad87e4c0a825e4b390c56a3e71593b7e8d8"},
-    {file = "pandas-1.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:afbddad78a98ec4d2ce08b384b81730de1ccc975b99eb663e6dac43703f36d98"},
-    {file = "pandas-1.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a08ceb59db499864c58a9bf85ab6219d527d91f14c0240cc25fa2c261032b2a7"},
-    {file = "pandas-1.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0959c41004e3d2d16f39c828d6da66ebee329836a7ecee49fb777ac9ad8a7501"},
-    {file = "pandas-1.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:87b4194f344dcd14c0f885cecb22005329b38bda10f1aaf7b9596a00ec8a4768"},
-    {file = "pandas-1.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d2a7a3c1fea668d56bd91edbd5f2732e0af8feb9d2bf8d9bfacb2dea5fa9536"},
-    {file = "pandas-1.4.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a981cfabf51c318a562deb4ae7deec594c07aee7cf18b4594a92c23718ec8275"},
-    {file = "pandas-1.4.4-cp39-cp39-win32.whl", hash = "sha256:050aada67a5ec6699a7879e769825b510018a95fb9ac462bb1867483d0974a97"},
-    {file = "pandas-1.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:8d4d2fe2863ecddb0ba1979bdda26c8bc2ea138f5a979abe3ba80c0fa4015c91"},
-    {file = "pandas-1.4.4.tar.gz", hash = "sha256:ab6c0d738617b675183e5f28db32b5148b694ad9bba0a40c3ea26d96b431db67"},
-]
+pandas = []
 pillow = [
     {file = "Pillow-9.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a9c9bc489f8ab30906d7a85afac4b4944a572a7432e00698a7239f44a44e6efb"},
     {file = "Pillow-9.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:510cef4a3f401c246cfd8227b300828715dd055463cdca6176c2e4036df8bd4f"},
@@ -1340,10 +1143,7 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-pre-commit = [
-    {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
-    {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
-]
+pre-commit = []
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
@@ -1383,14 +1183,8 @@ pyerfa = [
     {file = "pyerfa-2.0.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:63a83c35cea8c5d50d53c18089f1e625c0ffc59a7a5b8d44e0f1b3ec5288f183"},
     {file = "pyerfa-2.0.0.1.tar.gz", hash = "sha256:2fd4637ffe2c1e6ede7482c13f583ba7c73119d78bef90175448ce506a0ede30"},
 ]
-pyjwt = [
-    {file = "PyJWT-2.4.0-py3-none-any.whl", hash = "sha256:72d1d253f32dbd4f5c88eaf1fdc62f3a19f676ccbadb9dbc5d07e951b2b26daf"},
-    {file = "PyJWT-2.4.0.tar.gz", hash = "sha256:d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba"},
-]
-pyopenssl = [
-    {file = "pyOpenSSL-22.0.0-py2.py3-none-any.whl", hash = "sha256:ea252b38c87425b64116f808355e8da644ef9b07e429398bfece610f893ee2e0"},
-    {file = "pyOpenSSL-22.0.0.tar.gz", hash = "sha256:660b1b1425aac4a1bea1d94168a85d99f0b3144c869dd4390d27629d0087f1bf"},
-]
+pyjwt = []
+pyopenssl = []
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
@@ -1441,18 +1235,12 @@ pyrxp = [
     {file = "pyRXP-3.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:f02185da19c7e24bead96cdd599177590b91f53ff70ed5c788f218877484cfb5"},
     {file = "pyRXP-3.0.1.tar.gz", hash = "sha256:f5563dee342f329f840380aafccf786b504d6a82e91611defb27f3f51043be9a"},
 ]
-pytest = [
-    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
-    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
-]
+pytest = []
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
-pytz = [
-    {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
-    {file = "pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
-]
+pytz = []
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
@@ -1496,43 +1284,10 @@ safe-netrc = [
     {file = "safe-netrc-1.0.0.tar.gz", hash = "sha256:55fe78dfc8bda48ee5b26c930a8efdecbb7ff5b5a45e2552381c84f13bb4a98a"},
     {file = "safe_netrc-1.0.0-py2.py3-none-any.whl", hash = "sha256:5011368564eabd3accc196e499de111e4403c29f48eb6c60a3141b6ad507eb50"},
 ]
-scipy = [
-    {file = "scipy-1.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c61b4a91a702e8e04aeb0bfc40460e1f17a640977c04dda8757efb0199c75332"},
-    {file = "scipy-1.9.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d79da472015d0120ba9b357b28a99146cd6c17b9609403164b1a8ed149b4dfc8"},
-    {file = "scipy-1.9.1-cp310-cp310-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:825951b88f56765aeb6e5e38ac9d7d47407cfaaeb008d40aa1b45a2d7ea2731e"},
-    {file = "scipy-1.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f950a04b33e17b38ff561d5a0951caf3f5b47caa841edd772ffb7959f20a6af0"},
-    {file = "scipy-1.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8cc81ac25659fec73599ccc52c989670e5ccd8974cf34bacd7b54a8d809aff1a"},
-    {file = "scipy-1.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:8d3faa40ac16c6357aaf7ea50394ea6f1e8e99d75e927a51102b1943b311b4d9"},
-    {file = "scipy-1.9.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7a412c476a91b080e456229e413792bbb5d6202865dae963d1e6e28c2bb58691"},
-    {file = "scipy-1.9.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:eb954f5aca4d26f468bbebcdc5448348eb287f7bea536c6306f62ea062f63d9a"},
-    {file = "scipy-1.9.1-cp38-cp38-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:3c6f5d1d4b9a5e4fe5e14f26ffc9444fc59473bbf8d45dc4a9a15283b7063a72"},
-    {file = "scipy-1.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bc4e2c77d4cd015d739e75e74ebbafed59ba8497a7ed0fd400231ed7683497c4"},
-    {file = "scipy-1.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0419485dbcd0ed78c0d5bf234c5dd63e86065b39b4d669e45810d42199d49521"},
-    {file = "scipy-1.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34441dfbee5b002f9e15285014fd56e5e3372493c3e64ae297bae2c4b9659f5a"},
-    {file = "scipy-1.9.1-cp38-cp38-win32.whl", hash = "sha256:b97b479f39c7e4aaf807efd0424dec74bbb379108f7d22cf09323086afcd312c"},
-    {file = "scipy-1.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8fe305d9d67a81255e06203454729405706907dccbdfcc330b7b3482a6c371d"},
-    {file = "scipy-1.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:39ab9240cd215a9349c85ab908dda6d732f7d3b4b192fa05780812495536acc4"},
-    {file = "scipy-1.9.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:71487c503e036740635f18324f62a11f283a632ace9d35933b2b0a04fd898c98"},
-    {file = "scipy-1.9.1-cp39-cp39-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:3bc1ab68b9a096f368ba06c3a5e1d1d50957a86665fc929c4332d21355e7e8f4"},
-    {file = "scipy-1.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f7c39f7dbb57cce00c108d06d731f3b0e2a4d3a95c66d96bce697684876ce4d4"},
-    {file = "scipy-1.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47d1a95bd9d37302afcfe1b84c8011377c4f81e33649c5a5785db9ab827a6ade"},
-    {file = "scipy-1.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d7cf7b25c9f23c59a766385f6370dab0659741699ecc7a451f9b94604938ce"},
-    {file = "scipy-1.9.1-cp39-cp39-win32.whl", hash = "sha256:09412eb7fb60b8f00b328037fd814d25d261066ebc43a1e339cdce4f7502877e"},
-    {file = "scipy-1.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:90c805f30c46cf60f1e76e947574f02954d25e3bb1e97aa8a07bc53aa31cf7d1"},
-    {file = "scipy-1.9.1.tar.gz", hash = "sha256:26d28c468900e6d5fdb37d2812ab46db0ccd22c63baa095057871faa3a498bc9"},
-]
-scitokens = [
-    {file = "scitokens-1.7.0-py3-none-any.whl", hash = "sha256:d5e533fad0ead554b147e38419ddaeb6e2e3982bc1a7e14a65bf2979dfde8322"},
-    {file = "scitokens-1.7.0.tar.gz", hash = "sha256:c08dc3018c06506a38206ba78cc594df5812979ae38c19ad99614cc0e01eb19b"},
-]
-setuptools = [
-    {file = "setuptools-65.3.0-py3-none-any.whl", hash = "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82"},
-    {file = "setuptools-65.3.0.tar.gz", hash = "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"},
-]
-setuptools-scm = [
-    {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
-    {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
-]
+scipy = []
+scitokens = []
+setuptools = []
+setuptools-scm = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1545,49 +1300,13 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-torch = [
-    {file = "torch-1.12.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:9c038662db894a23e49e385df13d47b2a777ffd56d9bcd5b832593fab0a7e286"},
-    {file = "torch-1.12.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4e1b9c14cf13fd2ab8d769529050629a0e68a6fc5cb8e84b4a3cc1dd8c4fe541"},
-    {file = "torch-1.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:e9c8f4a311ac29fc7e8e955cfb7733deb5dbe1bdaabf5d4af2765695824b7e0d"},
-    {file = "torch-1.12.1-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:976c3f997cea38ee91a0dd3c3a42322785414748d1761ef926b789dfa97c6134"},
-    {file = "torch-1.12.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:68104e4715a55c4bb29a85c6a8d57d820e0757da363be1ba680fa8cc5be17b52"},
-    {file = "torch-1.12.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:743784ccea0dc8f2a3fe6a536bec8c4763bd82c1352f314937cb4008d4805de1"},
-    {file = "torch-1.12.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b5dbcca369800ce99ba7ae6dee3466607a66958afca3b740690d88168752abcf"},
-    {file = "torch-1.12.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f3b52a634e62821e747e872084ab32fbcb01b7fa7dbb7471b6218279f02a178a"},
-    {file = "torch-1.12.1-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:8a34a2fbbaa07c921e1b203f59d3d6e00ed379f2b384445773bd14e328a5b6c8"},
-    {file = "torch-1.12.1-cp37-none-macosx_11_0_arm64.whl", hash = "sha256:42f639501928caabb9d1d55ddd17f07cd694de146686c24489ab8c615c2871f2"},
-    {file = "torch-1.12.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0b44601ec56f7dd44ad8afc00846051162ef9c26a8579dda0a02194327f2d55e"},
-    {file = "torch-1.12.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:cd26d8c5640c3a28c526d41ccdca14cf1cbca0d0f2e14e8263a7ac17194ab1d2"},
-    {file = "torch-1.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:42e115dab26f60c29e298559dbec88444175528b729ae994ec4c65d56fe267dd"},
-    {file = "torch-1.12.1-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:a8320ba9ad87e80ca5a6a016e46ada4d1ba0c54626e135d99b2129a4541c509d"},
-    {file = "torch-1.12.1-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:03e31c37711db2cd201e02de5826de875529e45a55631d317aadce2f1ed45aa8"},
-    {file = "torch-1.12.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:9b356aea223772cd754edb4d9ecf2a025909b8615a7668ac7d5130f86e7ec421"},
-    {file = "torch-1.12.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6cf6f54b43c0c30335428195589bd00e764a6d27f3b9ba637aaa8c11aaf93073"},
-    {file = "torch-1.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:f00c721f489089dc6364a01fd84906348fe02243d0af737f944fddb36003400d"},
-    {file = "torch-1.12.1-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:bfec2843daa654f04fda23ba823af03e7b6f7650a873cdb726752d0e3718dada"},
-    {file = "torch-1.12.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:69fe2cae7c39ccadd65a123793d30e0db881f1c1927945519c5c17323131437e"},
-]
-torchtyping = [
-    {file = "torchtyping-0.1.4-py3-none-any.whl", hash = "sha256:485fb6ef3965c39b0de15f00d6f49373e0a3a6993e9733942a63c5e207d35390"},
-    {file = "torchtyping-0.1.4.tar.gz", hash = "sha256:4763375d17752641bd1bff0faaddade29be3c125fca6355e3cee7700e975fdb5"},
-]
-tqdm = [
-    {file = "tqdm-4.64.0-py2.py3-none-any.whl", hash = "sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6"},
-    {file = "tqdm-4.64.0.tar.gz", hash = "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d"},
-]
-typeguard = [
-    {file = "typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"},
-    {file = "typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4"},
-]
+torch = []
+torchtyping = []
+tqdm = []
+typeguard = []
 typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
     {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
-urllib3 = [
-    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
-    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
-]
-virtualenv = [
-    {file = "virtualenv-20.16.4-py3-none-any.whl", hash = "sha256:035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22"},
-    {file = "virtualenv-20.16.4.tar.gz", hash = "sha256:014f766e4134d0008dcaa1f95bafa0fb0f575795d07cae50b1bee514185d6782"},
-]
+urllib3 = []
+virtualenv = []

--- a/tests/transforms/test_injection.py
+++ b/tests/transforms/test_injection.py
@@ -379,10 +379,10 @@ def test_random_waveform_injection(prob, ifos, dist):
     # corresponding to waveforms
     expected_params = torch.column_stack(
         (
+            intrinsic_parameters[:expected_count],
             dec[:expected_count],
             psi[:expected_count],
             phi[:expected_count],
-            intrinsic_parameters[:expected_count],
         )
     )
     assert (params == expected_params).all()

--- a/tests/transforms/test_injection.py
+++ b/tests/transforms/test_injection.py
@@ -189,7 +189,7 @@ def test_sample(sample_rate, ifos, dist):
     )
     mock.intrinsic_parameters = intrinsic_parameters
     result, params = RandomWaveformInjection.sample(mock, idx)
-    assert (params[:, -num_intrinsic:] == (intrinsic_parameters[idx])).all()
+    assert (params[:, :num_intrinsic] == (intrinsic_parameters[idx])).all()
 
 
 @pytest.fixture(params=[0.5, 1])

--- a/tests/transforms/test_injection.py
+++ b/tests/transforms/test_injection.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pytest
@@ -20,28 +20,25 @@ def ifos(request):
 
 @pytest.mark.parametrize("factor", [None, 1, 2, 0.5])
 def test_fit(sample_rate, ifos, factor):
-    
+
     mock = MagicMock()
     background = {i: np.random.randn(2048) for i in ifos}
     fit_sample_rate = sample_rate * factor if factor is not None else None
-    
+
     # first test that TypeError gets raised
-    # if .fit is called with snr as None    
+    # if .fit is called with snr as None
     mock.snr = None
 
     with pytest.raises(TypeError):
         RandomWaveformInjection.fit(mock, fit_sample_rate, **background)
-  
-    # reset mock 
+
+    # reset mock
     mock = MagicMock()
     mock.sample_rate = sample_rate
     mock.df = 1 / 8
 
-
-    
     RandomWaveformInjection.fit(mock, fit_sample_rate, **background)
 
-    
     assert mock.background.shape == (len(ifos), 4 * sample_rate + 1)
 
     # use this background as our target for passing things
@@ -108,27 +105,26 @@ def reweight_snrs(*args, **kwargs):
 
 @patch("ml4gw.gw.reweight_snrs", new=reweight_snrs)
 def test_sample(sample_rate, ifos, dist):
-  
-    mock = MagicMock() 
-    mock_dist = MagicMock(side_effect=dist)
-    
-    mock.dec =  mock_dist 
-    mock.phi =  mock_dist
-    mock.psi =  mock_dist
 
+    mock = MagicMock()
+    mock_dist = MagicMock(side_effect=dist)
+
+    mock.dec = mock_dist
+    mock.phi = mock_dist
+    mock.psi = mock_dist
 
     # first test sampling without
-    # intrinsic parameters 
+    # intrinsic parameters
     mock.intrinsic_parameters = None
-    
+
     # first make sure we enforce fitting
     # if sampling with snr reweighting
-    mock.snr = mock_dist 
+    mock.snr = mock_dist
     mock.background = None
     with pytest.raises(TypeError) as exc:
         RandomWaveformInjection.sample(mock, 1)
     assert str(exc.value).endswith("WaveformSampler.fit first")
-    
+
     # now set background as mock
     # to mimick having called .fit
     mock.background = MagicMock()
@@ -151,18 +147,17 @@ def test_sample(sample_rate, ifos, dist):
     # first test with passing indices
     idx = torch.arange(5, 50, 5)
     result, params = RandomWaveformInjection.sample(mock, idx)
-    assert params.shape == (len(idx), 4) # ra, dec, psi, snr 
-    assert (result == summed[idx]).all()
-    mock.dec.assert_called_with(len(idx))
-    
-    # now test when snr is None
-    # it doesn't get returned 
-    mock.snr = None
-    result, params = RandomWaveformInjection.sample(mock, idx)
-    assert params.shape == (len(idx), 3) # ra, dec, psi  
+    assert params.shape == (len(idx), 4)  # ra, dec, psi, snr
     assert (result == summed[idx]).all()
     mock.dec.assert_called_with(len(idx))
 
+    # now test when snr is None
+    # it doesn't get returned
+    mock.snr = None
+    result, params = RandomWaveformInjection.sample(mock, idx)
+    assert params.shape == (len(idx), 3)  # ra, dec, psi
+    assert (result == summed[idx]).all()
+    mock.dec.assert_called_with(len(idx))
 
     # now test with calling -1 to make sure
     # we get everything back in order
@@ -186,44 +181,48 @@ def test_sample(sample_rate, ifos, dist):
     # now pass intrinsic parameters of waveform to mock,
     # and ensure sampling returns them as expected
     num_intrinsic = 5
-    intrinsic_parameters = torch.column_stack([torch.arange(1, mock.num_waveforms, 1) * i for i in range(num_intrinsic)])
-    mock.intrinsic_parameters = intrinsic_parameters 
+    intrinsic_parameters = torch.column_stack(
+        [
+            torch.arange(1, mock.num_waveforms, 1) * i
+            for i in range(num_intrinsic)
+        ]
+    )
+    mock.intrinsic_parameters = intrinsic_parameters
     result, params = RandomWaveformInjection.sample(mock, idx)
-    assert (params[:,-num_intrinsic:] == (intrinsic_parameters[idx]) ).all()
-    
+    assert (params[:, -num_intrinsic:] == (intrinsic_parameters[idx])).all()
+
+
 @pytest.fixture(params=[0.5, 1])
 def prob(request):
     return request.param
+
 
 @pytest.fixture
 def dist():
     def f(N):
         return torch.Tensor(np.random.normal(size=N))
-    return f
 
+    return f
 
 
 @patch("ml4gw.gw.reweight_snrs", new=reweight_snrs)
 def test_random_waveform_injection(prob, ifos, dist):
     waveforms = {i: torch.randn(100, 1024) for i in ["plus", "cross"]}
-    
-    
+
     waveform = waveforms["plus"] + waveforms["cross"]
     summed = torch.stack([waveform + i for i in range(len(ifos))], axis=1)
 
-    
     dec = Mock(side_effect=dist)
     psi = Mock(side_effect=dist)
     phi = Mock(side_effect=dist)
     snr = Mock(side_effect=dist)
-
 
     sample_rate = 1024
     # enforce all polarizations have to be same length
     with pytest.raises(ValueError) as exc:
         wrong = {str(i): np.random.randn(i + 2, 1024) for i in range(2)}
         transform = RandomWaveformInjection(
-             sample_rate, ifos, dec, psi, phi, snr, prob=prob, **wrong
+            sample_rate, ifos, dec, psi, phi, snr, prob=prob, **wrong
         )
     assert str(exc.value).startswith("Polarization")
 
@@ -244,12 +243,19 @@ def test_random_waveform_injection(prob, ifos, dist):
     # enforce parameters has same length as waveforms
     with pytest.raises(ValueError) as exc:
         num_intrinsic = 5
-        wrong_intrinsic = np.zeros((len(waveforms)-1, num_intrinsic ))
+        wrong_intrinsic = np.zeros((len(waveforms) - 1, num_intrinsic))
         transform = RandomWaveformInjection(
-            sample_rate, ifos, dec, psi, phi, snr, intrinsic_parameters = wrong_intrinsic, **waveforms
+            sample_rate,
+            ifos,
+            dec,
+            psi,
+            phi,
+            snr,
+            intrinsic_parameters=wrong_intrinsic,
+            **waveforms
         )
     assert str(exc.value).startswith("Waveform parameters")
-    
+
     # now make it for real
     transform = RandomWaveformInjection(
         sample_rate, ifos, dec, psi, phi, snr, prob=prob, **waveforms
@@ -260,7 +266,7 @@ def test_random_waveform_injection(prob, ifos, dist):
     assert transform.mask is None
     assert transform.tensors.shape == (len(ifos), 3, 3)
     assert transform.vertices.shape == (len(ifos), 3)
-    
+
     # make background not None so we can sample
     transform.background = MagicMock()
 
@@ -291,7 +297,7 @@ def test_random_waveform_injection(prob, ifos, dist):
     # now verify that the data matches up: the first
     # `exepcted_count` rows should be injected, and
     # the rest should be all 0s
-    assert (indices == torch.arange(0, expected_count , 1)).all()
+    assert (indices == torch.arange(0, expected_count, 1)).all()
     for i, x_row in enumerate(X_hat):
         if i >= expected_count:
             assert (x_row == 0).all()
@@ -332,16 +338,23 @@ def test_random_waveform_injection(prob, ifos, dist):
 
     # now re-make transform passing intrinsic parameters
     num_intrinsic = 5
-    intrinsic_parameters = torch.randn((100, num_intrinsic ))
-    
+    intrinsic_parameters = torch.randn((100, num_intrinsic))
+
     dec = torch.arange(0, 100, 1) * 1
     psi = torch.arange(0, 100, 1) * 2
     phi = torch.arange(0, 100, 1) * 3
-    
+
     transform = RandomWaveformInjection(
-        sample_rate, ifos, dec, psi, phi, prob = prob, intrinsic_parameters=intrinsic_parameters, **waveforms
+        sample_rate,
+        ifos,
+        dec,
+        psi,
+        phi,
+        prob=prob,
+        intrinsic_parameters=intrinsic_parameters,
+        **waveforms
     )
-    
+
     transform.background = MagicMock()
     assert transform.num_waveforms == 100
     assert transform.df == 1
@@ -352,23 +365,30 @@ def test_random_waveform_injection(prob, ifos, dist):
     rand_patch = patch("torch.rand", return_value=mask)
     randint_patch = patch(
         "torch.randint", return_value=torch.arange(expected_count)
-    )  
- 
+    )
+
     X = torch.zeros((16, len(ifos), 256))
     with rand_patch as rand_mock, perm_patch as perm_mock:
         with randint_patch as randint_mock:
             X_hat, indices, params = transform(X)
-    
+
     # all indices should have injection
     assert len(indices) == expected_count
-    
+
     # make sure we're sampling correct params
     # corresponding to waveforms
-    expected_params = torch.column_stack((dec[:expected_count], psi[:expected_count], phi[:expected_count], intrinsic_parameters[:expected_count]))
+    expected_params = torch.column_stack(
+        (
+            dec[:expected_count],
+            psi[:expected_count],
+            phi[:expected_count],
+            intrinsic_parameters[:expected_count],
+        )
+    )
     assert (params == expected_params).all()
 
     for i, x_row in enumerate(X_hat):
         if i >= expected_count:
             assert (x_row == 0).all()
         else:
-            assert (x_row == summed[i, :, i : i + 256]).all() 
+            assert (x_row == summed[i, :, i : i + 256]).all()


### PR DESCRIPTION
1. Specifying `snr` is now `Optional`. If `None`, will not perform any snr reweighting
2. `forward` method now returns the injected tensor `X`, the `indices` of `X` where injections where performed, and the `sample_params` that correspond to those indices.
3.  Can now optionally pass `intrinsic_parameters`. This is a `Tensor` that contains the intrinsic parameter used to generate the polarizations passed. During the `forward` call, the parameters corresponding to the random injections will be appended to the sampled extrinsic parameters and returned. 
