### PR TITLE
Fixing some issues with device placement

### DIFF
--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -445,7 +445,9 @@ class RandomWaveformInjection(FittableTransform):
             waveforms = waveforms.to(X.device)
             X[mask] += waveforms
 
+            # make sure all our returns live on the same device
             indices = torch.where(mask)[0].to(X.device)
+            sampled_params = sampled_params.to(X.device)
         else:
             # if we're in eval mode, skip injection
             # altogether and return nones to indicate this

--- a/ml4gw/transforms/injection.py
+++ b/ml4gw/transforms/injection.py
@@ -304,9 +304,7 @@ class RandomWaveformInjection(FittableTransform):
         return torch.nn.Module.__call__(self, *args, **kwargs)
 
     def sample(
-        self,
-        N_or_idx: Union[int, gw.ScalarTensor],
-        device: Optional[str] = None,
+        self, N_or_idx: Union[int, gw.ScalarTensor]
     ) -> Tuple[gw.WaveformTensor, Tuple[gw.ScalarTensor, ...]]:
         """
         Sample some waveforms and source parameters and use them
@@ -350,6 +348,12 @@ class RandomWaveformInjection(FittableTransform):
                 # we asked for some specific random number of waveforms
                 idx = torch.randperm(self.num_waveforms)[:N_or_idx]
                 N = N_or_idx
+        elif N_or_idx.ndim != 1:
+            raise ValueError(
+                "Can't slice waveforms with index tensor with {} dims".format(
+                    N_or_idx.ndim
+                )
+            )
         else:
             # we provided specific waveform indices that
             # we would like to project
@@ -365,9 +369,7 @@ class RandomWaveformInjection(FittableTransform):
         polarizations = {}
         for polarization, waveforms in self.polarizations.items():
             waveforms = waveforms[idx]
-            if device is not None:
-                waveforms = waveforms.to(device)
-            polarizations[polarization] = waveforms
+            polarizations[polarization] = waveforms.to(dec.device)
 
         ifo_responses = gw.compute_observed_strain(
             dec,
@@ -425,17 +427,28 @@ class RandomWaveformInjection(FittableTransform):
                     param_shape += 1
                 if self.intrinsic_parameters is not None:
                     param_shape += self.intrinsic_parameters.size(-1)
-                return X, torch.zeros((0,)), torch.zeros((0, param_shape))
 
-            waveforms, sampled_params = self.sample(N, X.device)
+                indices = torch.zeros((0,), device=X.device)
+                sampled_params = torch.zeros((0, param_shape), device=X.device)
+                return X, indices, sampled_params
+
+            waveforms, sampled_params = self.sample(N)
             waveforms = sample_kernels(
                 waveforms,
                 kernel_size=X.shape[-1],
                 max_center_offset=self.trigger_offset,
                 coincident=True,
             )
+
+            # map waveforms to appropriate device and
+            # inject them into input tensor
+            waveforms = waveforms.to(X.device)
             X[mask] += waveforms
 
-            indices = torch.where(mask)[0]
+            indices = torch.where(mask)[0].to(X.device)
+        else:
+            # if we're in eval mode, skip injection
+            # altogether and return nones to indicate this
+            indices = sampled_params = None
 
         return X, indices, sampled_params

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -52,6 +52,11 @@ def slice_kernels(
         `num_channels = x.shape[0]` if `x` is 2D.
     """
 
+    # create the indices all the slices will be built around,
+    # and ensure they live on the appropriate device
+    kernels = torch.arange(kernel_size, device=x.device)
+    idx = idx.to(kernels.device)
+
     # TODO: add try-catches aroud the actual slicing operations
     # to catch out-of-range index errors and raise with a
     # standardized error that's very explicit
@@ -64,7 +69,7 @@ def slice_kernels(
         # this is a one dimensional array that we want
         # to select kernels from beginning at each of
         # the specified indices
-        kernels = torch.arange(kernel_size).view(kernel_size, 1)
+        kernels = kernels.view(kernel_size, 1)
         kernels = kernels.repeat(1, len(idx))
         kernels = (kernels + idx).t()
         return torch.take(x, kernels)
@@ -74,8 +79,7 @@ def slice_kernels(
         # coincidentally
 
         # channels x batch_size x kernel_size
-        kernels = torch.arange(kernel_size).view(1, 1, kernel_size)
-        kernels = kernels.to(x.device)
+        kernels = kernels.view(1, 1, kernel_size)
         kernels = kernels.repeat(len(x), len(idx), 1)
         kernels += idx.view(1, -1, 1)
 
@@ -101,8 +105,7 @@ def slice_kernels(
             )
 
         # batch_size x num_channels x kernel_size
-        kernels = torch.arange(kernel_size).view(1, 1, kernel_size)
-        kernels = kernels.to(x.device)
+        kernels = kernels.view(1, 1, kernel_size)
         kernels = kernels.repeat(len(idx), len(x), 1)
         kernels += idx[:, :, None]
 
@@ -133,8 +136,7 @@ def slice_kernels(
             )
 
         # batch_size x kernel_size
-        kernels = torch.arange(kernel_size).view(1, -1)
-        kernels = kernels.to(x.device)
+        kernels = kernels.view(1, -1)
         kernels = kernels.repeat(len(idx), 1)
         kernels += idx.view(-1, 1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ml4gw"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tools for training torch models on gravitational wave data"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Makes sure that slicing indices in `slice_kernels` are matched appropriately, and uses the `RandomWaveformInjection.tensors` parameter to pick the device on which waveform projection gets done, then maps back to `X.device` in `.forward` (if they're the same, this is a no-op).

I've tested these locally to ensure they work, but ideally we'd create unit tests for this in CI. Unforunately, since the GitHub runner nodes don't have GPUs and torch doesn't have a dummy device object you can use for testing this functionality, I'm not quite sure how to do it as part of CI.