### PR TITLE
Initial chi-squared veto implementation

### DIFF
--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -291,7 +291,7 @@ def snr_from_freqs(
     psd: Optional[PSDTensor] = None,
     strain: Optional[PSDTensor] = None,
     highpass: Union[float, TensorType["frequency"], None] = None,
-    scale: float = 1e20
+    scale: float = 1e20,
 ) -> PSDTensor:
     """
     Returns SNR as a function of frequency
@@ -406,7 +406,7 @@ def compute_ifo_snr(
     """
 
     integrand = snr_integral(responses, sample_rate, psd, highpass=highpass)
-    return integrand.sum(-1)**0.5
+    return integrand.sum(-1) ** 0.5
 
 
 def compute_network_snr(

--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -1,3 +1,4 @@
+from .chisq import ChiSq
 from .scaler import ChannelWiseScaler
 from .snr_rescaler import SnrRescaler
 from .spectral import SpectralDensity

--- a/ml4gw/transforms/chisq.py
+++ b/ml4gw/transforms/chisq.py
@@ -13,7 +13,7 @@ class ChiSq(torch.nn.Module):
         sample_rate: float,
         highpass: Optional[float] = None,
         return_snr: bool = False,
-        input_domain: Literal["time", "frequncy"] = "time"
+        input_domain: Literal["time", "frequncy"] = "time",
     ) -> None:
         super().__init__()
         self.sample_rate = sample_rate
@@ -108,7 +108,7 @@ class ChiSq(torch.nn.Module):
     def interpolate_psd(self, psd):
         # have to scale the interpolated psd to ensure
         # that the integral of the power remains constant
-        factor = (psd.size(-1) / self.num_freqs)**2
+        factor = (psd.size(-1) / self.num_freqs) ** 2
         psd = torch.nn.functional.interpolate(
             psd, size=self.num_freqs, mode="linear"
         )
@@ -135,10 +135,10 @@ class ChiSq(torch.nn.Module):
             )
 
     def forward(
-        self, 
+        self,
         template: torch.Tensor,
         strain: torch.Tensor,
-        psd: Optional[torch.Tensor] = None
+        psd: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Make PSD optional in case strain has already been whitened
@@ -160,12 +160,14 @@ class ChiSq(torch.nn.Module):
             stilde = stilde[:, :, self.mask]
 
         qtilde, edges = self.partition_frequencies(htilde, psd)
-        snr_per_bin, total_snr = self.get_snr_per_bin(qtilde, stilde, edges, psd)
+        snr_per_bin, total_snr = self.get_snr_per_bin(
+            qtilde, stilde, edges, psd
+        )
 
         # for each frequency bin, compute the square of the
         # deviation from the expected amount of SNR in the bin
         # and then sum it over all the bins
-        chisq_summand = (snr_per_bin - total_snr / self.num_bins)**2
+        chisq_summand = (snr_per_bin - total_snr / self.num_bins) ** 2
         chisq = chisq_summand.sum(dim=-1)
 
         # normalize by number of degrees of freedom
@@ -173,4 +175,3 @@ class ChiSq(torch.nn.Module):
         if self.return_snr:
             return chisq, total_snr
         return chisq
-        

--- a/ml4gw/transforms/chisq.py
+++ b/ml4gw/transforms/chisq.py
@@ -90,16 +90,16 @@ class ChiSq(torch.nn.Module):
         """
         # compute the cumulative SNR of our template
         # wrt the background PSD as a function of frequency
-        snr_integral = self.get_cumulative_snr(htilde, psd)
+        cumulative_snr = self.get_cumulative_snr(htilde, psd)
 
         # break the total SNR up into even bins
-        total_snr = snr_integral[:, :, -1:]
+        total_snr = cumulative_snr[:, :, -1:]
         bins = self.bins * total_snr
 
         # figure out which indices along the frequency axis
         # break up the SNR as closely into these bins as possible
-        edges = torch.searchsorted(snr_integral, bins, side="right")
-        edges = edges.clamp(0, snr_integral.size(-1) - 1)
+        edges = torch.searchsorted(cumulative_snr, bins, side="right")
+        edges = edges.clamp(0, cumulative_snr.size(-1) - 1)
 
         # normalize by the sqrt of the total SNR
         qtilde = htilde / total_snr**0.5

--- a/ml4gw/transforms/chisq.py
+++ b/ml4gw/transforms/chisq.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional
 
 import torch
 
-from ml4gw.gw import snr_from_freqs
+from ml4gw.gw import snr_frequency_series
 
 
 class ChiSq(torch.nn.Module):
@@ -37,7 +37,12 @@ class ChiSq(torch.nn.Module):
         self.input_domain = input_domain
 
     def get_cumulative_snr(self, htilde, psd=None, stilde=None):
-        snr = snr_from_freqs(htilde, self.sample_rate, psd, stilde)
+        """
+        Compute the cumulative integral of the SNR frequency
+        series along the frequency dimension.
+        """
+
+        snr = snr_frequency_series(htilde, self.sample_rate, psd, stilde)
         return snr.cumsum(dim=-1)
 
     def make_indices(self, batch_size, num_channels):

--- a/ml4gw/transforms/chisq.py
+++ b/ml4gw/transforms/chisq.py
@@ -1,0 +1,176 @@
+from typing import Literal, Optional
+
+import torch
+
+from ml4gw.gw import snr_from_freqs
+
+
+class ChiSq(torch.nn.Module):
+    def __init__(
+        self,
+        num_bins: int,
+        fftlength: float,
+        sample_rate: float,
+        highpass: Optional[float] = None,
+        return_snr: bool = False,
+        input_domain: Literal["time", "frequncy"] = "time"
+    ) -> None:
+        super().__init__()
+        self.sample_rate = sample_rate
+
+        # include extra bin so that we have all left and right edges
+        self.num_bins = num_bins
+        bins = torch.arange(num_bins + 1) / num_bins
+        self.register_buffer("bins", bins)
+
+        self.fftsize = int(fftlength * sample_rate)
+        self.num_freqs = int(fftlength * sample_rate // 2 + 1)
+        freqs = torch.arange(self.num_freqs) / fftlength
+        self.register_buffer("freqs", freqs)
+
+        if highpass is not None:
+            mask = freqs >= highpass
+            self.register_buffer("mask", mask)
+        else:
+            self.mask = None
+        self.return_snr = return_snr
+        self.input_domain = input_domain
+
+    def get_cumulative_snr(self, htilde, psd=None, stilde=None):
+        snr = snr_from_freqs(htilde, self.sample_rate, psd, stilde)
+        return snr.cumsum(dim=-1)
+
+    def make_indices(self, batch_size, num_channels):
+        """
+        Helper function for selecting arbitrary indices
+        along the last axis of our batches by building
+        tensors of repeated index selectors for the
+        batch and channel axes.
+        """
+        idx0 = torch.arange(batch_size)
+        idx0 = idx0.view(-1, 1, 1).repeat(1, num_channels, self.num_bins)
+
+        idx1 = torch.arange(num_channels)
+        idx1 = idx1.view(1, -1, 1).repeat(batch_size, 1, self.num_bins)
+        return idx0, idx1
+
+    def get_snr_per_bin(self, qtilde, stilde, edges, psd=None):
+        """
+        For a normalized frequency template qtilde and
+        frequency-domain strain measurement stilde, measure
+        the SNR in the bins between the specified edges
+        (whose last dimension should be one greater than the
+        number of bins).
+        """
+
+        # calculate how much SNR _actually_ ended up in each bin
+        cumulative_snr = self.get_cumulative_snr(qtilde, psd, stilde)
+
+        # since we have the cumulative SNR, all we need to
+        # do is grab the value at the left and right bin
+        # edges and then subtract them to get the sum
+        # in between them
+        batch_size, num_channels, _ = cumulative_snr.shape
+        idx0, idx1 = self.make_indices(batch_size, num_channels)
+
+        right = cumulative_snr[idx0, idx1, edges[:, :, 1:]]
+        left = cumulative_snr[idx0, idx1, edges[:, :, :-1]]
+
+        # need the actual total SNR to see how much
+        # we deviated from the expected breakdown
+        total_snr = cumulative_snr[:, :, -1:]
+        return right - left, total_snr
+
+    def partition_frequencies(self, htilde, psd=None):
+        """
+        Compute the edges of the frequency bins that would
+        (roughly) evenly break up the optimal SNR of the
+        template. Normalize the template by its maximum
+        SNR as illustrated in TODO: cite
+        """
+        # compute the cumulative SNR of our template
+        # wrt the background PSD as a function of frequency
+        snr_integral = self.get_cumulative_snr(htilde, psd)
+
+        # break the total SNR up into even bins
+        total_snr = snr_integral[:, :, -1:]
+        bins = self.bins * total_snr
+
+        # figure out which indices along the frequency axis
+        # break up the SNR as closely into these bins as possible
+        edges = torch.searchsorted(snr_integral, bins, side="right")
+        edges = edges.clamp(0, snr_integral.size(-1) - 1)
+
+        # normalize by the sqrt of the total SNR
+        qtilde = htilde / total_snr**0.5
+        return qtilde, edges
+
+    def interpolate_psd(self, psd):
+        # have to scale the interpolated psd to ensure
+        # that the integral of the power remains constant
+        factor = (psd.size(-1) / self.num_freqs)**2
+        psd = torch.nn.functional.interpolate(
+            psd, size=self.num_freqs, mode="linear"
+        )
+        return psd * factor
+
+    def _check_time_domain(self, template, strain):
+        bad_tensors, bad_shapes = [], []
+        if template.size(-1) != self.fftsize:
+            bad_tensors.append("template")
+            bad_shapes.append(template.shape)
+        if strain.size(-1) != self.fftsize:
+            bad_tensors.append("strain")
+            bad_shapes.append(strain.shape)
+
+        if bad_tensors:
+            verb = "has" if len(bad_tensors) == 1 else "have"
+            bad_tensors = " and ".join(bad_tensors)
+            raise ValueError(
+                "Both template and strain timeseries are "
+                "expected to have time dimension of size {}, "
+                "but {} {} shape(s) {}".format(
+                    self.fftsize, bad_tensors, verb, ",".join(bad_shapes)
+                )
+            )
+
+    def forward(
+        self, 
+        template: torch.Tensor,
+        strain: torch.Tensor,
+        psd: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """
+        Make PSD optional in case strain has already been whitened
+        """
+        if psd is not None:
+            if psd.size(-1) != self.num_freqs:
+                psd = self.interpolate_psd(psd)
+            if self.mask is not None:
+                psd = psd[:, :, self.mask]
+
+        if self.input_domain == "time":
+            self._check_time_domain(template, strain)
+            htilde = torch.fft.rfft(template, dim=-1) / self.sample_rate
+            stilde = torch.fft.rfft(strain, dim=-1) / self.sample_rate
+        else:
+            htilde, stilde = template, strain
+        if self.mask is not None:
+            htilde = htilde[:, :, self.mask]
+            stilde = stilde[:, :, self.mask]
+
+        qtilde, edges = self.partition_frequencies(htilde, psd)
+        snr_per_bin, total_snr = self.get_snr_per_bin(qtilde, stilde, edges, psd)
+
+        # for each frequency bin, compute the square of the
+        # deviation from the expected amount of SNR in the bin
+        # and then sum it over all the bins
+        chisq_summand = (snr_per_bin - total_snr / self.num_bins)**2
+        chisq = chisq_summand.sum(dim=-1)
+
+        # normalize by number of degrees of freedom
+        chisq *= self.num_bins / (self.num_bins - 1)
+        if self.return_snr:
+            return chisq, total_snr
+        return chisq
+        

--- a/tests/transforms/test_chisq.py
+++ b/tests/transforms/test_chisq.py
@@ -1,0 +1,29 @@
+import torch
+
+from ml4gw.transforms import ChiSq, SpectralDensity
+
+
+def test_chisq():
+    scale = 10**(-19)
+    background = scale * torch.randn(4, 2, 2048 * 32)
+    strain = scale * torch.randn(4, 2, 2048 * 4)
+
+    t = torch.arange(2048 * 4) / 2048
+    freq = 10 + t**3
+    amp = scale * (0.1 + t**3/64)
+    signal = amp * torch.sin(2 * torch.pi * freq * t)
+    signal = signal.view(1, 1, -1).repeat(4, 2, 1)
+    injected = strain + signal
+
+    spec = SpectralDensity(
+        sample_rate=2048,
+        fftlength=4,
+        overlap=2,
+        average="median"
+    )
+    psd = spec(background)
+
+    transform = ChiSq(num_bins=8, fftlength=4, sample_rate=2048, highpass=10)
+    chisq = transform(signal, injected, psd)
+    print(chisq)
+    raise ValueError

--- a/tests/transforms/test_chisq.py
+++ b/tests/transforms/test_chisq.py
@@ -4,22 +4,19 @@ from ml4gw.transforms import ChiSq, SpectralDensity
 
 
 def test_chisq():
-    scale = 10**(-19)
+    scale = 10 ** (-19)
     background = scale * torch.randn(4, 2, 2048 * 32)
     strain = scale * torch.randn(4, 2, 2048 * 4)
 
     t = torch.arange(2048 * 4) / 2048
     freq = 10 + t**3
-    amp = scale * (0.1 + t**3/64)
+    amp = scale * (0.1 + t**3 / 64)
     signal = amp * torch.sin(2 * torch.pi * freq * t)
     signal = signal.view(1, 1, -1).repeat(4, 2, 1)
     injected = strain + signal
 
     spec = SpectralDensity(
-        sample_rate=2048,
-        fftlength=4,
-        overlap=2,
-        average="median"
+        sample_rate=2048, fftlength=4, overlap=2, average="median"
     )
     psd = spec(background)
 


### PR DESCRIPTION
Generalizes some of the SNR calculation code to make this feasible and plays around with some scaling on this front. Think the transform itself is still missing some normalization constants here and there because the values are coming out enormous, but the general idea seems to work.

This metric should be close to 1 if the observed data contains the signal plus some gaussian noise, so the idea with testing is to construct such a signal/observation combination and test that the values come out as expected, but still not fully resolved how best to do this.

- [ ] Figure out normalization in the transform class
- [ ] Get rid of debugging print statements once things are solved
- [ ] Figure out how best to handle scaling in the SNR calculations, see all the TODOs in `gw.py`
