### PR TITLE
fix prefactor_four_thirds in inspiral amplitude

### DIFF
--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -955,9 +955,7 @@ def phenom_d_mrd_phase(Mf, eta, eta2, chi1, chi2, xi):
     mrd_phasing += (4.0 / 3.0) * (Mf.t() ** (3.0 / 4.0) * alpha3).t()
     mrd_phasing += (torch.atan(f_minus_alpha5_fRD.t() / fDM) * alpha4).t()
 
-    mrd_Dphasing = (
-        alpha4 * fDM / (f_minus_alpha5_fRD.t() ** 2 + fDM**2)
-    ).t()
+    mrd_Dphasing = (alpha4 * fDM / (f_minus_alpha5_fRD.t() ** 2 + fDM**2)).t()
     mrd_Dphasing += (Mf.t() ** (-1.0 / 4.0) * alpha3).t()
     mrd_Dphasing += (Mf.t() ** (-2.0) * alpha2).t()
     mrd_Dphasing = (mrd_Dphasing.t() + alpha1).t()
@@ -1065,8 +1063,9 @@ def phenom_d_inspiral_amp(Mf, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22):
                 + 857304 * chi22
             )
             * eta
-            + 35371056 * eta2 * PI ** (4.0 / 3.0)
+            + 35371056 * eta2
         )
+        * PI ** (4.0 / 3.0)
     ) / 8.128512e6
     prefactors_five_thirds = (
         PI ** (5.0 / 3.0)


### PR DESCRIPTION
The prefactor four_thirds variable has a `35371056 * eta2 * PI ** (4.0 / 3.0)` towards the bottom, whereas it should be `35371056 * eta2 )* PI ** (4.0 / 3.0)` according to LAL.

Please refer line 330 of https://lscsoft.docs.ligo.org/lalsuite/lalsimulation/_l_a_l_sim_i_m_r_phenom_d__internals_8c_source.html

This did not impact the waveform drastically, and I found all tests to be passing with roughly the same tolerance, so I've left the tests unchanged.