### PR TITLE
Highpass device fix

### DIFF
--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -365,7 +365,7 @@ def compute_ifo_snr(
     elif highpass is not None:
         freqs = torch.fft.rfftfreq(responses.shape[-1], 1 / sample_rate)
         mask = freqs >= highpass
-        integrand *= mask
+        integrand *= mask.to(integrand.device)
 
     # TODO: we could in principle do this without requiring
     # that the user specify the sample rate by taking the

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -352,19 +352,18 @@ def compute_ifo_snr(
 
     # mask out low frequency components if a critical
     # frequency or frequency mask was provided
-    if isinstance(highpass, torch.Tensor):
-        if len(highpass) != integrand.shape[-1]:
+    if highpass is not None:
+        if not isinstance(highpass, torch.Tensor):
+            freqs = torch.fft.rfftfreq(responses.shape[-1], 1 / sample_rate)
+            highpass = freqs >= highpass
+        elif len(highpass) != integrand.shape[-1]:
             raise ValueError(
                 "Can't apply highpass filter mask with {} frequecy bins"
                 "to signal fft with {} frequency bins".format(
                     len(highpass), integrand.shape[-1]
                 )
             )
-    elif highpass is not None:
-        freqs = torch.fft.rfftfreq(responses.shape[-1], 1 / sample_rate)
-        highpass = freqs >= highpass
-
-    integrand *= highpass.to(integrand.device)
+        integrand *= highpass.to(integrand.device)
 
     # sum over the desired frequency range and multiply
     # by df to turn it into an integration (and get

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -286,7 +286,7 @@ def get_ifo_geometry(
 
 def compute_ifo_snr(
     responses: WaveformTensor,
-    backgrounds: PSDTensor,
+    psd: PSDTensor,
     sample_rate: float,
     highpass: Union[float, TensorType["frequency"], None] = None,
 ) -> TensorType["batch", "num_ifos"]:
@@ -314,10 +314,15 @@ def compute_ifo_snr(
         responses:
             A batch of interferometer responses to a batch of
             raw gravitational waveforms
-        backgrounds:
+        psd:
             The one-sided power spectral density of the background
             noise at each interferometer to which a response
-            in `responses` has been calculated.
+            in `responses` has been calculated. If 2D, each row of
+            `psd` will be assumed to be the background PSD for each
+            channel of _every_ batch element in `responses`. If 3D,
+            this should contain a background PSD for each channel
+            of each element in `responses`, and therefore the first
+            two dimensions of `psd` and `responses` should match.
         sample_rate:
             The frequency at which the waveform responses timeseries
             have been sampled. Upon fourier transforming, should
@@ -334,7 +339,7 @@ def compute_ifo_snr(
     """
 
     # TODO: should we do windowing here?
-    # compute frequency power, upsample precision so that
+    # compute frequency power, upsampling precision so that
     # computing absolute value doesn't accidentally zero some
     # values out.
     fft = torch.fft.rfft(responses, axis=-1).type(torch.complex128)
@@ -342,13 +347,8 @@ def compute_ifo_snr(
 
     # divide by background asd, then go back to FP32 precision
     # and square now that values are back in a reasonable range
-    integrand = fft / (backgrounds**0.5)
+    integrand = fft / (psd**0.5)
     integrand = integrand.type(torch.float32) ** 2
-
-    # sum over the desired frequency range and multiply
-    # by df to turn it into an integration (and get
-    # our units to drop out)
-    df = sample_rate / responses.shape[-1]
 
     # mask out low frequency components if a critical
     # frequency or frequency mask was provided
@@ -360,13 +360,15 @@ def compute_ifo_snr(
                     len(highpass), integrand.shape[-1]
                 )
             )
-
-        integrand *= highpass
     elif highpass is not None:
         freqs = torch.fft.rfftfreq(responses.shape[-1], 1 / sample_rate)
-        mask = freqs >= highpass
-        integrand *= mask.to(integrand.device)
+        highpass = freqs >= highpass
 
+    integrand *= highpass.to(integrand.device)
+
+    # sum over the desired frequency range and multiply
+    # by df to turn it into an integration (and get
+    # our units to drop out)
     # TODO: we could in principle do this without requiring
     # that the user specify the sample rate by taking the
     # fft as-is (without dividing by sample rate) and then
@@ -376,6 +378,7 @@ def compute_ifo_snr(
     # need the sample rate to compute the mask, but if we
     # replace this with a `mask` argument instead we're in
     # the clear
+    df = sample_rate / responses.shape[-1]
     integrated = integrand.sum(axis=-1) * df
 
     # multiply by 4 for mystical reasons
@@ -385,7 +388,7 @@ def compute_ifo_snr(
 
 def compute_network_snr(
     responses: WaveformTensor,
-    backgrounds: PSDTensor,
+    psd: PSDTensor,
     sample_rate: float,
     highpass: Union[float, TensorType["frequency"], None] = None,
 ) -> ScalarTensor:
@@ -407,7 +410,12 @@ def compute_network_snr(
         backgrounds:
             The one-sided power spectral density of the background
             noise at each interferometer to which a response
-            in `responses` has been calculated.
+            in `responses` has been calculated. If 2D, each row of
+            `psd` will be assumed to be the background PSD for each
+            channel of _every_ batch element in `responses`. If 3D,
+            this should contain a background PSD for each channel
+            of each element in `responses`, and therefore the first
+            two dimensions of `psd` and `responses` should match.
         sample_rate:
             The frequency at which the waveform responses timeseries
             have been sampled. Upon fourier transforming, should
@@ -422,7 +430,7 @@ def compute_network_snr(
     Returns:
         Batch of SNRs for each waveform across the interferometer network
     """
-    snrs = compute_ifo_snr(responses, backgrounds, sample_rate, highpass)
+    snrs = compute_ifo_snr(responses, psd, sample_rate, highpass)
     snrs = snrs**2
     return snrs.sum(axis=-1) ** 0.5
 
@@ -430,7 +438,7 @@ def compute_network_snr(
 def reweight_snrs(
     responses: WaveformTensor,
     target_snrs: Union[float, ScalarTensor],
-    backgrounds: PSDTensor,
+    psd: PSDTensor,
     sample_rate: float,
     highpass: Union[float, TensorType["frequency"], None] = None,
 ) -> WaveformTensor:
@@ -443,10 +451,15 @@ def reweight_snrs(
         target_snrs:
             Either a tensor of desired SNRs for each waveform,
             or a single SNR to which all waveforms should be scaled.
-        backgrounds:
+        psd:
             The one-sided power spectral density of the background
             noise at each interferometer to which a response
-            in `responses` has been calculated.
+            in `responses` has been calculated. If 2D, each row of
+            `psd` will be assumed to be the background PSD for each
+            channel of _every_ batch element in `responses`. If 3D,
+            this should contain a background PSD for each channel
+            of each element in `responses`, and therefore the first
+            two dimensions of `psd` and `responses` should match.
         sample_rate:
             The frequency at which the waveform responses timeseries
             have been sampled. Upon fourier transforming, should
@@ -462,6 +475,6 @@ def reweight_snrs(
         Rescaled interferometer responses
     """
 
-    snrs = compute_network_snr(responses, backgrounds, sample_rate, highpass)
+    snrs = compute_network_snr(responses, psd, sample_rate, highpass)
     weights = target_snrs / snrs
     return responses * weights[:, None, None]


### PR DESCRIPTION
When passing `highpass` as a float to the various SNR-related functions, a device issue gets raised if the responses are on GPU. This fixes that error and switches the `background` argument to `psd` to emphasize what it's meant to represent (as opposed to a time domain representation or even the ASD).