### PR TITLE
Remove leftover `scipy` and `numpy` utils

### DIFF
--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -16,11 +16,6 @@ from torchtyping import TensorType
 
 from ml4gw import types
 
-try:
-    from scipy.signal.spectral import _median_bias
-except ImportError:
-    from scipy.signal._spectral_py import _median_bias
-
 time = None
 
 
@@ -29,8 +24,10 @@ def median(x, axis):
     Implements a median calculation that matches numpy's
     behavior for an even number of elements and includes
     the same bias correction used by scipy's implementation.
+    see https://github.com/scipy/scipy/blob/main/scipy/signal/_spectral_py.py#L2066 # noqa
     """
-    bias = _median_bias(x.shape[axis])
+    ii_2 = 2 * np.arange(1., (n-1) // 2 + 1)
+    bias = 1 + np.sum(1. / (ii_2 + 1) - 1. / ii_2)
     return torch.quantile(x, q=0.5, axis=axis) / bias
 
 

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -26,8 +26,8 @@ def median(x, axis):
     the same bias correction used by scipy's implementation.
     see https://github.com/scipy/scipy/blob/main/scipy/signal/_spectral_py.py#L2066 # noqa
     """
-    ii_2 = 2 * np.arange(1., (n-1) // 2 + 1)
-    bias = 1 + np.sum(1. / (ii_2 + 1) - 1. / ii_2)
+    ii_2 = 2 * torch.arange(1., (n-1) // 2 + 1)
+    bias = 1 + torch.sum(1. / (ii_2 + 1) - 1. / ii_2)
     return torch.quantile(x, q=0.5, axis=axis) / bias
 
 

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -26,8 +26,9 @@ def median(x, axis):
     the same bias correction used by scipy's implementation.
     see https://github.com/scipy/scipy/blob/main/scipy/signal/_spectral_py.py#L2066 # noqa
     """
-    ii_2 = 2 * torch.arange(1., (n-1) // 2 + 1)
-    bias = 1 + torch.sum(1. / (ii_2 + 1) - 1. / ii_2)
+    n = x.shape[axis]
+    ii_2 = 2 * torch.arange(1.0, (n - 1) // 2 + 1)
+    bias = 1 + torch.sum(1.0 / (ii_2 + 1) - 1.0 / ii_2)
     return torch.quantile(x, q=0.5, axis=axis) / bias
 
 

--- a/ml4gw/transforms/scaler.py
+++ b/ml4gw/transforms/scaler.py
@@ -44,21 +44,19 @@ class ChannelWiseScaler(FittableTransform):
 
         if X.ndim == 1:
             assert self.mean.ndim == self.std.ndim == 1
-            mean = X.mean(keepdims=True)
-            std = X.std(keepdims=True)
+            mean = X.mean(dim=0, keepdim=True)
+            # default for torch is to include bessel correction
+            std = X.std(dim=0, correction=0, keepdim=True)
         elif X.ndim == 2:
             assert self.mean.ndim == self.std.ndim == 2
             assert len(X) == self.mean.size(0) == self.std.size(0)
-            mean = X.mean(axis=-1, keepdims=True)
-            std = X.std(axis=-1, keepdims=True)
+            mean = X.mean(dim=-1, keepdim=True)
+            std = X.std(dim=-1, correction=0, keepdim=True)
         else:
             raise ValueError(
                 "Can't fit channel wise mean and standard deviation "
                 "from tensor of shape {}".format(X.shape)
             )
-
-        mean = torch.tensor(mean)
-        std = torch.tensor(std)
 
         super().build(mean=mean, std=std)
 

--- a/ml4gw/transforms/scaler.py
+++ b/ml4gw/transforms/scaler.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import numpy as np
 import torch
 
 from ml4gw.transforms.transform import FittableTransform
@@ -35,7 +34,7 @@ class ChannelWiseScaler(FittableTransform):
         self.register_buffer("mean", mean)
         self.register_buffer("std", std)
 
-    def fit(self, X: np.ndarray) -> None:
+    def fit(self, X: torch.Tensor) -> None:
         """Fit the scaling parameters to a timeseries
 
         Computes the channel-wise mean and standard deviation

--- a/ml4gw/transforms/snr_rescaler.py
+++ b/ml4gw/transforms/snr_rescaler.py
@@ -1,6 +1,5 @@
-from typing import Optional, Union
+from typing import Optional
 
-import numpy as np
 import torch
 
 from ml4gw import gw
@@ -35,7 +34,7 @@ class SnrRescaler(FittableSpectralTransform):
 
     def fit(
         self,
-        *background: Union[torch.Tensor, np.ndarray],
+        *background: torch.Tensor,
         fftlength: Optional[float] = None,
         overlap: Optional[float] = None,
     ):

--- a/ml4gw/transforms/transform.py
+++ b/ml4gw/transforms/transform.py
@@ -49,9 +49,6 @@ class FittableSpectralTransform(FittableTransform):
         fftlength: Optional[float] = None,
         overlap: Optional[float] = None,
     ):
-        if not isinstance(x, torch.Tensor):
-            x = torch.tensor(x)
-
         # if we specified an FFT length, convert
         # the (assumed) time-domain data to the
         # frequency domain

--- a/tests/transforms/test_scaler.py
+++ b/tests/transforms/test_scaler.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 import torch
 
@@ -12,7 +11,7 @@ def test_scaler_1d():
     assert scaler.std.shape == (1,)
 
     # test fitting
-    background = np.arange(1, 11)
+    background = torch.arange(1, 11).type(torch.float32)
     scaler.fit(background)
 
     mean, std = 5.5, (99 / 12) ** 0.5
@@ -46,7 +45,12 @@ def test_scaler_2d():
     assert scaler.std.shape == (num_channels, 1)
 
     # test fitting
-    background = np.arange(num_channels * 10).reshape(num_channels, 10) + 1
+    background = (
+        torch.arange(num_channels * 10)
+        .reshape(num_channels, 10)
+        .type(torch.float32)
+        + 1
+    )
     scaler.fit(background)
 
     std = (99 / 12) ** 0.5
@@ -62,7 +66,7 @@ def test_scaler_2d():
         scaler.fit(background[None, None])
 
     # test forward with 2D
-    x = torch.arange(num_channels * 10)
+    x = torch.arange(num_channels * 10).type(torch.float32)
     x = x.reshape(num_channels, 10).type(torch.float32) + 1
     y = scaler(x)
     expected = (torch.arange(1, 11) - 5.5) / std
@@ -85,7 +89,7 @@ def test_scaler_2d():
 
 def test_scaler_save_and_load(tmp_path):
     scaler = ChannelWiseScaler()
-    background = np.arange(1, 11)
+    background = torch.arange(1, 11).type(torch.float32)
 
     scaler.fit(background)
     assert scaler.built


### PR DESCRIPTION
1. Removes `numpy` import and type annotation in `scaler.py`
2. Removes scipy `_median_bias` call in spectral.py