### PR TITLE
getting rid of poetry in unit tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,18 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: PyPI
+    steps:
+    - uses: actions/checkout@v2
+    - 
+      name: Build and publish to pypi
+      uses: JRubics/poetry-publish@v1.16
+      with:
+        python_version: "3.10.9"
+        pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,8 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
-        poetry-version: ['', '1.2.0', '1.2.1', '1.2.2', '1.3.0', '1.3.1']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
 
@@ -23,13 +22,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - 
-      name: Install Poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      if: ${{ matrix.poetry-version != '' }}
-      with:
-        poetry-version: ${{ matrix.poetry-version }}
-
     -
       name: Install tox
       run: |
@@ -41,12 +33,7 @@ jobs:
       name: run tests
       env:
         pyver: ${{ matrix.python-version }}
-      run: |
-        if [[ -z "${{ matrix.poetry-version }}" ]]; then
-            tox -e py${pyver//./}-pip
-        else
-            tox -e py${pyver//./}-poetry
-        fi
+      run: tox -e py${pyver//./}
 
   # if all the tests pass on a push to main,
   # publish the new code to pypi

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -34,19 +34,3 @@ jobs:
       env:
         pyver: ${{ matrix.python-version }}
       run: tox -e py${pyver//./}
-
-  # if all the tests pass on a push to main,
-  # publish the new code to pypi
-  publish:
-    runs-on: ubuntu-latest
-    needs: test
-    environment: PyPI
-    if: ${{ github.event_name == 'push' }}
-    steps:
-    - uses: actions/checkout@v2
-    - 
-      name: Build and publish to pypi
-      uses: JRubics/poetry-publish@v1.16
-      with:
-        python_version: "3.10.9"
-        pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ include_trailing_comma = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{38,39,310}-{pip,poetry}
+envlist = py{38,39,310,311}
 isolated_build = true
 
 [gh-actions]
@@ -55,21 +55,16 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
-[testenv:py{38,39,310}-poetry]
-allowlist_externals = poetry
-skip_install = true
-commands_pre = poetry install
-commands = poetry run pytest tests
-
-[testenv:py{38,39,310}-pip]
+[testenv:py{38,39,310,311}]
 deps = 
     pytest>=7,<8
     lalsuite>=7,<8
     bilby>=1.1,<2
+    gwpy>=3.0
 commands = pytest tests
 """
-
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Removal of poetry use in CI testing. Includes python 3.11 so needs #60 to be merged first