### PR TITLE
fix SNR calculation in compute_snr_ifo, add test against lalsimulation

### DIFF
--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -377,7 +377,8 @@ def compute_ifo_snr(
     integrated = integrand.sum(axis=-1) * df
 
     # multiply by 4 for mystical reasons
-    return 4 * integrated
+    integrated = 4 * integrated  # rho-squared
+    return torch.sqrt(integrated)
 
 
 def compute_network_snr(


### PR DESCRIPTION
SNR for a (30, 30) system at 100 Mpc is computed with lalsimulation tools, and checked against that in `test_compute_ifo_snr` with a 10% relative tolerance