### PR TITLE
loosely re-implement distributions using torch.distributions

### DIFF
--- a/ml4gw/distributions.py
+++ b/ml4gw/distributions.py
@@ -103,17 +103,22 @@ class LogNormal:
         return x
 
 
-class LogUniform(Uniform):
+class LogUniform(dist.TransformedDistribution):
     """
     Sample from a log uniform distribution
     """
 
-    def __init__(self, low: float, high: float) -> None:
-        super().__init__(math.log(low), math.log(high))
-
-    def __call__(self, N: int) -> torch.Tensor:
-        u = super().__call__(N)
-        return torch.exp(u)
+    def __init__(self, low: float, high: float, validate_args=None):
+        base_dist = dist.Uniform(
+            torch.as_tensor(low).log(),
+            torch.as_tensor(high).log(),
+            validate_args,
+        )
+        super().__init__(
+            base_dist,
+            [dist.ExpTransform()],
+            validate_args=validate_args,
+        )
 
 
 class PowerLaw(dist.TransformedDistribution):

--- a/ml4gw/distributions.py
+++ b/ml4gw/distributions.py
@@ -6,6 +6,7 @@ from the corresponding distribution.
 """
 
 import math
+from typing import Optional
 
 import torch
 import torch.distributions as dist
@@ -80,6 +81,22 @@ class LogUniform(dist.TransformedDistribution):
             [dist.ExpTransform()],
             validate_args=validate_args,
         )
+
+
+class LogNormal(dist.LogNormal):
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        low: Optional[float] = None,
+        validate_args=None,
+    ):
+        self.low = low
+        super().__init__(loc=mean, scale=std, validate_args=validate_args)
+
+    def support(self):
+        if self.low is not None:
+            return dist.constraints.greater_than(self.low)
 
 
 class PowerLaw(dist.TransformedDistribution):

--- a/ml4gw/distributions.py
+++ b/ml4gw/distributions.py
@@ -191,16 +191,20 @@ class PowerLawDistribution(dist.TransformedDistribution):
         if index == 0:
             raise RuntimeError("Index of 0 is the same as Uniform")
         elif index == -1:
-            raise RuntimeError("Supply index less that -1 or greater than 0")
-        index_plus = index + 1
-        base_min = minimum**index_plus / index_plus
-        base_max = maximum**index_plus / index_plus
+            base_min = torch.as_tensor(minimum).log()
+            base_max = torch.as_tensor(maximum).log()
+            transforms = [dist.ExpTransform()]
+        else:
+            index_plus = index + 1
+            base_min = minimum**index_plus / index_plus
+            base_max = maximum**index_plus / index_plus
+            transforms = [
+                dist.AffineTransform(loc=0, scale=index_plus),
+                dist.PowerTransform(1 / index_plus),
+            ]
         base_dist = dist.Uniform(base_min, base_max, validate_args=False)
         super().__init__(
             base_dist,
-            [
-                dist.AffineTransform(loc=0, scale=index_plus),
-                dist.PowerTransform(1 / index_plus),
-            ],
+            transforms,
             validate_args=validate_args,
         )

--- a/ml4gw/distributions.py
+++ b/ml4gw/distributions.py
@@ -6,23 +6,9 @@ from the corresponding distribution.
 """
 
 import math
-from typing import Optional
 
 import torch
 import torch.distributions as dist
-
-
-class Uniform:
-    """
-    Sample uniformly between `low` and `high`.
-    """
-
-    def __init__(self, low: float = 0, high: float = 1) -> None:
-        self.low = low
-        self.high = high
-
-    def __call__(self, N: int) -> torch.Tensor:
-        return self.low + torch.rand(size=(N,)) * (self.high - self.low)
 
 
 class Cosine(dist.Distribution):
@@ -76,31 +62,6 @@ class Sine(dist.TransformedDistribution):
             ],
             validate_args=validate_args,
         )
-
-
-class LogNormal:
-    """
-    Sample from a log normal distribution with the
-    specified `mean` and standard deviation `std`.
-    If a `low` value is specified, values sampled
-    lower than this will be clipped to `low`.
-    """
-
-    def __init__(
-        self, mean: float, std: float, low: Optional[float] = None
-    ) -> None:
-        self.sigma = math.log((std / mean) ** 2 + 1) ** 0.5
-        self.mu = 2 * math.log(mean / (mean**2 + std**2) ** 0.25)
-        self.low = low
-
-    def __call__(self, N: int) -> torch.Tensor:
-
-        u = self.mu + torch.randn(N) * self.sigma
-        x = torch.exp(u)
-
-        if self.low is not None:
-            x = torch.clip(x, self.low)
-        return x
 
 
 class LogUniform(dist.TransformedDistribution):

--- a/ml4gw/waveforms/generator.py
+++ b/ml4gw/waveforms/generator.py
@@ -12,7 +12,7 @@ class ParameterSampler(torch.nn.Module):
         self,
         N: int,
     ):
-        return {k: v(N) for k, v in self.parameters.items()}
+        return {k: v.sample((N,)) for k, v in self.parameters.items()}
 
 
 class WaveformGenerator(torch.nn.Module):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -11,28 +11,6 @@ from ml4gw import distributions
 # distribution has the expected shape?
 
 
-def test_uniform():
-    sampler = distributions.Uniform()
-
-    samples = sampler(10)
-    assert len(samples) == 10
-    assert ((0 <= samples) & (samples <= 1)).all()
-
-    sampler = distributions.Uniform(-3, 5)
-    samples = sampler(100)
-    assert len(samples) == 100
-    assert ((-3 <= samples) & (samples <= 5)).all()
-
-    # check that the mean is roughly correct
-    # (within three standard deviations)
-    samples = sampler(100000)
-    mean = samples.mean().item()
-    variance = 64 / 12
-    sample_variance = variance / 10000
-    sample_std = sample_variance**0.5
-    assert abs(mean - 1) < (3 * sample_std)
-
-
 def test_log_uniform():
     sampler = distributions.LogUniform(math.e, math.e**2)
     samples = sampler.sample((10,))
@@ -61,25 +39,6 @@ def test_cosine():
     samples = sampler.sample((100,))
     assert len(samples) == 100
     assert ((-3 <= samples) & (samples <= 5)).all()
-
-
-def test_log_normal():
-    sampler = distributions.LogNormal(6, 4)
-    samples = sampler(10)
-    assert len(samples) == 10
-    assert (0 < samples).all()
-
-    sampler = distributions.LogNormal(6, 4, 3)
-    samples = sampler(100)
-    assert len(samples) == 100
-    assert (3 <= samples).all()
-
-    # check that mean is roughly correct
-    # (within 2 standard deviations)
-    sampler = distributions.LogNormal(10, 2)
-    samples = sampler(10000)
-    mean = samples.mean().item()
-    assert (abs(mean - 10) / 10) < (3 * 2 / 10000**0.5)
 
 
 def test_power_law():

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -132,4 +132,16 @@ def test_power_law_distribution():
 
     popt, _ = optimize.curve_fit(foo, bins, counts, (20, 3))
     # popt[1] is the index
-    assert popt[1] == pytest.approx(2, rel=1e-1)
+    assert popt[1] == pytest.approx(2, rel=5e-2)
+
+    # test 1/x distribution
+    inverse_in_distance = distributions.PowerLawDistribution(
+        min_dist, max_dist, index=-1
+    )
+    samples = inverse_in_distance.sample((10000,)).numpy()
+    counts, ebins = np.histogram(samples, bins=100)
+    bins = ebins[1:] + ebins[:-1]
+    bins *= 0.5
+    popt, _ = optimize.curve_fit(foo, bins, counts, (20, 3))
+    # popt[1] is the index
+    assert popt[1] == pytest.approx(-1, rel=5e-2)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -53,24 +53,12 @@ def test_log_uniform():
 
 def test_cosine():
     sampler = distributions.Cosine()
-    samples = sampler(10)
-    assert len(samples) == 10
-    assert ((-pi / 2 <= samples) & (samples <= pi / 2)).all()
-
-    sampler = distributions.Cosine(-3, 5)
-    samples = sampler(100)
-    assert len(samples) == 100
-    assert ((-3 <= samples) & (samples <= 5)).all()
-
-
-def test_cosine_distribution():
-    sampler = distributions.CosineDistribution()
     samples = sampler.sample((10,))
     assert len(samples) == 10
     assert ((-pi / 2 <= samples) & (samples <= pi / 2)).all()
 
-    sampler = distributions.CosineDistribution(-3, 5)
-    samples = sampler.sample(100)
+    sampler = distributions.Cosine(-3, 5)
+    samples = sampler.sample((100,))
     assert len(samples) == 100
     assert ((-3 <= samples) & (samples <= 5)).all()
 
@@ -95,53 +83,41 @@ def test_log_normal():
 
 
 def test_power_law():
-    """Test PowerLaw distribution against expected distribution of SNRs"""
+    """Test PowerLaw distribution"""
     ref_snr = 8
-    sampler = distributions.PowerLaw(
-        x_min=ref_snr, x_max=float("inf"), alpha=4
-    )
-    samples = sampler(10000).numpy()
+    sampler = distributions.PowerLaw(ref_snr, float("inf"), index=-4)
+    samples = sampler.sample((10000,)).numpy()
     # check x^-4 behavior
     counts, ebins = np.histogram(samples, bins=100)
     bins = ebins[1:] + ebins[:-1]
     bins *= 0.5
 
     def foo(x, a, b):
-        return a * x ** (-b)
+        return a * x**b
 
     popt, _ = optimize.curve_fit(foo, bins, counts, (20, 3))
     # popt[1] is the index
-    assert popt[1] == pytest.approx(4, rel=1e-1)
+    assert popt[1] == pytest.approx(-4, rel=1e-1)
 
-
-def test_power_law_distribution():
-    """Test PowerLawDistribution against expected distribution of SNRs"""
     min_dist = 10
     max_dist = 1000
-    uniform_in_volume = distributions.PowerLawDistribution(
-        min_dist, max_dist, index=2
-    )
+    uniform_in_volume = distributions.PowerLaw(min_dist, max_dist, index=2)
     samples = uniform_in_volume.sample((10000,)).numpy()
     # check d^2 behavior
     counts, ebins = np.histogram(samples, bins=100)
     bins = ebins[1:] + ebins[:-1]
     bins *= 0.5
 
-    def foo(x, a, b):
-        return a * x ** (b)
-
     popt, _ = optimize.curve_fit(foo, bins, counts, (20, 3))
     # popt[1] is the index
-    assert popt[1] == pytest.approx(2, rel=5e-2)
+    assert popt[1] == pytest.approx(2, rel=1e-1)
 
     # test 1/x distribution
-    inverse_in_distance = distributions.PowerLawDistribution(
-        min_dist, max_dist, index=-1
-    )
+    inverse_in_distance = distributions.PowerLaw(min_dist, max_dist, index=-1)
     samples = inverse_in_distance.sample((10000,)).numpy()
     counts, ebins = np.histogram(samples, bins=100)
     bins = ebins[1:] + ebins[:-1]
     bins *= 0.5
     popt, _ = optimize.curve_fit(foo, bins, counts, (20, 3))
     # popt[1] is the index
-    assert popt[1] == pytest.approx(-1, rel=5e-2)
+    assert popt[1] == pytest.approx(-1, rel=1e-1)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -35,13 +35,13 @@ def test_uniform():
 
 def test_log_uniform():
     sampler = distributions.LogUniform(math.e, math.e**2)
-    samples = sampler(10)
+    samples = sampler.sample((10,))
     assert len(samples) == 10
     assert ((math.e <= samples) & (math.e**2 <= 100)).all()
 
     # check that the mean is roughly correct
     # (within three standard deviations)
-    samples = sampler(100000)
+    samples = sampler.sample((100000,))
     log_samples = np.log(samples)
 
     mean = log_samples.mean().item()

--- a/tests/waveforms/test_generator.py
+++ b/tests/waveforms/test_generator.py
@@ -24,12 +24,14 @@ def sample_rate(request):
 
 def test_parameter_sampler(n_samples):
     parameter_sampler = ParameterSampler(
-        phi=distributions.Uniform(0, 2 * pi),
+        phi=torch.distributions.Uniform(0, 2 * pi),
         dec=distributions.Cosine(),
         snr=distributions.LogNormal(6, 4, 3),
     )
 
-    samples = parameter_sampler(n_samples)
+    samples = parameter_sampler(
+        n_samples,
+    )
 
     for k in ["phi", "dec", "snr"]:
         assert len(samples[k]) == n_samples
@@ -52,9 +54,9 @@ def test_waveform_generator(sample_rate, duration, n_samples):
         return waveforms
 
     parameter_sampler = ParameterSampler(
-        amplitude=distributions.Uniform(0, 1),
-        frequency=distributions.Uniform(0, 1),
-        phase=distributions.Uniform(0, 2 * pi),
+        amplitude=torch.distributions.Uniform(0, 1),
+        frequency=torch.distributions.Uniform(0, 1),
+        phase=torch.distributions.Uniform(0, 2 * pi),
     )
 
     generator = WaveformGenerator(waveform, parameter_sampler)


### PR DESCRIPTION
I was thinking of having a loose implementation of the bilby priors using torch tools, to directly sample from priors on the GPU. One intermediary step is to take advantage of the torch distributions and transforms. 

Several of the distributions like `Uniform` and `LogUniform` do not need to be separately implemented in `ml4gw` since they already exist in `torch.distributions`. I did not remove it here yet (since libs downstream may still be using it), but can do so if we agree. The others like PowerLaw, Sine, and Cosine is re-implemented as a Distribution or a Transformed-distribution.