### PR TITLE
reformulating things to build batch-level dataloader (#67)

### DIFF
--- a/ml4gw/dataloading/__init__.py
+++ b/ml4gw/dataloading/__init__.py
@@ -1,2 +1,3 @@
-from .chunked_dataset import ChunkedDataset
+from .chunked_dataset import ChunkedTimeSeriesDataset
+from .hdf5_dataset import Hdf5TimeSeriesDataset
 from .in_memory_dataset import InMemoryDataset

--- a/ml4gw/dataloading/hdf5_dataset.py
+++ b/ml4gw/dataloading/hdf5_dataset.py
@@ -1,0 +1,176 @@
+import warnings
+from typing import Sequence, Union
+
+import h5py
+import numpy as np
+import torch
+
+from ml4gw.types import WaveformTensor
+
+
+class ContiguousHdf5Warning(Warning):
+    pass
+
+
+class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
+    """
+    Iterable dataset that samples and loads windows of
+    timeseries data uniformly from a set of HDF5 files.
+    It is _strongly_ recommended that these files have been
+    written using [chunked storage]
+    (https://docs.h5py.org/en/stable/high/dataset.html#chunked-storage).
+    This has shown to produce increases in read-time speeds
+    of over an order of magnitude.
+
+    Args:
+        fnames:
+            Paths to HDF5 files from which to sample data.
+        channels:
+            Datasets to read from the indicated files, which
+            will be stacked along dim 1 of the generated batches
+            during iteration.
+        kernel_size:
+            Size of the windows to read, in number of samples.
+            This will be the size of the last dimension of the
+            generated batches.
+        batch_size:
+            Number of windows to sample at each iteration.
+        batches_per_epoch:
+            Number of batches to generate during each call
+            to `__iter__`.
+        coincident:
+            Whether windows for each channel in a given batch
+            element should be sampled coincidentally, i.e.
+            corresponding to the same time indices from the
+            same files, or should be sampled independently.
+            For the latter case, users can either specify
+            `False`, which will sample filenames independently
+            for each channel, or `"files"`, which will sample
+            windows independently within a given file for each
+            channel. The latter setting limits the amount of
+            entropy in the effective dataset, but can provide
+            over 2x improvement in total throughput.
+    """
+
+    def __init__(
+        self,
+        fnames: Sequence[str],
+        channels: Sequence[str],
+        kernel_size: int,
+        batch_size: int,
+        batches_per_epoch: int,
+        coincident: Union[bool, str],
+    ) -> None:
+        if not isinstance(coincident, bool) and coincident != "files":
+            raise ValueError(
+                "coincident must be either a boolean or 'files', "
+                "got unrecognized value {}".format(coincident)
+            )
+
+        self.fnames = fnames
+        self.channels = channels
+        self.num_channels = len(channels)
+        self.kernel_size = kernel_size
+        self.batch_size = batch_size
+        self.batches_per_epoch = batches_per_epoch
+        self.coincident = coincident
+
+        self.sizes = {}
+        for fname in self.fnames:
+            with h5py.File(fname, "r") as f:
+                dset = f[channels[0]]
+                if dset.chunks is None:
+                    warnings.warn(
+                        "File {} contains datasets that were generated "
+                        "without using chunked storage. This can have "
+                        "severe performance impacts at data loading time. "
+                        "If you need faster loading, try re-generating "
+                        "your datset with chunked storage turned on.".format(
+                            fname
+                        ),
+                        category=ContiguousHdf5Warning,
+                    )
+
+                self.sizes[fname] = len(dset)
+        total = sum(self.sizes.values())
+        self.probs = np.array([i / total for i in self.sizes.values()])
+
+    def __len__(self) -> int:
+        return self.batches_per_epoch
+
+    def sample_fnames(self, size) -> np.ndarray:
+        return np.random.choice(
+            self.fnames,
+            p=self.probs,
+            size=size,
+            replace=True,
+        )
+
+    def sample_batch(self) -> WaveformTensor:
+        """
+        Sample a single batch of multichannel timeseries
+        """
+
+        # allocate memory up front
+        x = np.zeros((self.batch_size, len(self.channels), self.kernel_size))
+
+        # sample filenames, but only loop through each unique
+        # filename once to avoid unnecessary I/O overhead
+        if self.coincident is not False:
+            size = (self.batch_size,)
+        else:
+            size = (self.batch_size, self.num_channels)
+        fnames = self.sample_fnames(size)
+
+        unique_fnames, inv, counts = np.unique(
+            fnames, return_inverse=True, return_counts=True
+        )
+        for i, (fname, count) in enumerate(zip(unique_fnames, counts)):
+            size = self.sizes[fname]
+            max_idx = size - self.kernel_size
+
+            # figure out which batch indices should be
+            # sampled from the current filename
+            indices = np.where(inv == i)[0]
+
+            # when sampling coincidentally either fully
+            # or at the file level, all channels will
+            # correspond to the same file
+            if self.coincident is not False:
+                batch_indices = np.repeat(indices, self.num_channels)
+                channel_indices = np.arange(self.num_channels)
+                channel_indices = np.concatenate([channel_indices] * count)
+            else:
+                batch_indices = indices // self.num_channels
+                channel_indices = indices % self.num_channels
+
+            # if we're sampling fully coincidentally, each
+            # channel will be the same in each file
+            if self.coincident is True:
+                idx = np.random.randint(max_idx, size=count)
+                idx = np.repeat(idx, self.num_channels)
+            else:
+                # otherwise, every channel will be different
+                # for the given file
+                idx = np.random.randint(max_idx, size=len(batch_indices))
+
+            # open the file and sample a different set of
+            # kernels for each batch element it occupies
+            with h5py.File(fname, "r") as f:
+                for b, c, i in zip(batch_indices, channel_indices, idx):
+                    x[b, c] = f[self.channels[c]][i : i + self.kernel_size]
+        return torch.Tensor(x)
+
+    def __iter__(self) -> torch.Tensor:
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:
+            num_batches = self.batches_per_epoch
+        else:
+            num_batches, remainder = divmod(
+                self.batches_per_epoch, worker_info.num_workers
+            )
+            if worker_info.id < remainder:
+                num_batches += 1
+
+        for _ in range(num_batches):
+            yield self.sample_batch()

--- a/tests/dataloading/test_chunked_dataset.py
+++ b/tests/dataloading/test_chunked_dataset.py
@@ -1,130 +1,35 @@
-import h5py
-import numpy as np
+import random
+
 import pytest
 import torch
 
-from ml4gw.dataloading.chunked_dataset import ChunkedDataset, ChunkLoader
+from ml4gw.dataloading import ChunkedTimeSeriesDataset
 
 
-@pytest.fixture
-def channels():
-    return ["A", "B"]
-
-
-@pytest.fixture
-def sample_rate():
-    return 128
-
-
-@pytest.fixture
-def fnames(channels, sample_rate, tmp_path):
-    data_dir = tmp_path / "data"
-    data_dir.mkdir(exist_ok=True)
-
-    fnames = {"a.h5": 10, "b.h5": 4, "c.h5": 6}
-    idx = 0
-    for fname, length in fnames.items():
-        with h5py.File(fname, "w") as f:
-            size = int(length * sample_rate)
-            x = np.arange(idx, idx + size)
-            f[channels[0]] = x
-            f[channels[1]] = -x
-            idx += size
-    return fnames
-
-
-class TestChunkLoader:
+class TestChunkedTimeseriesDataset:
     @pytest.fixture
     def chunk_length(self):
         return 2
-
-    @pytest.fixture
-    def reads_per_chunk(self):
-        return 4
 
     @pytest.fixture
     def chunks_per_epoch(self):
         return 6
 
     @pytest.fixture
-    def loader(
-        self,
-        fnames,
-        channels,
-        sample_rate,
-        chunk_length,
-        reads_per_chunk,
-        chunks_per_epoch,
-    ):
-        return ChunkLoader(
-            sorted(fnames.keys()),
-            channels,
-            int(chunk_length * sample_rate),
-            reads_per_chunk,
-            chunks_per_epoch,
-        )
+    def chunk_it(self, chunk_length, chunks_per_epoch):
+        def it():
+            for i in range(chunks_per_epoch):
+                chunk = []
+                for _ in range(6):
+                    start = random.randint(0, 128 * 8)
+                    stop = start + 128 * chunk_length
+                    row = torch.arange(start, stop)
+                    row = torch.stack([row, -row])
+                    chunk.append(row)
+                chunk = torch.stack(chunk)
+                yield chunk
 
-    def test_init(self, loader):
-        assert loader.coincident
-        expected_probs = np.array([0.5, 0.2, 0.3])
-        np.testing.assert_equal(expected_probs, loader.probs)
-
-    def test_sample_fnames(self, loader):
-        fnames = loader.sample_fnames()
-        assert len(fnames) == 4
-
-        # really weak check: let's at least confirm
-        # that we sample the 10s segment  more than
-        # we sample the 4s segment.
-        counts = {fname: 0 for fname in loader.fnames}
-        for i in range(10):
-            fnames = loader.sample_fnames()
-            for fname in fnames:
-                counts[fname] += 1
-        assert counts["a.h5"] > counts["b.h5"]
-
-    def test_load_coincident(self, loader, sample_rate):
-        x = loader.load_coincident()
-        assert x.shape == (4, 2, 2 * sample_rate)
-
-        for sample in x:
-            np.testing.assert_equal(sample[0], -sample[1])
-            np.testing.assert_equal(np.diff(sample[0]), 1)
-
-    def test_load_noncoincident(self, loader, sample_rate):
-        x = loader.load_noncoincident()
-        assert x.shape == (4, 2, 2 * sample_rate)
-
-        for sample in x:
-            assert (sample[0] != -sample[1]).any()
-            np.testing.assert_equal(np.diff(sample[0]), 1)
-
-    def test_iter(self, loader, sample_rate):
-        for i, x in enumerate(loader):
-            assert x.shape == (4, 2, 2 * sample_rate)
-
-            for sample in x:
-                torch.testing.assert_close(
-                    sample[0], -sample[1], rtol=0, atol=0
-                )
-                diffs = torch.diff(sample[0])
-                expected = torch.ones_like(diffs)
-                torch.testing.assert_close(diffs, expected, rtol=0, atol=0)
-        assert i == 5
-
-
-class TestChunkedDataset:
-    @pytest.fixture
-    def chunk_length(self):
-        return 2
-
-    @pytest.fixture
-    def reads_per_chunk(self):
-        return 4
-
-    @pytest.fixture
-    def chunks_per_epoch(self):
-        return 6
+        return it
 
     @pytest.fixture
     def kernel_length(self):
@@ -138,10 +43,6 @@ class TestChunkedDataset:
     def batches_per_chunk(self):
         return 7
 
-    @pytest.fixture(params=[0, 3])
-    def num_workers(self, request):
-        return request.param
-
     @pytest.fixture(params=[True, False])
     def coincident(self, request):
         return request.param
@@ -149,38 +50,20 @@ class TestChunkedDataset:
     @pytest.fixture
     def dataset(
         self,
-        fnames,
-        channels,
+        chunk_it,
         kernel_length,
-        sample_rate,
         batch_size,
-        chunk_length,
-        reads_per_chunk,
         batches_per_chunk,
-        chunks_per_epoch,
-        num_workers,
         coincident,
     ):
-        return ChunkedDataset(
-            sorted(fnames),
-            channels,
-            kernel_length=kernel_length,
-            sample_rate=sample_rate,
+        return ChunkedTimeSeriesDataset(
+            chunk_it(),
+            int(kernel_length * 128),
             batch_size=batch_size,
-            reads_per_chunk=reads_per_chunk,
-            chunk_length=chunk_length,
             batches_per_chunk=batches_per_chunk,
-            chunks_per_epoch=chunks_per_epoch,
-            num_workers=num_workers,
             coincident=coincident,
-            pin_memory=False,
+            device="cpu",
         )
-
-    def test_init(self, dataset, num_workers):
-        assert dataset.chunk_size == 256
-        assert dataset.kernel_size == 192
-        if num_workers:
-            assert dataset.chunk_loader.dataset.reads_per_chunk == 1
 
     def test_iter(self, dataset, coincident):
         for i, x in enumerate(dataset):

--- a/tests/dataloading/test_hdf5_dataset.py
+++ b/tests/dataloading/test_hdf5_dataset.py
@@ -1,0 +1,169 @@
+import h5py
+import numpy as np
+import pytest
+
+from ml4gw.dataloading import Hdf5TimeSeriesDataset
+
+
+class TestHdf5TimeSeriesDataset:
+    @pytest.fixture
+    def channels(self):
+        return ["A", "B"]
+
+    @pytest.fixture
+    def sample_rate(self):
+        return 128
+
+    @pytest.fixture
+    def kernel_size(self, sample_rate):
+        return 2 * sample_rate
+
+    @pytest.fixture
+    def batch_size(self):
+        return 128
+
+    @pytest.fixture
+    def batches_per_epoch(self):
+        return 10
+
+    @pytest.fixture
+    def fnames(self, channels, sample_rate, tmp_path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(exist_ok=True)
+
+        fnames = {"a.h5": 10, "b.h5": 4, "c.h5": 6}
+        idx = 0
+        keys = sorted(fnames)
+        for fname in keys:
+            length = fnames[fname]
+            with h5py.File(fname, "w") as f:
+                size = int(length * sample_rate)
+                x = np.arange(idx, idx + size)
+                f[channels[0]] = x
+                f[channels[1]] = -x
+                idx += size
+        return fnames
+
+    @pytest.fixture(params=[True, False, "files"])
+    def coincident(self, request):
+        return request.param
+
+    @pytest.fixture
+    def dataset(
+        self,
+        fnames,
+        channels,
+        kernel_size,
+        batch_size,
+        batches_per_epoch,
+        coincident,
+    ):
+        return Hdf5TimeSeriesDataset(
+            sorted(fnames.keys()),
+            channels,
+            kernel_size,
+            batch_size,
+            batches_per_epoch,
+            coincident=coincident,
+        )
+
+    def test_coincident_arg_value(
+        self,
+        fnames,
+        channels,
+        kernel_size,
+        batch_size,
+        batches_per_epoch,
+    ):
+        with pytest.raises(ValueError):
+            Hdf5TimeSeriesDataset(
+                sorted(fnames.keys()),
+                channels,
+                kernel_size,
+                batch_size,
+                batches_per_epoch,
+                coincident="wrong",
+            )
+
+    def test_init(self, dataset):
+        assert dataset.num_channels == 2
+        assert len(dataset) == 10
+        expected_probs = np.array([0.5, 0.2, 0.3])
+        np.testing.assert_equal(expected_probs, dataset.probs)
+
+    def test_sample_fnames(self, dataset):
+        fnames = dataset.sample_fnames(size=(10,))
+        assert len(fnames) == 10
+
+        # really weak check: let's at least confirm
+        # that we sample the 10s segment  more than
+        # we sample the 4s segment.
+        counts = {fname: 0 for fname in dataset.fnames}
+        for _ in range(10):
+            fnames = dataset.sample_fnames((10,))
+            for fname in fnames:
+                counts[fname] += 1
+        assert counts["a.h5"] > counts["b.h5"]
+
+    def test_sample_batch(self, dataset, kernel_size, coincident):
+        x = dataset.sample_batch()
+        assert x.shape == (128, 2, kernel_size)
+
+        if coincident is True:
+            # coincidence check is simple: they should all match
+            for sample in x:
+                assert (sample[0] == -sample[1]).all().item()
+                assert (np.diff(sample[0].numpy()) == 1).all()
+        else:
+            # for non-coincident loading, do some checks around
+            # which file each sampled channel corresponds to
+            def get_bin(i):
+                if i < (128 * 10):
+                    return 0
+                if i >= (128 * 14):
+                    return 2
+                return 1
+
+            all_equal = True
+            for sample in x:
+                # check the files each channel came from
+                bin0 = get_bin(sample[0, 0])
+                bin1 = get_bin(-sample[1, 0])
+
+                if bin0 != bin1:
+                    # if they're not equal, we know that at
+                    # least one batch element came out with
+                    # non-coincident samples, which is good
+                    # enough for us
+                    all_equal = False
+
+                    # if we're being fully non-coincident, then
+                    # just the fact that we have any samples
+                    # from different files means the check is done
+                    if coincident is False:
+                        break
+
+                    # if we're sampling independently from within
+                    # a given file, this is incorrect
+                    raise ValueError(f"Got bins {bin0} and {bin1}")
+                else:
+                    # if the channels are from the same file,
+                    # still check whether they come from the
+                    # same part of the same file
+                    all_equal &= (sample[0] == -sample[1]).all().item()
+            else:
+                # only get here if the loop never broke, which is only
+                # a problem when we're sampling fully non-coincidentally
+                if self.coincident is False:
+                    raise ValueError("All channels came from same file")
+
+            # if all channels came out the same, something went wrong
+            if all_equal:
+                raise ValueError("Sampling was coincident")
+
+    def test_iter(self, dataset, kernel_size):
+        # test_sample_batch covered most our checks, so here
+        # we'll just make sure that we respect the dataset lengths
+        for i, x in enumerate(dataset):
+            assert x.shape == (128, 2, kernel_size)
+        assert i == 9


### PR DESCRIPTION
* reformulating things to build batch-level dataloader

* adding tests for hdf5 loader

* fixing chunked dataloader tests

* overriding __iter__s directly

* getting rid of print statement

* fixing typing for 3.8 support

* using custom warning class and fixing typo in error message