### PR TITLE
shifted pearson correlation

### DIFF
--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -1,3 +1,4 @@
+from .pearson import ShiftedPearsonCorrelation
 from .scaler import ChannelWiseScaler
 from .snr_rescaler import SnrRescaler
 from .spectral import SpectralDensity

--- a/ml4gw/transforms/pearson.py
+++ b/ml4gw/transforms/pearson.py
@@ -1,0 +1,87 @@
+import torch
+
+from ml4gw.utils.slicing import unfold_windows
+
+
+class ShiftedPearsonCorrelation(torch.nn.Module):
+    """
+    Compute the [Pearson correlation]
+    (https://en.wikipedia.org/wiki/Pearson_correlation_coefficient)
+    for two equal-length timeseries over a pre-defined number of time
+    shifts in each direction. Useful for when you want a
+    correlation, but not over every possible shift (i.e.
+    a convolution).
+
+    The number of dimensions of the second timeseries `y`
+    passed at call time should always be less than or equal
+    to the number of dimensions of the first timeseries `x`,
+    and each dimension should match the corresponding one of
+    `x` in  reverse order (i.e. if `x` has shape `(B, C, T)`
+    then `y` should either have shape `(T,)`, `(C, T)`, or
+    `(B, C, T)`).
+
+    Note that no windowing to either timeseries is applied
+    at call time. Users should do any requisite windowing
+    beforehand.
+
+    TODOs:
+    - Should we perform windowing?
+    - Should we support stride > 1?
+
+    Args:
+        max_shift:
+            The maximum number of 1-step time shifts in
+            each direction over which to compute the
+            Pearson coefficient. Output shape will then
+            be `(2 * max_shifts + 1, B, C)`.
+    """
+
+    def __init__(self, max_shift: int) -> None:
+        super().__init__()
+        self.max_shift = max_shift
+
+    def _shape_checks(self, x: torch.Tensor, y: torch.Tensor):
+        if x.ndim > 3:
+            raise ValueError(
+                "Tensor x can only have up to 3 dimensions "
+                f"to compute ShiftedPearsonCorrelation. Found {x.ndim}."
+            )
+        elif y.ndim > x.ndim:
+            raise ValueError(
+                "y may not have more dimensions that x for "
+                "ShiftedPearsonCorrelation, but found shapes "
+                "{} and {}".format(y.shape, x.shape)
+            )
+        for dim in range(y.ndim):
+            if y.size(-dim - 1) != x.size(-dim - 1):
+                raise ValueError(
+                    "x and y expected to have same size along "
+                    "last dimensions, but found shapes {} and {}".format(
+                        x.shape, y.shape
+                    )
+                )
+
+    # TODO: torchtyping annotate
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        self._shape_checks(x, y)
+        dim = x.size(-1)
+
+        # pad x along time dimension so that it has shape
+        # batch x channels x (time + 2 * max_shift)
+        pad = (self.max_shift, self.max_shift)
+        x = torch.nn.functional.pad(x, pad)
+
+        # num_windows x batch x channels x time
+        x = unfold_windows(x, dim, 1)
+
+        # now compute the correlation between each window
+        # of x and the single window of y. Start by de-meaning
+        x = x - x.mean(-1, keepdims=True)
+        y = y - y.mean(-1, keepdims=True)
+
+        # apply formula and sum along time dimension to give final shape
+        # num_windows x batch x channels
+        corr = (x * y).sum(axis=-1)
+        norm = (x**2).sum(-1) * (y**2).sum(-1)
+
+        return corr / norm**0.5

--- a/tests/transforms/test_pearson.py
+++ b/tests/transforms/test_pearson.py
@@ -1,0 +1,81 @@
+import pytest
+import torch
+
+from ml4gw.transforms import ShiftedPearsonCorrelation
+
+
+class TestShiftedPearsonCorrelation:
+    @pytest.fixture
+    def max_shift(self):
+        return 5
+
+    @pytest.fixture
+    def transform(self, max_shift):
+        return ShiftedPearsonCorrelation(max_shift)
+
+    def check_in_range(self, corr):
+        in_range = (-1 <= corr) & (corr <= 1)
+        assert in_range.all().item()
+
+    def test_x_ndim_3(self, transform, max_shift):
+        expected_shape = (2 * max_shift + 1, 4, 2)
+
+        x = torch.randn(2, 2048)
+
+        # set up a y which is just a shifted
+        # version of x at each batch index
+        y = torch.zeros((4, 2, 2048))
+        for i in range(4):
+            j = i - 2
+            if j < 0:
+                y[i, :, -j:] = x[:, :j]
+            elif j > 0:
+                y[i, :, :-j] = x[:, j:]
+            else:
+                y[i] = x
+
+        # make all batch elements of x the same
+        x = x.view(1, 2, -1).repeat(4, 1, 1)
+        corr = transform(x, y)
+
+        # first check that we have the expected shape
+        assert corr.shape == expected_shape
+
+        # check that all our values are in the expected range
+        self.check_in_range(corr)
+
+        # check that we get our maximum matches
+        # at the expected indices
+        idx = corr[:, :, 0].argmax(dim=0)
+        expected_shifts = torch.arange(4) + max_shift - 2
+        assert torch.equal(idx, expected_shifts)
+
+        # and that those matches are nearly 1
+        maxs = corr[idx, torch.arange(4), 0]
+        expected_max = torch.ones(4)
+        assert torch.allclose(maxs, expected_max, rtol=0.01)
+
+        # do similar checks for 2dim y
+        corr = transform(x, y[0])
+        assert corr.shape == expected_shape
+        self.check_in_range(corr)
+
+        idx = corr[:, :, 0].argmax(dim=0)
+        expected_shifts = torch.ones(4) * (max_shift - 2)
+        assert torch.equal(idx, expected_shifts)
+
+        maxs = corr[max_shift - 2, :, 0]
+        assert torch.allclose(maxs, expected_max, rtol=0.01)
+
+        # and finally for 1dim y. We've only been checking
+        # against y's first channel, so this will just
+        # look exactly like the last one.
+        corr = transform(x, y[0, 0])
+        assert corr.shape == expected_shape
+        self.check_in_range(corr)
+
+        idx = corr[:, :, 0].argmax(dim=0)
+        assert torch.equal(idx, expected_shifts)
+
+        maxs = corr[max_shift - 2, :, 0]
+        assert torch.allclose(maxs, expected_max, rtol=0.01)


### PR DESCRIPTION
Adding an implementation of the Pearson correlation we've had floating around for a while now. Tests are pretty basic but it works for now. Nice to haves, but maybe not strictly required for getting this merged, are:
- [ ] Needs testing for when the first input is 2 or 1 dimensional
- [ ] See TODOs in class doc string: possible support for strides and windowing 