### PR TITLE
SineGaussian improvements

### DIFF
--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -11,6 +11,13 @@ def semi_major_minor_from_e(e: Tensor):
     return a, b
 
 class SineGaussian(torch.nn.Module):
+    """
+    Callable class for generating sine-Gaussian waveforms.
+
+    Args:
+        sample_rate: Sample rate of waveform
+        duration: Duration of waveform
+    """
     def __init__(self, sample_rate: float, duration: float):
         super().__init__()
         # determine times based on requested duration and sample rate
@@ -31,8 +38,9 @@ class SineGaussian(torch.nn.Module):
         eccentricity: ScalarTensor,
     ):
         """
-        Generate lalsimulation implementation of a sine-Gaussian waveform.
-        https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalinference/lib/LALInferenceBurstRoutines.c#L381
+        Generate lalinference implementation of a sine-Gaussian waveform.
+        See https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalinference/lib/LALInferenceBurstRoutines.c#L381
+        for details on parameter definitions.
 
         Args:
             frequency:
@@ -48,8 +56,7 @@ class SineGaussian(torch.nn.Module):
                 Controls the relative amplitudes of the
                 hplus and hcross polarizations.
         Returns:
-            A tensor of size (batch, 2, time) containing
-            the hplus and hcross polarizations
+            Tensors of cross and plus polarizations
         """
 
         # add dimension for calculating waveforms in batch

--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -6,15 +6,9 @@ from ml4gw.types import ScalarTensor
 
 
 def semi_major_minor_from_e(e: Tensor):
-    a = 1.0 / torch.sqrt(2.0 - e * e)
-    b = a * torch.sqrt(1.0 - e * e)
+    a = 1.0 / torch.sqrt(2.0 - (e * e))
+    b = a * torch.sqrt(1.0 - (e * e))
     return a, b
-
-
-# TODO: replace with torch implementation
-def tukey_window(num: int, alpha: float = 0.5):
-    return torch.tensor(tukey(num, alpha=alpha))
-
 
 class SineGaussian(torch.nn.Module):
     def __init__(self, sample_rate: float, duration: float):

--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -32,7 +32,7 @@ class SineGaussian(torch.nn.Module):
     ):
         """
         Generate lalsimulation implementation of a sine-Gaussian waveform.
-        https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimBurst.c#L1080
+        https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalinference/lib/LALInferenceBurstRoutines.c#L381
 
         Args:
             frequency:

--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -40,7 +40,7 @@ class SineGaussian(torch.nn.Module):
     ):
         """
         Generate lalinference implementation of a sine-Gaussian waveform.
-        See 
+        See
         git.ligo.org/lscsoft/lalsuite/-/blob/master/lalinference/lib/LALInferenceBurstRoutines.c#L381
         for details on parameter definitions.
 

--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -1,5 +1,4 @@
 import torch
-from scipy.signal.windows import tukey
 from torch import Tensor
 
 from ml4gw.types import ScalarTensor
@@ -10,6 +9,7 @@ def semi_major_minor_from_e(e: Tensor):
     b = a * torch.sqrt(1.0 - (e * e))
     return a, b
 
+
 class SineGaussian(torch.nn.Module):
     """
     Callable class for generating sine-Gaussian waveforms.
@@ -18,6 +18,7 @@ class SineGaussian(torch.nn.Module):
         sample_rate: Sample rate of waveform
         duration: Duration of waveform
     """
+
     def __init__(self, sample_rate: float, duration: float):
         super().__init__()
         # determine times based on requested duration and sample rate
@@ -39,7 +40,8 @@ class SineGaussian(torch.nn.Module):
     ):
         """
         Generate lalinference implementation of a sine-Gaussian waveform.
-        See https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalinference/lib/LALInferenceBurstRoutines.c#L381
+        See 
+        git.ligo.org/lscsoft/lalsuite/-/blob/master/lalinference/lib/LALInferenceBurstRoutines.c#L381
         for details on parameter definitions.
 
         Args:
@@ -103,11 +105,9 @@ class SineGaussian(torch.nn.Module):
 
         cross = fac.imag * h0_cross
         plus = fac.real * h0_plus
-        
+
         # TODO dtype as argument?
         cross = cross.double()
         plus = plus.double()
-        
-        return cross, plus
 
-        
+        return cross, plus

--- a/tests/waveforms/test_sine_gaussian.py
+++ b/tests/waveforms/test_sine_gaussian.py
@@ -2,46 +2,54 @@ import numpy as np
 import pytest
 import torch
 from lalinference import BurstSineGaussian
-import scipy
+
 from ml4gw.waveforms import SineGaussian
-import itertools
-import scipy
+
 
 @pytest.fixture(params=[2048, 4096])
 def sample_rate(request):
     return request.param
 
 
-@pytest.fixture(params=[2., 4., 8.])
+@pytest.fixture(params=[2.0, 4.0, 8.0])
 def duration(request):
     return request.param
 
 
-@pytest.fixture(params=[3., 10., 100., 55.])
+@pytest.fixture(params=[3.0, 10.0, 100.0, 55.0])
 def quality(request):
     return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[100., 500., 800., 961.])
+@pytest.fixture(params=[100.0, 500.0, 800.0, 961.0])
 def frequency(request):
     return torch.tensor(request.param, dtype=torch.float64)
+
 
 # for amplitudes above ~7e-20, the difference between torch imp
 # and lalsim is > ~1e-24. Our implementations are 1 to 1, so
 # discrep must be from numerical issues?
-@pytest.fixture(params=[1e-23, 1e-22, 1e-21, 1e-20, 7e-20]) 
+@pytest.fixture(params=[1e-23, 1e-22, 1e-21, 1e-20, 7e-20])
 def hrss(request):
     return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[0., np.pi / 2., np.pi, 2*np.pi])
+@pytest.fixture(params=[0.0, np.pi / 2.0, np.pi, 2 * np.pi])
 def phase(request):
     return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[0., 0.5, 1., 0.1, ])
+@pytest.fixture(
+    params=[
+        0.0,
+        0.5,
+        1.0,
+        0.1,
+    ]
+)
 def eccentricity(request):
     return torch.tensor(request.param, dtype=torch.float64)
+
 
 def test_sine_gaussian(
     duration,
@@ -55,17 +63,15 @@ def test_sine_gaussian(
     sine_gaussian = SineGaussian(sample_rate, duration)
 
     # calculate waveforms with torch implementation
-    cross, plus = sine_gaussian(
-        quality, frequency, hrss, phase, eccentricity
-    )
+    cross, plus = sine_gaussian(quality, frequency, hrss, phase, eccentricity)
     cross, plus = cross[0].numpy(), plus[0].numpy()
-    
+
     quality = quality.item()
     frequency = frequency.item()
     phase = phase.item()
     eccentricity = eccentricity.item()
     hrss = hrss.item()
-    
+
     # calculate waveform with lalsimulation
     hplus, hcross = BurstSineGaussian(
         Q=quality,
@@ -73,7 +79,7 @@ def test_sine_gaussian(
         hrss=hrss,
         eccentricity=eccentricity,
         phase=phase,
-        delta_t= 1 / sample_rate,
+        delta_t=1 / sample_rate,
     )
     hplus = hplus.data.data
     hcross = hcross.data.data
@@ -86,6 +92,9 @@ def test_sine_gaussian(
     )
     cross, plus = cross[start:stop], plus[start:stop]
 
-    assert np.allclose(cross, hcross, atol=1e-24) # factor of 10 smaller than ligo noise floor
-    assert np.allclose(plus, hplus, atol=1e-24) # factor of 10 smaller than ligo noise floor
-    
+    assert np.allclose(
+        cross, hcross, atol=1e-24
+    )  # factor of 10 smaller than ligo noise floor
+    assert np.allclose(
+        plus, hplus, atol=1e-24
+    )  # factor of 10 smaller than ligo noise floor

--- a/tests/waveforms/test_sine_gaussian.py
+++ b/tests/waveforms/test_sine_gaussian.py
@@ -2,90 +2,90 @@ import numpy as np
 import pytest
 import torch
 from lalinference import BurstSineGaussian
-
+import scipy
 from ml4gw.waveforms import SineGaussian
-
+import itertools
+import scipy
 
 @pytest.fixture(params=[2048, 4096])
 def sample_rate(request):
     return request.param
 
 
-@pytest.fixture(params=[2, 4, 8])
+@pytest.fixture(params=[2., 4., 8.])
 def duration(request):
     return request.param
 
 
-@pytest.fixture(params=[[3, 10, 100]])
-def qualities(request):
-    return torch.tensor(request.param)
+@pytest.fixture(params=[3., 10., 100., 55.])
+def quality(request):
+    return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[[100, 500, 800]])
-def frequencies(request):
-    return torch.tensor(request.param)
+@pytest.fixture(params=[100., 500., 800., 961.])
+def frequency(request):
+    return torch.tensor(request.param, dtype=torch.float64)
 
-
-@pytest.fixture(params=[[1e-22, 1e-21, 1e-20]])
+# for amplitudes above ~7e-20, the difference between torch imp
+# and lalsim is > ~1e-24. Our implementations are 1 to 1, so
+# discrep must be from numerical issues?
+@pytest.fixture(params=[1e-23, 1e-22, 1e-21, 1e-20, 7e-20]) 
 def hrss(request):
-    return torch.tensor(request.param)
+    return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[[0, np.pi / 2, np.pi]])
-def phases(request):
-    return torch.tensor(request.param)
+@pytest.fixture(params=[0., np.pi / 2., np.pi, 2*np.pi])
+def phase(request):
+    return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[[0, 0.5, 1]])
-def eccentricities(request):
-    return torch.tensor(request.param)
-
+@pytest.fixture(params=[0., 0.5, 1., 0.1, ])
+def eccentricity(request):
+    return torch.tensor(request.param, dtype=torch.float64)
 
 def test_sine_gaussian(
     duration,
     sample_rate,
-    qualities,
-    frequencies,
+    quality,
+    frequency,
     hrss,
-    phases,
-    eccentricities,
+    phase,
+    eccentricity,
 ):
-
     sine_gaussian = SineGaussian(sample_rate, duration)
+
     # calculate waveforms with torch implementation
-    waveforms = sine_gaussian(
-        qualities, frequencies, hrss, phases, eccentricities
+    cross, plus = sine_gaussian(
+        quality, frequency, hrss, phase, eccentricity
     )
+    cross, plus = cross[0].numpy(), plus[0].numpy()
+    
+    quality = quality.item()
+    frequency = frequency.item()
+    phase = phase.item()
+    eccentricity = eccentricity.item()
+    hrss = hrss.item()
+    
+    # calculate waveform with lalsimulation
+    hplus, hcross = BurstSineGaussian(
+        Q=quality,
+        centre_frequency=frequency,
+        hrss=hrss,
+        eccentricity=eccentricity,
+        phase=phase,
+        delta_t= 1 / sample_rate,
+    )
+    hplus = hplus.data.data
+    hcross = hcross.data.data
 
-    # calculate waveforms with lalsimulation implementation
-    # and compare to torch version
-    for i in range(len(qualities)):
-        quality = qualities[i].item()
-        frequency = frequencies[i].item()
-        phase = phases[i].item()
-        eccentricity = eccentricities[i].item()
-        waveform = waveforms[i]
+    # compare cross and plus polarizations
+    n_samples = len(hplus)
+    start, stop = (
+        len(cross) // 2 - n_samples // 2,
+        len(cross) // 2 + n_samples // 2 + 1,
+    )
+    cross, plus = cross[start:stop], plus[start:stop]
 
-        # calculate waveform with lalsimulation
-        hplus, hcross = BurstSineGaussian(
-            Q=quality,
-            centre_frequency=frequency,
-            hrss=hrss[i].item(),
-            eccentricity=eccentricity,
-            phase=phase,
-            delta_t=1 / sample_rate,
-        )
-        hplus = hplus.data.data
-        hcross = hcross.data.data
-
-        # compare hplus and hcross polarizations
-        torch_polarizations = waveform.numpy()
-        n_samples = len(hplus)
-        start, stop = (
-            torch_polarizations.shape[-1] // 2 - n_samples // 2,
-            torch_polarizations.shape[-1] // 2 + n_samples // 2 + 1,
-        )
-        torch_polarizations = torch_polarizations[..., start:stop]
-
-        assert np.allclose(torch_polarizations[0], hplus, atol=1e-25)
-        assert np.allclose(torch_polarizations[1], hcross, atol=1e-25)
+    assert np.allclose(cross, hcross, atol=1e-24) # factor of 10 smaller than ligo noise floor
+    assert np.allclose(plus, hplus, atol=1e-24) # factor of 10 smaller than ligo noise floor
+    


### PR DESCRIPTION
1. Now return `cross` and `plus` polarizations directly, and alphabetically. Returning this way is most compatible with other functions in `ml4gw` like `gw.compute_observed_strain` that expect the polarizations to be passed individually.
2. Removes windowing - our implementation is now fully equivalent to the lalinference implementation
3. Makes SG tests more robust

There is still some discrepancy between our implementation and the lalinference implementation that I can't track down. I presume it must be some numerical issue. As amplitudes increase, this discrepancy also increases. For amplitudes less than `7e-20` this discrepancy is less than 1e-24 (i.e. ~10x the LIGO noise floor). 

