### PR TITLE
fix minor bug in injection transform `.to` method

### DIFF
--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -218,7 +218,7 @@ class RandomWaveformInjection(torch.nn.Module):
     def to(self, device, waveforms: bool = False):
         super().to(device)
         if waveforms:
-            for t in self.polarizations.values:
+            for t in self.polarizations.values():
                 t.to(device)
         return self
 


### PR DESCRIPTION
Missing parentheses in `polarizations.values()` call