### PR TITLE
Transform overhaul

### DIFF
--- a/tests/transforms/test_spectral_transform.py
+++ b/tests/transforms/test_spectral_transform.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 import numpy as np
 import pytest
 import scipy
@@ -39,6 +41,14 @@ def test_init(overlap, fftlength, sample_rate):
             overlap * sample_rate
         )
     assert transform.nstride == expected_stride
+    assert len(list(transform.buffers())) == 2
+
+    # test read/write
+    weights_io = BytesIO()
+    torch.save(transform.state_dict(), weights_io)
+
+    weights_io.seek(0)
+    transform.load_state_dict(torch.load(weights_io))
 
 
 @pytest.fixture(params=[0.5, 2, 4])


### PR DESCRIPTION
- Preferring buffers over parameters in `RandomWaveformInjection` for both internal consistency and consistency with Torch's preferred syntax for tensors that should be associated with a module (e.g. get moved around via `to`) but not tracked with gradients
- Making buffers for extrinsic and intrinsic parameters, as well as frequency mask, non-persistent, i.e. they don't get tracked with `RandomWaveformInjection.state_dict` and therefore don't get saved. Consistent with the model that a layer that has been fit on some background for some IFOs can be saved and then loaded again to project a totally new set of waveforms and their parameters.
- Initializing `RandomWaveformInjection.background` to zeros in `__init__` so that the PSD of a previously saved layer can be loaded back in to a new one without it having to call `.fit` (or even have access to the original data). In order to avoid having to check if `(background == 0).all()` on the forward call, introduced an internal `_has_fit` flag to keep track of whether `.fit` has been called.
- Polarizations are tracked via regular tensors, since these can have a large memory footprint and you don't necessarily want them living where all the other tensors live. They can either be moved manually, or by providing a `waveforms=True` kwarg to `RandomWaveformInjection.to`.
- A `device` kwarg has been added to `RandomWaveformInjection.sample` to control where the polarization tensors get moved to. It might make more sense to just move them automatically to `self.tensors.device`, but this felt like it allowed more flexibility. In `forward`, `X.device` is passed to this argument
- `window` and `scale` are saved as buffers in `SpectralDensity`. Doesn't make a big difference now, but could be useful once more exotic windows and scaling factors are allowed.