### PR TITLE
handle corner case of eta=0.25 giving nan in phenom_d

### DIFF
--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -477,6 +477,7 @@ def rho3_fun(eta, eta2, xi):
 
 def FinalSpin0815(eta, eta2, chi1, chi2):
     Seta = torch.sqrt(1.0 - 4.0 * eta)
+    Seta = torch.nan_to_num(Seta)  # avoid nan around eta = 0.25
     m1 = 0.5 * (1.0 + Seta)
     m2 = 0.5 * (1.0 - Seta)
     m1s = m1 * m1


### PR DESCRIPTION
For context
```
>>> torch.sqrt(torch.tensor([0, -1e-30]))
tensor([0., nan])
```

The expression that is leading to corner cases like this sometimes is
```
Seta = torch.sqrt(1.0 - 4.0 * eta)
```
around eta = 0.25, in which case the answer is Seta=0