### PR TITLE
Whitening transform

### DIFF
--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -51,6 +51,9 @@ def normalize_psd(
             # at the specified sample rate
             x = TimeSeries(x, sample_rate=sample_rate or target_sample_rate)
 
+        if x.sample_rate.value != target_sample_rate:
+            x = x.resample(target_sample_rate)
+
         # now convert to frequency space
         fftlength = fftlength or 1 / df
         default_psd_kwargs = dict(method="median", window="hann")

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -9,14 +9,62 @@ and
 https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.csd.html
 """
 
-from typing import Optional
+from typing import Optional, Union
 
+import numpy as np
 import torch
+from gwpy.frequencyseries import FrequencySeries
+from gwpy.timeseries import TimeSeries
 
 try:
     from scipy.signal.spectral import _median_bias
 except ImportError:
     from scipy.signal._spectral_py import _median_bias
+
+Background = Union[np.ndarray, TimeSeries, FrequencySeries]
+
+
+def normalize_psd(
+    x: Background,
+    df: float,
+    target_sample_rate: float,
+    sample_rate: Optional[float] = None,
+    fftlength: Optional[float] = None,
+    **psd_kwargs,
+) -> np.ndarray:
+    """Utility function for mapping from generic data types to psds
+
+    Build a PSD out of background data contained in `x`. If `x`
+    is a Numpy array or a gwpy `TimeSeries`, the data will assumed
+    to exist in the time domain and will be converted to the
+    frequency domain via the gwpy `TimeSeries.psd` method. In any case,
+    the `FrequencySeries` will be resampled to the desired frequency
+    resolution `df` before being returned as a numpy array.
+    """
+    if not isinstance(x, FrequencySeries):
+        # this is not already a frequency series, so we'll
+        # assume it's a timeseries of some sort and convert
+        # it to frequency space via psd
+        if not isinstance(x, TimeSeries):
+            # if it's also not a TimeSeries object, then we'll
+            # assume that it's a numpy array which is sampled
+            # at the specified sample rate
+            x = TimeSeries(x, sample_rate=sample_rate or target_sample_rate)
+
+        # now convert to frequency space
+        fftlength = fftlength or 1 / df
+        default_psd_kwargs = dict(method="median", window="hann")
+        default_psd_kwargs.update(**psd_kwargs)
+        x = x.psd(fftlength, **default_psd_kwargs)
+
+    # since the FFT length used to compute this PSD
+    # won't, in general, match the length of waveforms
+    # we're sampling, we'll interpolate the frequencies
+    # to the expected frequency resolution
+    if x.df.value != df:
+        x = x.interpolate(df)
+    x = x.crop(0, target_sample_rate / 2 + df)
+    return x.value
 
 
 def median(x, axis):

--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -1,3 +1,4 @@
 from .injection import RandomWaveformInjection
 from .scaler import ChannelWiseScaler
 from .spectral import SpectralDensity
+from .whitening import Whitening

--- a/ml4gw/transforms/transform.py
+++ b/ml4gw/transforms/transform.py
@@ -1,0 +1,33 @@
+from typing import Any, Mapping
+
+import torch
+
+
+class FittableTransform(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.built = False
+
+    def build(self, **params):
+        state_dict = self.state_dict()
+        for name, value in params.items():
+            state_dict[name].copy_(value)
+        self.built = True
+
+    def _check_built(self):
+        if not self.built:
+            raise ValueError(
+                "Must fit parameters of {} transform to data "
+                "before calling forward step".format(self.__class__.__name__)
+            )
+
+    def __call__(self, *args, **kwargs):
+        self._check_built()
+        return super().__call__(*args, **kwargs)
+
+    def load_state_dict(
+        self, state_dict: Mapping[str, Any], strict: bool = True
+    ):
+        keys = super().load_state_dict(state_dict, strict)
+        self.built = True
+        return keys

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -213,6 +213,15 @@ class Whitening(FittableTransform):
         super().build(time_domain_filter=tdf, kernel_length=kernel_length)
 
     def forward(self, X: torch.Tensor) -> torch.Tensor:
+        expected_dim = int(self.kernel_length.item() * self.sample_rate)
+        if X.size(-1) != expected_dim:
+            raise ValueError(
+                "Whitening transform was fit using a kernel length "
+                "of {}s, but was passed data of length {}s".format(
+                    self.kernel_length.item(), X.size(-1) / self.sample_rate
+                )
+            )
+
         # do a constant detrend along the time axis,
         X = X - X.mean(axis=-1, keepdims=True)
 

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -1,0 +1,197 @@
+"""
+Whitening logic largely lifted from gwpy's whitening functionality:
+
+https://github.com/gwpy/gwpy/blob/main/gwpy/timeseries/timeseries.py
+"""
+
+from typing import Any, Mapping, Optional
+
+import numpy as np
+import torch
+from gwpy.signal.filter_design import fir_from_transfer
+
+from ml4gw.spectral import Background, normalize_psd
+from ml4gw.transforms.transform import FittableTransform
+
+
+class _Conv1d(torch.nn.Module):
+    def __init__(self, num_channels: int) -> None:
+        super().__init__()
+        self.num_channels = num_channels
+
+    def forward(self, X: torch.Tensor, tdf: torch.Tensor):
+        return torch.nn.functional.conv1d(
+            X, tdf, groups=self.num_channels, padding="same"
+        )
+
+
+def _overlap_add_conv(
+    X: torch.Tensor, tdf: torch.Tensor, conv_op: torch.nn.Module, nfft: int
+) -> torch.Tensor:
+    """
+    TODO: Stand-in implementation until we
+    implement efficiently using windowing
+    rather than looping
+    """
+    conv = torch.zeros_like(X)
+    pad = conv_op.pad
+    kernel_size = X.shape[-1]
+
+    # handle first chunk separately
+    y0 = conv_op(X[:, :, :nfft], tdf)
+    conv[:, :, : nfft - pad] = y0[:, :, : nfft - pad]
+
+    # process chunks of length nstep
+    k = nfft - pad
+    nstep = nfft - 2 * pad
+    while k < kernel_size - nfft + pad:
+        xk = X[:, :, k - pad : k + nstep + pad]
+        yk = conv_op(xk, tdf)[:, :, pad:-pad]
+        conv[:, :, k : k + yk.size(-1) - 2 * pad] = yk
+        k += nstep
+
+    # handle last chunk separately
+    yf = conv_op(X[:, :, -nfft:], tdf)
+    conv[:, :, -nfft + pad :] = yf[:, :, -nfft + pad :]
+    return conv
+
+
+class Whitening(FittableTransform):
+    def __init__(
+        self,
+        num_channels: int,
+        sample_rate: float,
+        fduration: float,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        """Torch module for performing whitening. The first and last
+        (fduration / 2) seconds of data are corrupted by the whitening
+        and will be cropped. Thus, the output length
+        that is ultimately passed to the network will be
+        (kernel_length - fduration)
+        """
+
+        super().__init__()
+        self.num_channels = num_channels
+        self.sample_rate = sample_rate
+
+        # shape properties of transfrom are only
+        # functions of the fduration
+        self.crop_samples = int((fduration / 2) * self.sample_rate)
+        self.ntaps = int(fduration * self.sample_rate)
+        self.pad = int((self.ntaps - 1) / 2)
+
+        # the op that will actually convolve incoming
+        # kernels with the time domain filter
+        self.conv_op = _Conv1d(num_channels)
+
+        # initialize the time domain filter with 0s,
+        # then fill it out later
+        tdf = torch.zeros((num_channels, 1, self.ntaps - 1), dtype=dtype)
+        self.register_buffer("time_domain_filter", tdf)
+
+        # save this as a parameter since it's decided at fit time
+        kernel_length = torch.zeros((1,))
+        self.register_buffer("kernel_length", kernel_length)
+
+        # set up a window that we won't save with state
+        # since it doesn't depend on the data at all
+        window = torch.zeros((self.ntaps,), dtype=dtype)
+        window[:-1] = torch.hann_window(self.ntaps - 1)
+        self.register_buffer("window", window, persistent=False)
+
+        self._has_fit = False
+        self._use_overlap_add = None
+        self.nfft = None
+
+    def _check_kernel_length(self, kernel_length: float):
+        kernel_size = int(kernel_length * self.sample_rate)
+        if kernel_size <= (2 * self.crop_samples):
+            raise ValueError(
+                "Whitening pad size {} is too long for "
+                "input kernel of size {}".format(
+                    2 * self.crop_samples, kernel_size
+                )
+            )
+        elif (8 * (self.ntaps - 1)) < (kernel_size / 2):
+            self.nfft = min(8 * (self.ntaps - 1), kernel_size)
+            # TODO: remove this error once the above
+            # implementation is optimized
+            raise NotImplementedError(
+                "An optimal torch implementation of whitening for short "
+                "filter padding is not complete. Use a larger value of pad."
+            )
+
+    def fit(
+        self,
+        kernel_length: float,
+        fftlength: float = 2,
+        highpass: Optional[float] = None,
+        sample_rate: Optional[float] = None,
+        **channels: Background,
+    ) -> None:
+        """
+        Build a whitening time domain filter
+        """
+        if len(channels) != self.num_channels:
+            raise ValueError(
+                "Expected to fit whitening transform on {} background "
+                "timeseries, but was passed {}".format(
+                    self.num_channels, len(channels)
+                )
+            )
+
+        self._check_kernel_length(kernel_length)
+        df = 1 / kernel_length
+        ncorner = int(highpass / df) if highpass else 0
+
+        tdfs = np.zeros((self.num_channels, 1, self.ntaps - 1))
+        for i, (channel, x) in enumerate(channels.items()):
+            psd = normalize_psd(
+                x, df, self.sample_rate, sample_rate, fftlength
+            )
+            if (psd == 0).any():
+                raise ValueError(f"Found 0 values in {channel} background asd")
+
+            tdf = fir_from_transfer(
+                1 / psd**0.5,
+                ntaps=self.ntaps,
+                window="hann",
+                ncorner=ncorner,
+            )
+            tdfs[i, 0] = tdf[:-1]
+
+        tdf = torch.tensor(tdfs, dtype=self.time_domain_filter.dtype)
+        kernel_length = torch.tensor((kernel_length,))
+        super().build(time_domain_filter=tdf, kernel_length=kernel_length)
+
+    def forward(self, X: torch.Tensor) -> torch.Tensor:
+        # do a constant detrend along the time axis,
+        X = X - X.mean(axis=-1, keepdims=True)
+
+        # apply our window
+        X[:, :, : self.pad] *= self.window[: self.pad]
+        X[:, :, -self.pad :] *= self.window[-self.pad :]
+
+        # apply different convolution depending on
+        # length of time domain filter
+        if self.nfft is None:
+            X = self.conv_op(X, self.time_domain_filter)
+        else:
+            X = _overlap_add_conv(
+                X, self.time_domain_filter, self.conv_op, self.nfft
+            )
+
+        # crop the beginning and ending fduration / 2
+        X = X[:, :, self.crop_samples : -self.crop_samples]
+
+        # scale by sqrt(2 / sample_rate) for some inscrutable
+        # signal processing reason beyond my understanding
+        return X * (2 / self.sample_rate) ** 0.5
+
+    def load_state_dict(
+        self, state_dict: Mapping[str, Any], strict: bool = True
+    ):
+        keys = super().load_state_dict(state_dict, strict)
+        self._check_kernel_length(self.kernel_length.item())
+        return keys

--- a/tests/transforms/test_whitening.py
+++ b/tests/transforms/test_whitening.py
@@ -66,8 +66,15 @@ def test_whitening_transform(
         tform.fit(fduration, fftlength, highpass, **backgrounds)
     assert str(exc_info.value).startswith("Whitening pad size")
 
-    # now fit to background and actually do the whitening
+    # now fit to background
     tform.fit(kernel_length, fftlength, highpass, **backgrounds)
+
+    # make sure shape has to match
+    with pytest.raises(ValueError) as exc_info:
+        tform(X[:, :, :-1])
+    assert f"kernel length of {kernel_length:0.1f}s" in str(exc_info.value)
+
+    # apply transform
     results = tform(X).cpu().numpy()
 
     # check to make sure that whitened data is 0 mean unit variance

--- a/tests/transforms/test_whitening.py
+++ b/tests/transforms/test_whitening.py
@@ -1,0 +1,135 @@
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+import torch
+from gwpy.timeseries import TimeSeries
+
+from ml4gw.transforms import Whitening
+
+
+@pytest.fixture(params=[512, 1024])
+def sample_rate(request):
+    return request.param
+
+
+@pytest.fixture(params=[1, 2, 3])
+def num_ifos(request):
+    return request.param
+
+
+@pytest.fixture(params=[0.5, 1])
+def fduration(request):
+    return request.param
+
+
+@pytest.fixture(params=[2, 4])
+def fftlength(request):
+    return request.param
+
+
+@pytest.fixture(params=[0, 20])
+def highpass(request):
+    return request.param
+
+
+@pytest.fixture(params=[torch.float32, torch.float64])
+def dtype(request):
+    return request.param
+
+
+def test_whitening_transform(
+    num_ifos, sample_rate, fduration, fftlength, highpass, dtype
+):
+    tform = Whitening(num_ifos, sample_rate, fduration, dtype=dtype)
+
+    # make sure that trying to run the forward
+    # call without fitting raises an error
+    kernel_length = fduration * 2
+    kernel_size = int(kernel_length * sample_rate)
+    X = torch.randn(8, num_ifos, kernel_size).type(dtype)
+    X = 1e-19 + 1e-20 * X
+    with pytest.raises(ValueError) as exc_info:
+        tform(X)
+    assert str(exc_info.value).startswith("Must fit parameters")
+
+    # fit to some random background
+    ifos = "hlv"[:num_ifos]
+    backgrounds = OrderedDict(
+        [(i, np.random.randn(100 * sample_rate)) for i in ifos]
+    )
+    backgrounds = {k: 1e-19 + 1e-20 * v for k, v in backgrounds.items()}
+
+    # verify that if our kernel length isn't greater
+    # than the length of fduration we raise an error
+    with pytest.raises(ValueError) as exc_info:
+        tform.fit(fduration, fftlength, highpass, **backgrounds)
+    assert str(exc_info.value).startswith("Whitening pad size")
+
+    # now fit to background and actually do the whitening
+    tform.fit(kernel_length, fftlength, highpass, **backgrounds)
+    results = tform(X).cpu().numpy()
+
+    # check to make sure that whitened data is 0 mean unit variance
+    # TODO: there are better statistically-motivated values to use
+    # here, but we have to make the bounds so loose they ultimately
+    # lose most meaning
+    mean = results.mean()
+    std = results.std()
+    assert np.isclose(mean, 0, atol=0.02)
+    assert np.isclose(std, 1, atol=0.1)
+
+    # pre-compute the background asds for comparison
+    asds = {}
+    for ifo, x in backgrounds.items():
+        x = TimeSeries(x, sample_rate=sample_rate)
+        x = x.asd(fftlength, method="median", window="hann")
+        asds[ifo] = x
+
+    # for each ifo in each batch element, verify that whitening
+    # with gwpy produces roughly the same result
+    pad = int(sample_rate * fduration / 2)
+    for x, y in zip(X.cpu().numpy(), results):
+        for input, result, ifo in zip(x, y, ifos):
+            asd = asds[ifo]
+            ts = TimeSeries(input, sample_rate=sample_rate)
+            ts = ts.whiten(
+                asd=asd, fduration=fduration, highpass=highpass, window="hann"
+            )
+            ts = ts.value[pad:-pad]
+
+            # TODO: this isn't the strongest check in the world,
+            # but it's the closest I can get for now. Check that
+            # at least 95% of the outputs are within 1% of the
+            # value produced by gwpy
+            close = np.isclose(result, ts, rtol=1e-2)
+            assert close.mean() > 0.95
+
+
+def test_whitening_save_and_load(dtype, tmp_path):
+    tform = Whitening(2, 512, 1, dtype)
+    h1 = torch.randn(512 * 10)
+    l1 = torch.randn(512 * 10)
+    tform.fit(2, 2, h1=h1, l1=l1)
+
+    assert (tform.kernel_length == 2).all().item()
+    assert tform.built
+    value = tform.time_domain_filter
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    torch.save(tform.state_dict(), tmp_path / "weights.pt")
+
+    tform = Whitening(2, 512, 1, dtype)
+    assert not tform.built
+    assert (tform.kernel_length == 0).all().item()
+
+    tform.load_state_dict(torch.load(tmp_path / "weights.pt"))
+    assert tform.built
+    assert (tform.kernel_length == 2).all().item()
+    assert (tform.time_domain_filter == value).all().item()
+
+    # ensure that loading something with the wrong shape
+    # causes an error to get raised
+    tform = Whitening(2, 512, 0.5, dtype)
+    with pytest.raises(RuntimeError):
+        tform.load_state_dict(torch.load(tmp_path / "weights.pt"))


### PR DESCRIPTION
Closes #6 . Creating a whitening transform with an associated base class for transforms with parameters that need to be fit to some data (but not by gradient descent). Slightly reorganized from the implementation in BBHNet, with:
- Only arguments needed to set the size of the time domain filter are required at `__init__` time.
- Arguments needed to set the values of the time domain filter, which are arguments pertaining to how the background data should be converted to the frequency domain and then converted into a filter.