### PR TITLE
Refactor waveforms + IMRPhenomPv2

### DIFF
--- a/ml4gw/constants.py
+++ b/ml4gw/constants.py
@@ -26,6 +26,9 @@ gt = G * MSUN / (C**3.0)
 G MSUN / C^3 in seconds
 """
 
+MTSUN_SI = 4.925490947641266978197229498498379006e-6
+"""1 solar mass in seconds. Same value as lal.MTSUN_SI"""
+
 m_per_Mpc = 3.085677581491367278913937957796471611e22
 """
 Meters per Mpc.

--- a/ml4gw/constants.py
+++ b/ml4gw/constants.py
@@ -1,0 +1,42 @@
+"""
+Various constants, all in SI units.
+"""
+
+EulerGamma = 0.577215664901532860606512090082402431
+
+MSUN = 1.988409902147041637325262574352366540e30  # kg
+"""Solar mass"""
+
+MRSUN = 1.476625038050124729627979840144936351e3
+"""Geometrized nominal solar mass, m"""
+
+G = 6.67430e-11  # m^3 / kg / s^2
+"""Newton's gravitational constant"""
+
+C = 299792458.0  # m / s
+"""Speed of light"""
+
+"""Pi"""
+PI = 3.141592653589793238462643383279502884
+
+TWO_PI = 6.283185307179586476925286766559005768
+
+gt = G * MSUN / (C**3.0)
+"""
+G MSUN / C^3 in seconds
+"""
+
+m_per_Mpc = 3.085677581491367278913937957796471611e22
+"""
+Meters per Mpc.
+"""
+
+MPC_SEC = m_per_Mpc / C
+"""
+1 Mpc in seconds.
+"""
+
+clightGpc = C / 3.0856778570831e22
+"""
+Speed of light in vacuum (:math:`c`), in gigaparsecs per second
+"""

--- a/ml4gw/waveforms/__init__.py
+++ b/ml4gw/waveforms/__init__.py
@@ -1,3 +1,4 @@
 from .phenom_d import IMRPhenomD
 from .sine_gaussian import SineGaussian
 from .taylorf2 import TaylorF2
+from .phenom_p import IMRPhenomPv2

--- a/ml4gw/waveforms/__init__.py
+++ b/ml4gw/waveforms/__init__.py
@@ -1,4 +1,4 @@
 from .phenom_d import IMRPhenomD
+from .phenom_p import IMRPhenomPv2
 from .sine_gaussian import SineGaussian
 from .taylorf2 import TaylorF2
-from .phenom_p import IMRPhenomPv2

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -1,1303 +1,127 @@
 import torch
+from .taylorf2 import TaylorF2
 from torchtyping import TensorType
+from ..constants import MTSUN_SI, PI
+from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
 
-from . import phenom_d_data
-from .taylorf2 import MTSUN_SI, PI, taylorf2_amplitude, taylorf2_phase
 
+class IMRPhenomD(TaylorF2):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("QNMData_a", QNMData_a)
+        self.register_buffer("QNMData_fdamp", QNMData_fdamp)
+        self.register_buffer("QNMData_fring", QNMData_fring)
 
-# Utility functions taken from PhenomD utilities in lalsimulation
-# https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimIMRPhenomD_internals.c
-def sigma1Fit(eta, eta2, xi):
-    return (
-        2096.551999295543
-        + 1463.7493168261553 * eta
-        + (
-            1312.5493286098522
-            + 18307.330017082117 * eta
-            - 43534.1440746107 * eta2
-            + (
-                -833.2889543511114
-                + 32047.31997183187 * eta
-                - 108609.45037520859 * eta2
-            )
-            * xi
-            + (
-                452.25136398112204
-                + 8353.439546391714 * eta
-                - 44531.3250037322 * eta2
-            )
-            * xi
-            * xi
+    def forward(
+        self,
+        f: TensorType,
+        chirp_mass: TensorType,
+        mass_ratio: TensorType,
+        chi1: TensorType,
+        chi2: TensorType,
+        distance: TensorType,
+        phic: TensorType,
+        inclination: TensorType,
+        f_ref: float,
+    ):
+        """
+        IMRPhenomD waveform
+
+        Returns:
+        --------
+        hp, hc
+        """
+        # shape assumed (n_batch, params)
+        if (
+            chirp_mass.shape[0] != mass_ratio.shape[0]
+            or mass_ratio.shape[0] != chi1.shape[0]
+            or chi1.shape[0] != chi2.shape[0]
+            or chi2.shape[0] != distance.shape[0]
+            or distance.shape[0] != phic.shape[0]
+            or phic.shape[0] != inclination.shape[0]
+        ):
+            raise RuntimeError("Tensors should have same batch size")
+        cfac = torch.cos(inclination)
+        pfac = 0.5 * (1.0 + cfac * cfac)
+
+        htilde = self.phenom_d_htilde(
+            f, chirp_mass, mass_ratio, chi1, chi2, distance, phic, f_ref
         )
-        * xi
-    )
 
+        hp = (htilde.mT * pfac).mT
+        hc = -1j * (htilde.mT * cfac).mT
 
-def sigma2Fit(eta, eta2, xi):
-    return (
-        -10114.056472621156
-        - 44631.01109458185 * eta
-        + (
-            -6541.308761668722
-            - 266959.23419307504 * eta
-            + 686328.3229317984 * eta2
-            + (
-                3405.6372187679685
-                - 437507.7208209015 * eta
-                + 1.6318171307344697e6 * eta2
-            )
-            * xi
-            + (
-                -7462.648563007646
-                - 114585.25177153319 * eta
-                + 674402.4689098676 * eta2
-            )
-            * xi
-            * xi
+        return hp, hc
+
+    def phenom_d_htilde(
+        self,
+        f: TensorType,
+        chirp_mass: TensorType,
+        mass_ratio: TensorType,
+        chi1: TensorType,
+        chi2: TensorType,
+        distance: TensorType,
+        phic: TensorType,
+        f_ref: float,
+    ):
+        total_mass = chirp_mass * (1 + mass_ratio) ** 1.2 / mass_ratio**0.6
+        mass_1 = total_mass / (1 + mass_ratio)
+        mass_2 = mass_1 * mass_ratio
+        eta = (chirp_mass / total_mass) ** (5 / 3)
+        eta2 = eta * eta
+        Seta = torch.sqrt(1.0 - 4.0 * eta)
+        chi = self.chiPN(Seta, eta, chi1, chi2)
+        chi22 = chi2 * chi2
+        chi12 = chi1 * chi1
+        xi = -1.0 + chi
+        M_s = total_mass * MTSUN_SI
+
+        gamma2 = self.gamma2_fun(eta, eta2, xi)
+        gamma3 = self.gamma3_fun(eta, eta2, xi)
+
+        fRD, fDM = self.fring_fdamp(eta, eta2, chi1, chi2)
+        Mf_peak = self.fmaxCalc(fRD, fDM, gamma2, gamma3)
+        _, t0 = self.phenom_d_mrd_phase(Mf_peak, eta, eta2, chi1, chi2, xi)
+
+        Mf = torch.outer(M_s, f)
+        Mf_ref = torch.outer(M_s, f_ref * torch.ones_like(f))
+
+        Psi, _ = self.phenom_d_phase(
+            Mf, mass_1, mass_2, eta, eta2, chi1, chi2, xi
         )
-        * xi
-    )
-
-
-def sigma3Fit(eta, eta2, xi):
-    return (
-        22933.658273436497
-        + 230960.00814979506 * eta
-        + (
-            14961.083974183695
-            + 1.1940181342318142e6 * eta
-            - 3.1042239693052764e6 * eta2
-            + (
-                -3038.166617199259
-                + 1.8720322849093592e6 * eta
-                - 7.309145012085539e6 * eta2
-            )
-            * xi
-            + (
-                42738.22871475411
-                + 467502.018616601 * eta
-                - 3.064853498512499e6 * eta2
-            )
-            * xi
-            * xi
+        Psi_ref, _ = self.phenom_d_phase(
+            Mf_ref, mass_1, mass_2, eta, eta2, chi1, chi2, xi
         )
-        * xi
-    )
 
+        Psi = (Psi.T - 2 * phic).mT
+        Psi -= Psi_ref
+        Psi -= ((Mf - Mf_ref).mT * t0).mT
 
-def sigma4Fit(eta, eta2, xi):
-    return (
-        -14621.71522218357
-        - 377812.8579387104 * eta
-        + (
-            -9608.682631509726
-            - 1.7108925257214056e6 * eta
-            + 4.332924601416521e6 * eta2
-            + (
-                -22366.683262266528
-                - 2.5019716386377467e6 * eta
-                + 1.0274495902259542e7 * eta2
-            )
-            * xi
-            + (
-                -85360.30079034246
-                - 570025.3441737515 * eta
-                + 4.396844346849777e6 * eta2
-            )
-            * xi
-            * xi
+        amp, _ = self.phenom_d_amp(
+            Mf,
+            mass_1,
+            mass_2,
+            eta,
+            eta2,
+            Seta,
+            chi1,
+            chi2,
+            chi12,
+            chi22,
+            xi,
+            distance,
         )
-        * xi
-    )
 
+        amp_0 = self.taylorf2_amplitude(
+            Mf, mass_1, mass_2, eta, distance
+        )  # this includes f^(-7/6) dependence
 
-def gamma1_fun(eta, eta2, xi):
-    return (
-        0.006927402739328343
-        + 0.03020474290328911 * eta
-        + (
-            0.006308024337706171
-            - 0.12074130661131138 * eta
-            + 0.26271598905781324 * eta2
-            + (
-                0.0034151773647198794
-                - 0.10779338611188374 * eta
-                + 0.27098966966891747 * eta2
-            )
-            * xi
-            + (
-                0.0007374185938559283
-                - 0.02749621038376281 * eta
-                + 0.0733150789135702 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
+        h0 = -amp_0 * amp * torch.exp(-1j * Psi)
 
+        return h0
 
-def gamma2_fun(eta, eta2, xi):
-    return (
-        1.010344404799477
-        + 0.0008993122007234548 * eta
-        + (
-            0.283949116804459
-            - 4.049752962958005 * eta
-            + 13.207828172665366 * eta2
-            + (
-                0.10396278486805426
-                - 7.025059158961947 * eta
-                + 24.784892370130475 * eta2
-            )
-            * xi
-            + (
-                0.03093202475605892
-                - 2.6924023896851663 * eta
-                + 9.609374464684983 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def gamma3_fun(eta, eta2, xi):
-    return (
-        1.3081615607036106
-        - 0.005537729694807678 * eta
-        + (
-            -0.06782917938621007
-            - 0.6689834970767117 * eta
-            + 3.403147966134083 * eta2
-            + (
-                -0.05296577374411866
-                - 0.9923793203111362 * eta
-                + 4.820681208409587 * eta2
-            )
-            * xi
-            + (
-                -0.006134139870393713
-                - 0.38429253308696365 * eta
-                + 1.7561754421985984 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def beta1Fit(eta, eta2, xi):
-    return (
-        97.89747327985583
-        - 42.659730877489224 * eta
-        + (
-            153.48421037904913
-            - 1417.0620760768954 * eta
-            + 2752.8614143665027 * eta2
-            + (
-                138.7406469558649
-                - 1433.6585075135881 * eta
-                + 2857.7418952430758 * eta2
-            )
-            * xi
-            + (
-                41.025109467376126
-                - 423.680737974639 * eta
-                + 850.3594335657173 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def beta2Fit(eta, eta2, xi):
-    return (
-        -3.282701958759534
-        - 9.051384468245866 * eta
-        + (
-            -12.415449742258042
-            + 55.4716447709787 * eta
-            - 106.05109938966335 * eta2
-            + (
-                -11.953044553690658
-                + 76.80704618365418 * eta
-                - 155.33172948098394 * eta2
-            )
-            * xi
-            + (
-                -3.4129261592393263
-                + 25.572377569952536 * eta
-                - 54.408036707740465 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def beta3Fit(eta, eta2, xi):
-    return (
-        -0.000025156429818799565
-        + 0.000019750256942201327 * eta
-        + (
-            -0.000018370671469295915
-            + 0.000021886317041311973 * eta
-            + 0.00008250240316860033 * eta2
-            + (
-                7.157371250566708e-6
-                - 0.000055780000112270685 * eta
-                + 0.00019142082884072178 * eta2
-            )
-            * xi
-            + (
-                5.447166261464217e-6
-                - 0.00003220610095021982 * eta
-                + 0.00007974016714984341 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def alpha1Fit(eta, eta2, xi):
-    return (
-        43.31514709695348
-        + 638.6332679188081 * eta
-        + (
-            -32.85768747216059
-            + 2415.8938269370315 * eta
-            - 5766.875169379177 * eta2
-            + (
-                -61.85459307173841
-                + 2953.967762459948 * eta
-                - 8986.29057591497 * eta2
-            )
-            * xi
-            + (
-                -21.571435779762044
-                + 981.2158224673428 * eta
-                - 3239.5664895930286 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def alpha2Fit(eta, eta2, xi):
-    return (
-        -0.07020209449091723
-        - 0.16269798450687084 * eta
-        + (
-            -0.1872514685185499
-            + 1.138313650449945 * eta
-            - 2.8334196304430046 * eta2
-            + (
-                -0.17137955686840617
-                + 1.7197549338119527 * eta
-                - 4.539717148261272 * eta2
-            )
-            * xi
-            + (
-                -0.049983437357548705
-                + 0.6062072055948309 * eta
-                - 1.682769616644546 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def alpha3Fit(eta, eta2, xi):
-    return (
-        9.5988072383479
-        - 397.05438595557433 * eta
-        + (
-            16.202126189517813
-            - 1574.8286986717037 * eta
-            + 3600.3410843831093 * eta2
-            + (
-                27.092429659075467
-                - 1786.482357315139 * eta
-                + 5152.919378666511 * eta2
-            )
-            * xi
-            + (
-                11.175710130033895
-                - 577.7999423177481 * eta
-                + 1808.730762932043 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def alpha4Fit(eta, eta2, xi):
-    return (
-        -0.02989487384493607
-        + 1.4022106448583738 * eta
-        + (
-            -0.07356049468633846
-            + 0.8337006542278661 * eta
-            + 0.2240008282397391 * eta2
-            + (
-                -0.055202870001177226
-                + 0.5667186343606578 * eta
-                + 0.7186931973380503 * eta2
-            )
-            * xi
-            + (
-                -0.015507437354325743
-                + 0.15750322779277187 * eta
-                + 0.21076815715176228 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def alpha5Fit(eta, eta2, xi):
-    return (
-        0.9974408278363099
-        - 0.007884449714907203 * eta
-        + (
-            -0.059046901195591035
-            + 1.3958712396764088 * eta
-            - 4.516631601676276 * eta2
-            + (
-                -0.05585343136869692
-                + 1.7516580039343603 * eta
-                - 5.990208965347804 * eta2
-            )
-            * xi
-            + (
-                -0.017945336522161195
-                + 0.5965097794825992 * eta
-                - 2.0608879367971804 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def rho1_fun(eta, eta2, xi):
-    return (
-        3931.8979897196696
-        - 17395.758706812805 * eta
-        + (
-            3132.375545898835
-            + 343965.86092361377 * eta
-            - 1.2162565819981997e6 * eta2
-            + (
-                -70698.00600428853
-                + 1.383907177859705e6 * eta
-                - 3.9662761890979446e6 * eta2
-            )
-            * xi
-            + (
-                -60017.52423652596
-                + 803515.1181825735 * eta
-                - 2.091710365941658e6 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def rho2_fun(eta, eta2, xi):
-    return (
-        -40105.47653771657
-        + 112253.0169706701 * eta
-        + (
-            23561.696065836168
-            - 3.476180699403351e6 * eta
-            + 1.137593670849482e7 * eta2
-            + (
-                754313.1127166454
-                - 1.308476044625268e7 * eta
-                + 3.6444584853928134e7 * eta2
-            )
-            * xi
-            + (
-                596226.612472288
-                - 7.4277901143564405e6 * eta
-                + 1.8928977514040343e7 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def rho3_fun(eta, eta2, xi):
-    return (
-        83208.35471266537
-        - 191237.7264145924 * eta
-        + (
-            -210916.2454782992
-            + 8.71797508352568e6 * eta
-            - 2.6914942420669552e7 * eta2
-            + (
-                -1.9889806527362722e6
-                + 3.0888029960154563e7 * eta
-                - 8.390870279256162e7 * eta2
-            )
-            * xi
-            + (
-                -1.4535031953446497e6
-                + 1.7063528990822166e7 * eta
-                - 4.2748659731120914e7 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def FinalSpin0815(eta, eta2, chi1, chi2):
-    Seta = torch.sqrt(1.0 - 4.0 * eta)
-    Seta = torch.nan_to_num(Seta)  # avoid nan around eta = 0.25
-    m1 = 0.5 * (1.0 + Seta)
-    m2 = 0.5 * (1.0 - Seta)
-    m1s = m1 * m1
-    m2s = m2 * m2
-    s = m1s * chi1 + m2s * chi2
-    eta3 = eta2 * eta
-    s2 = s * s
-    s3 = s2 * s
-    return eta * (
-        3.4641016151377544
-        - 4.399247300629289 * eta
-        + 9.397292189321194 * eta2
-        - 13.180949901606242 * eta3
-        + (
-            (1.0 / eta - 0.0850917821418767 - 5.837029316602263 * eta)
-            + (0.1014665242971878 - 2.0967746996832157 * eta) * s
-            + (-1.3546806617824356 + 4.108962025369336 * eta) * s2
-            + (-0.8676969352555539 + 2.064046835273906 * eta) * s3
-        )
-        * s
-    )
-
-
-def PhenomInternal_EradRational0815(eta, eta2, chi1, chi2):
-    Seta = torch.sqrt(1.0 - 4.0 * eta)
-    m1 = 0.5 * (1.0 + Seta)
-    m2 = 0.5 * (1.0 - Seta)
-    m1s = m1 * m1
-    m2s = m2 * m2
-    s = (m1s * chi1 + m2s * chi2) / (m1s + m2s)
-
-    eta3 = eta2 * eta
-
-    return (
-        eta
-        * (
-            0.055974469826360077
-            + 0.5809510763115132 * eta
-            - 0.9606726679372312 * eta2
-            + 3.352411249771192 * eta3
-        )
-        * (
-            1.0
-            + (
-                -0.0030302335878845507
-                - 2.0066110851351073 * eta
-                + 7.7050567802399215 * eta2
-            )
-            * s
-        )
-    ) / (
-        1.0
-        + (
-            -0.6714403054720589
-            - 1.4756929437702908 * eta
-            + 7.304676214885011 * eta2
-        )
-        * s
-    )
-
-
-def AmpIntColFitCoeff(eta, eta2, xi):
-    return (
-        0.8149838730507785
-        + 2.5747553517454658 * eta
-        + (
-            1.1610198035496786
-            - 2.3627771785551537 * eta
-            + 6.771038707057573 * eta2
-            + (
-                0.7570782938606834
-                - 2.7256896890432474 * eta
-                + 7.1140380397149965 * eta2
-            )
-            * xi
-            + (
-                0.1766934149293479
-                - 0.7978690983168183 * eta
-                + 2.1162391502005153 * eta2
-            )
-            * xi
-            * xi
-        )
-        * xi
-    )
-
-
-def delta_values(f1, f2, f3, v1, v2, v3, d1, d2):
-    f12 = f1 * f1
-    f13 = f1 * f12
-    f14 = f1 * f13
-    f15 = f1 * f14
-    f22 = f2 * f2
-    f23 = f2 * f22
-    f24 = f2 * f23
-    f32 = f3 * f3
-    f33 = f3 * f32
-    f34 = f3 * f33
-    f35 = f3 * f34
-    delta_0 = -(
-        (
-            d2 * f15 * f22 * f3
-            - 2 * d2 * f14 * f23 * f3
-            + d2 * f13 * f24 * f3
-            - d2 * f15 * f2 * f32
-            + d2 * f14 * f22 * f32
-            - d1 * f13 * f23 * f32
-            + d2 * f13 * f23 * f32
-            + d1 * f12 * f24 * f32
-            - d2 * f12 * f24 * f32
-            + d2 * f14 * f2 * f33
-            + 2 * d1 * f13 * f22 * f33
-            - 2 * d2 * f13 * f22 * f33
-            - d1 * f12 * f23 * f33
-            + d2 * f12 * f23 * f33
-            - d1 * f1 * f24 * f33
-            - d1 * f13 * f2 * f34
-            - d1 * f12 * f22 * f34
-            + 2 * d1 * f1 * f23 * f34
-            + d1 * f12 * f2 * f35
-            - d1 * f1 * f22 * f35
-            + 4 * f12 * f23 * f32 * v1
-            - 3 * f1 * f24 * f32 * v1
-            - 8 * f12 * f22 * f33 * v1
-            + 4 * f1 * f23 * f33 * v1
-            + f24 * f33 * v1
-            + 4 * f12 * f2 * f34 * v1
-            + f1 * f22 * f34 * v1
-            - 2 * f23 * f34 * v1
-            - 2 * f1 * f2 * f35 * v1
-            + f22 * f35 * v1
-            - f15 * f32 * v2
-            + 3 * f14 * f33 * v2
-            - 3 * f13 * f34 * v2
-            + f12 * f35 * v2
-            - f15 * f22 * v3
-            + 2 * f14 * f23 * v3
-            - f13 * f24 * v3
-            + 2 * f15 * f2 * f3 * v3
-            - f14 * f22 * f3 * v3
-            - 4 * f13 * f23 * f3 * v3
-            + 3 * f12 * f24 * f3 * v3
-            - 4 * f14 * f2 * f32 * v3
-            + 8 * f13 * f22 * f32 * v3
-            - 4 * f12 * f23 * f32 * v3
-        )
-        / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (f3 - f2) ** 2)
-    )
-
-    delta_1 = -(
-        (
-            -(d2 * f15 * f22)
-            + 2 * d2 * f14 * f23
-            - d2 * f13 * f24
-            - d2 * f14 * f22 * f3
-            + 2 * d1 * f13 * f23 * f3
-            + 2 * d2 * f13 * f23 * f3
-            - 2 * d1 * f12 * f24 * f3
-            - d2 * f12 * f24 * f3
-            + d2 * f15 * f32
-            - 3 * d1 * f13 * f22 * f32
-            - d2 * f13 * f22 * f32
-            + 2 * d1 * f12 * f23 * f32
-            - 2 * d2 * f12 * f23 * f32
-            + d1 * f1 * f24 * f32
-            + 2 * d2 * f1 * f24 * f32
-            - d2 * f14 * f33
-            + d1 * f12 * f22 * f33
-            + 3 * d2 * f12 * f22 * f33
-            - 2 * d1 * f1 * f23 * f33
-            - 2 * d2 * f1 * f23 * f33
-            + d1 * f24 * f33
-            + d1 * f13 * f34
-            + d1 * f1 * f22 * f34
-            - 2 * d1 * f23 * f34
-            - d1 * f12 * f35
-            + d1 * f22 * f35
-            - 8 * f12 * f23 * f3 * v1
-            + 6 * f1 * f24 * f3 * v1
-            + 12 * f12 * f22 * f32 * v1
-            - 8 * f1 * f23 * f32 * v1
-            - 4 * f12 * f34 * v1
-            + 2 * f1 * f35 * v1
-            + 2 * f15 * f3 * v2
-            - 4 * f14 * f32 * v2
-            + 4 * f12 * f34 * v2
-            - 2 * f1 * f35 * v2
-            - 2 * f15 * f3 * v3
-            + 8 * f12 * f23 * f3 * v3
-            - 6 * f1 * f24 * f3 * v3
-            + 4 * f14 * f32 * v3
-            - 12 * f12 * f22 * f32 * v3
-            + 8 * f1 * f23 * f32 * v3
-        )
-        / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
-    )
-
-    delta_2 = -(
-        (
-            d2 * f15 * f2
-            - d1 * f13 * f23
-            - 3 * d2 * f13 * f23
-            + d1 * f12 * f24
-            + 2 * d2 * f12 * f24
-            - d2 * f15 * f3
-            + d2 * f14 * f2 * f3
-            - d1 * f12 * f23 * f3
-            + d2 * f12 * f23 * f3
-            + d1 * f1 * f24 * f3
-            - d2 * f1 * f24 * f3
-            - d2 * f14 * f32
-            + 3 * d1 * f13 * f2 * f32
-            + d2 * f13 * f2 * f32
-            - d1 * f1 * f23 * f32
-            + d2 * f1 * f23 * f32
-            - 2 * d1 * f24 * f32
-            - d2 * f24 * f32
-            - 2 * d1 * f13 * f33
-            + 2 * d2 * f13 * f33
-            - d1 * f12 * f2 * f33
-            - 3 * d2 * f12 * f2 * f33
-            + 3 * d1 * f23 * f33
-            + d2 * f23 * f33
-            + d1 * f12 * f34
-            - d1 * f1 * f2 * f34
-            + d1 * f1 * f35
-            - d1 * f2 * f35
-            + 4 * f12 * f23 * v1
-            - 3 * f1 * f24 * v1
-            + 4 * f1 * f23 * f3 * v1
-            - 3 * f24 * f3 * v1
-            - 12 * f12 * f2 * f32 * v1
-            + 4 * f23 * f32 * v1
-            + 8 * f12 * f33 * v1
-            - f1 * f34 * v1
-            - f35 * v1
-            - f15 * v2
-            - f14 * f3 * v2
-            + 8 * f13 * f32 * v2
-            - 8 * f12 * f33 * v2
-            + f1 * f34 * v2
-            + f35 * v2
-            + f15 * v3
-            - 4 * f12 * f23 * v3
-            + 3 * f1 * f24 * v3
-            + f14 * f3 * v3
-            - 4 * f1 * f23 * f3 * v3
-            + 3 * f24 * f3 * v3
-            - 8 * f13 * f32 * v3
-            + 12 * f12 * f2 * f32 * v3
-            - 4 * f23 * f32 * v3
-        )
-        / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
-    )
-
-    delta_3 = -(
-        (
-            -2 * d2 * f14 * f2
-            + d1 * f13 * f22
-            + 3 * d2 * f13 * f22
-            - d1 * f1 * f24
-            - d2 * f1 * f24
-            + 2 * d2 * f14 * f3
-            - 2 * d1 * f13 * f2 * f3
-            - 2 * d2 * f13 * f2 * f3
-            + d1 * f12 * f22 * f3
-            - d2 * f12 * f22 * f3
-            + d1 * f24 * f3
-            + d2 * f24 * f3
-            + d1 * f13 * f32
-            - d2 * f13 * f32
-            - 2 * d1 * f12 * f2 * f32
-            + 2 * d2 * f12 * f2 * f32
-            + d1 * f1 * f22 * f32
-            - d2 * f1 * f22 * f32
-            + d1 * f12 * f33
-            - d2 * f12 * f33
-            + 2 * d1 * f1 * f2 * f33
-            + 2 * d2 * f1 * f2 * f33
-            - 3 * d1 * f22 * f33
-            - d2 * f22 * f33
-            - 2 * d1 * f1 * f34
-            + 2 * d1 * f2 * f34
-            - 4 * f12 * f22 * v1
-            + 2 * f24 * v1
-            + 8 * f12 * f2 * f3 * v1
-            - 4 * f1 * f22 * f3 * v1
-            - 4 * f12 * f32 * v1
-            + 8 * f1 * f2 * f32 * v1
-            - 4 * f22 * f32 * v1
-            - 4 * f1 * f33 * v1
-            + 2 * f34 * v1
-            + 2 * f14 * v2
-            - 4 * f13 * f3 * v2
-            + 4 * f1 * f33 * v2
-            - 2 * f34 * v2
-            - 2 * f14 * v3
-            + 4 * f12 * f22 * v3
-            - 2 * f24 * v3
-            + 4 * f13 * f3 * v3
-            - 8 * f12 * f2 * f3 * v3
-            + 4 * f1 * f22 * f3 * v3
-            + 4 * f12 * f32 * v3
-            - 8 * f1 * f2 * f32 * v3
-            + 4 * f22 * f32 * v3
-        )
-        / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
-    )
-
-    delta_4 = -(
-        (
-            d2 * f13 * f2
-            - d1 * f12 * f22
-            - 2 * d2 * f12 * f22
-            + d1 * f1 * f23
-            + d2 * f1 * f23
-            - d2 * f13 * f3
-            + 2 * d1 * f12 * f2 * f3
-            + d2 * f12 * f2 * f3
-            - d1 * f1 * f22 * f3
-            + d2 * f1 * f22 * f3
-            - d1 * f23 * f3
-            - d2 * f23 * f3
-            - d1 * f12 * f32
-            + d2 * f12 * f32
-            - d1 * f1 * f2 * f32
-            - 2 * d2 * f1 * f2 * f32
-            + 2 * d1 * f22 * f32
-            + d2 * f22 * f32
-            + d1 * f1 * f33
-            - d1 * f2 * f33
-            + 3 * f1 * f22 * v1
-            - 2 * f23 * v1
-            - 6 * f1 * f2 * f3 * v1
-            + 3 * f22 * f3 * v1
-            + 3 * f1 * f32 * v1
-            - f33 * v1
-            - f13 * v2
-            + 3 * f12 * f3 * v2
-            - 3 * f1 * f32 * v2
-            + f33 * v2
-            + f13 * v3
-            - 3 * f1 * f22 * v3
-            + 2 * f23 * v3
-            - 3 * f12 * f3 * v3
-            + 6 * f1 * f2 * f3 * v3
-            - 3 * f22 * f3 * v3
-        )
-        / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
-    )
-
-    return delta_0, delta_1, delta_2, delta_3, delta_4
-
-
-def chiPN(Seta, eta, chi1, chi2):
-    chi_s = chi1 + chi2
-    chi_a = chi1 - chi2
-
-    return 0.5 * (chi_s * (1.0 - eta * 76.0 / 113.0) + Seta * chi_a)
-
-
-def _linear_interp_finspin(finspin):
-    # Put QNM data in same device as input
-    QNMData_a = phenom_d_data.QNMData_a.to(device=finspin.device)
-    QNMData_fdamp = phenom_d_data.QNMData_fdamp.to(device=finspin.device)
-    QNMData_fring = phenom_d_data.QNMData_fring.to(device=finspin.device)
-    # chi is a batch of final spins i.e. torch.Size([n])
-    right_spin_idx = torch.bucketize(finspin, QNMData_a)
-    right_spin_val = QNMData_a[right_spin_idx]
-    # QNMData_a is sorted, hence take the previous index
-    left_spin_idx = right_spin_idx - 1
-    left_spin_val = QNMData_a[left_spin_idx]
-
-    if not torch.all(left_spin_val < right_spin_val):
-        raise RuntimeError(
-            "Left value in grid should be greater than right. "
-            "Maybe be caused for extremal spin values."
-        )
-    left_fring = QNMData_fring[left_spin_idx]
-    right_fring = QNMData_fring[right_spin_idx]
-    slope_fring = right_fring - left_fring
-    slope_fring /= right_spin_val - left_spin_val
-
-    left_fdamp = QNMData_fdamp[left_spin_idx]
-    right_fdamp = QNMData_fdamp[right_spin_idx]
-    slope_fdamp = right_fdamp - left_fdamp
-    slope_fdamp /= right_spin_val - left_spin_val
-
-    return (
-        slope_fring * (finspin - left_spin_val) + left_fring,
-        slope_fdamp * (finspin - left_spin_val) + left_fdamp,
-    )
-
-
-def fmaxCalc(fRD, fDM, gamma2, gamma3):
-    res = torch.zeros_like(gamma2)
-    res = torch.abs(fRD + (-fDM * gamma3) / gamma2) * (gamma2 > 1).to(
-        torch.int
-    ) + torch.abs(
-        fRD + (fDM * (-1 + torch.sqrt(1 - gamma2 * gamma2)) * gamma3) / gamma2
-    ) * (
-        gamma2 <= 1
-    ).to(
-        torch.int
-    )
-    return res
-
-
-def fring_fdamp(eta, eta2, chi1, chi2):
-    finspin = FinalSpin0815(eta, eta2, chi1, chi2)
-    Erad = PhenomInternal_EradRational0815(eta, eta2, chi1, chi2)
-
-    fRD, fDM = _linear_interp_finspin(finspin)
-    fRD /= 1.0 - Erad
-    fDM /= 1.0 - Erad
-
-    return fRD, fDM
-
-
-def phenom_d_inspiral_phase(Mf, mass_1, mass_2, eta, eta2, xi, chi1, chi2):
-    ins_phasing, ins_Dphasing = taylorf2_phase(Mf, mass_1, mass_2, chi1, chi2)
-
-    sigma1 = sigma1Fit(eta, eta2, xi)
-    sigma2 = sigma2Fit(eta, eta2, xi)
-    sigma3 = sigma3Fit(eta, eta2, xi)
-    sigma4 = sigma4Fit(eta, eta2, xi)
-
-    ins_phasing += (Mf.mT * sigma1 / eta).mT
-    ins_phasing += (Mf.mT ** (4.0 / 3.0) * 0.75 * sigma2 / eta).mT
-    ins_phasing += (Mf.mT ** (5.0 / 3.0) * 0.6 * sigma3 / eta).mT
-    ins_phasing += (Mf.mT**2.0 * 0.5 * sigma4 / eta).mT
-
-    ins_Dphasing = (ins_Dphasing.T + sigma1 / eta).mT
-    ins_Dphasing += (Mf.mT ** (1.0 / 3.0) * sigma2 / eta).mT
-    ins_Dphasing += (Mf.mT ** (2.0 / 3.0) * sigma3 / eta).mT
-    ins_Dphasing += (Mf.mT * sigma4 / eta).mT
-
-    return ins_phasing, ins_Dphasing
-
-
-def phenom_d_int_phase(Mf, eta, eta2, xi):
-    beta1 = beta1Fit(eta, eta2, xi)
-    beta2 = beta2Fit(eta, eta2, xi)
-    beta3 = beta3Fit(eta, eta2, xi)
-    # Merger phase
-    # Leading beta0 is not added here
-    # overall 1/eta is not multiplied
-    int_phasing = (Mf.mT * beta1).mT
-    int_phasing += (torch.log(Mf).mT * beta2).mT
-    int_phasing -= (Mf.mT ** (-3.0) / 3.0 * beta3).mT
-
-    # overall 1/eta is multiple in derivative of
-    # intermediate phase
-    int_Dphasing = (Mf.mT ** (-4.0) * beta3).mT
-    int_Dphasing += (Mf.mT ** (-1.0) * beta2).mT
-    int_Dphasing = (int_Dphasing.T + beta1).mT
-    int_Dphasing = (int_Dphasing.T / eta).mT
-    return int_phasing, int_Dphasing
-
-
-def phenom_d_mrd_phase(Mf, eta, eta2, chi1, chi2, xi):
-    alpha1 = alpha1Fit(eta, eta2, xi)
-    alpha2 = alpha2Fit(eta, eta2, xi)
-    alpha3 = alpha3Fit(eta, eta2, xi)
-    alpha4 = alpha4Fit(eta, eta2, xi)
-    alpha5 = alpha5Fit(eta, eta2, xi)
-
-    # merger ringdown
-    fRD, fDM = fring_fdamp(eta, eta2, chi1, chi2)
-    f_minus_alpha5_fRD = (Mf.t() - alpha5 * fRD).t()
-
-    # Leading 1/eta is not multiplied at this stage
-    mrd_phasing = (Mf.t() * alpha1).t()
-    mrd_phasing -= (1 / Mf.t() * alpha2).t()
-    mrd_phasing += (4.0 / 3.0) * (Mf.t() ** (3.0 / 4.0) * alpha3).t()
-    mrd_phasing += (torch.atan(f_minus_alpha5_fRD.t() / fDM) * alpha4).t()
-
-    mrd_Dphasing = (
-        alpha4 * fDM / (f_minus_alpha5_fRD.t() ** 2 + fDM**2)
-    ).t()
-    mrd_Dphasing += (Mf.t() ** (-1.0 / 4.0) * alpha3).t()
-    mrd_Dphasing += (Mf.t() ** (-2.0) * alpha2).t()
-    mrd_Dphasing = (mrd_Dphasing.t() + alpha1).t()
-    mrd_Dphasing = (mrd_Dphasing.t() / eta).t()
-
-    return mrd_phasing, mrd_Dphasing
-
-
-def phenom_d_phase(Mf, mass_1, mass_2, eta, eta2, chi1, chi2, xi):
-    ins_phase, ins_Dphase = phenom_d_inspiral_phase(
-        Mf, mass_1, mass_2, eta, eta2, xi, chi1, chi2
-    )
-    int_phase, int_Dphase = phenom_d_int_phase(Mf, eta, eta2, xi)
-    mrd_phase, mrd_Dphase = phenom_d_mrd_phase(Mf, eta, eta2, chi1, chi2, xi)
-
-    # merger ringdown
-    fRD, fDM = fring_fdamp(eta, eta2, chi1, chi2)
-    # definitions in Eq. (35) of arXiv:1508.07253
-    # PHI_fJoin_INS in header LALSimIMRPhenomD.h
-    # C1 continuity at intermediate region i.e. f_1
-    PHI_fJoin_INS = 0.018 * torch.ones_like(Mf)
-    ins_phase_f1, ins_Dphase_f1 = phenom_d_inspiral_phase(
-        PHI_fJoin_INS, mass_1, mass_2, eta, eta2, xi, chi1, chi2
-    )
-    int_phase_f1, int_Dphase_f1 = phenom_d_int_phase(
-        PHI_fJoin_INS, eta, eta2, xi
-    )
-    C2Int = ins_Dphase_f1 - int_Dphase_f1
-    C1Int = ins_phase_f1 - (int_phase_f1.T / eta).mT - C2Int * PHI_fJoin_INS
-    # C1 continuity at ringdown
-    fRDJoin = (0.5 * torch.ones_like(Mf).mT * fRD).mT
-    int_phase_rd, int_Dphase_rd = phenom_d_int_phase(fRDJoin, eta, eta2, xi)
-    mrd_phase_rd, mrd_Dphase_rd = phenom_d_mrd_phase(
-        fRDJoin, eta, eta2, chi1, chi2, xi
-    )
-    PhiIntTempVal = (int_phase_rd.T / eta).mT + C1Int + C2Int * fRDJoin
-    # C2MRD = int_Dphase_rd - mrd_Dphase_rd
-    C2MRD = C2Int + int_Dphase_rd - mrd_Dphase_rd
-    C1MRD = PhiIntTempVal - (mrd_phase_rd.T / eta).mT - C2MRD * fRDJoin
-
-    int_phase = (int_phase.T / eta).mT
-    int_phase += C1Int
-    int_phase += Mf * C2Int
-
-    mrd_phase = (mrd_phase.T / eta).mT
-    mrd_phase += C1MRD
-    mrd_phase += Mf * C2MRD
-
-    # construct full IMR phase
-    theta_minus_f1 = torch.heaviside(
-        PHI_fJoin_INS - Mf, torch.tensor(0.0, device=Mf.device)
-    )
-    theta_plus_f1 = torch.heaviside(
-        Mf - PHI_fJoin_INS, torch.tensor(1.0, device=Mf.device)
-    )
-    theta_minus_f2 = torch.heaviside(
-        fRDJoin - Mf, torch.tensor(0.0, device=Mf.device)
-    )
-    theta_plus_f2 = torch.heaviside(
-        Mf - fRDJoin, torch.tensor(1.0, device=Mf.device)
-    )
-
-    phasing = theta_minus_f1 * ins_phase
-    phasing += theta_plus_f1 * int_phase * theta_minus_f2
-    phasing += theta_plus_f2 * mrd_phase
-
-    Dphasing = theta_minus_f1 * ins_Dphase
-    Dphasing += theta_plus_f1 * int_Dphase * theta_minus_f2
-    Dphasing += theta_plus_f2 * mrd_Dphase
-
-    return phasing, Dphasing
-
-
-def phenom_d_inspiral_amp(Mf, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22):
-    SetaPlus1 = 1 + Seta
-
-    Mf_one_third = Mf ** (1.0 / 3.0)
-    Mf_two_third = Mf_one_third * Mf_one_third
-    Mf_four_third = Mf_two_third * Mf_two_third
-    Mf_five_third = Mf_four_third * Mf_one_third
-    Mf_seven_third = Mf_five_third * Mf_two_third
-    MF_eight_third = Mf_seven_third * Mf_one_third
-    Mf_two = Mf * Mf
-    Mf_three = Mf_two * Mf
-
-    prefactors_two_thirds = ((-969 + 1804 * eta) * PI ** (2.0 / 3.0)) / 672
-    prefactors_one = (
-        (
-            chi1 * (81 * SetaPlus1 - 44 * eta)
-            + chi2 * (81 - 81 * Seta - 44 * eta)
-        )
-        * PI
-    ) / 48.0
-    prefactors_four_thirds = (
-        (
-            -27312085.0
-            - 10287648 * chi22
-            - 10287648 * chi12 * SetaPlus1
-            + 10287648 * chi22 * Seta
-            + 24
-            * (
-                -1975055
-                + 857304 * chi12
-                - 994896 * chi1 * chi2
-                + 857304 * chi22
-            )
-            * eta
-            + 35371056 * eta2
-        )
-        * PI ** (4.0 / 3.0)
-    ) / 8.128512e6
-    prefactors_five_thirds = (
-        PI ** (5.0 / 3.0)
-        * (
-            chi2
-            * (
-                -285197 * (-1 + Seta)
-                + 4 * (-91902 + 1579 * Seta) * eta
-                - 35632 * eta2
-            )
-            + chi1
-            * (
-                285197 * SetaPlus1
-                - 4 * (91902 + 1579 * Seta) * eta
-                - 35632 * eta2
-            )
-            + 42840 * (-1.0 + 4 * eta) * PI
-        )
-    ) / 32256.0
-    prefactors_two = (
-        -(
-            PI**2
-            * (
-                -336
-                * (
-                    -3248849057.0
-                    + 2943675504 * chi12
-                    - 3339284256 * chi1 * chi2
-                    + 2943675504 * chi22
-                )
-                * eta2
-                - 324322727232 * eta2 * eta
-                - 7
-                * (
-                    -177520268561
-                    + 107414046432 * chi22
-                    + 107414046432 * chi12 * SetaPlus1
-                    - 107414046432 * chi22 * Seta
-                    + 11087290368
-                    * (chi1 + chi2 + chi1 * Seta - chi2 * Seta)
-                    * PI
-                )
-                + 12
-                * eta
-                * (
-                    -545384828789
-                    - 176491177632 * chi1 * chi2
-                    + 202603761360 * chi22
-                    + 77616 * chi12 * (2610335 + 995766 * Seta)
-                    - 77287373856 * chi22 * Seta
-                    + 5841690624 * (chi1 + chi2) * PI
-                    + 21384760320 * PI**2
-                )
-            )
-        )
-        / 6.0085960704e10
-    )
-    prefactors_seven_thirds = rho1_fun(eta, eta2, xi)
-    prefactors_eight_thirds = rho2_fun(eta, eta2, xi)
-    prefactors_three = rho3_fun(eta, eta2, xi)
-
-    amp = torch.ones_like(Mf)
-    amp += (
-        Mf_two_third.T * prefactors_two_thirds
-        + Mf_four_third.T * prefactors_four_thirds
-        + Mf_five_third.T * prefactors_five_thirds
-        + Mf_seven_third.T * prefactors_seven_thirds
-        + MF_eight_third.T * prefactors_eight_thirds
-        + Mf.mT * prefactors_one
-        + Mf_two.T * prefactors_two
-        + Mf_three.T * prefactors_three
-    ).mT
-
-    Damp = (
-        (2.0 / 3.0) / Mf_one_third.T * prefactors_two_thirds
-        + (4.0 / 3.0) * Mf_one_third.T * prefactors_four_thirds
-        + (5.0 / 3.0) * Mf_two_third.T * prefactors_five_thirds
-        + (7.0 / 3.0) * Mf_four_third.T * prefactors_seven_thirds
-        + (8.0 / 3.0) * Mf_five_third.T * prefactors_eight_thirds
-        + prefactors_one
-        + 2.0 * Mf.mT * prefactors_two
-        + 3.0 * Mf_two.T * prefactors_three
-    ).mT
-
-    return amp, Damp
-
-
-def phenom_d_mrd_amp(Mf, eta, eta2, chi1, chi2, xi):
-    # merger ringdown
-    fRD, fDM = fring_fdamp(eta, eta2, chi1, chi2)
-
-    gamma1 = gamma1_fun(eta, eta2, xi)
-    gamma2 = gamma2_fun(eta, eta2, xi)
-    gamma3 = gamma3_fun(eta, eta2, xi)
-    fDMgamma3 = fDM * gamma3
-    pow2_fDMgamma3 = (torch.ones_like(Mf).mT * fDMgamma3 * fDMgamma3).mT
-    fminfRD = Mf - (torch.ones_like(Mf).mT * fRD).mT
-    exp_times_lorentzian = torch.exp(fminfRD.mT * gamma2 / fDMgamma3).mT
-    exp_times_lorentzian *= fminfRD**2 + pow2_fDMgamma3
-
-    amp = (1 / exp_times_lorentzian.T * gamma1 * gamma3 * fDM).mT
-    Damp = (fminfRD.mT * -2 * fDM * gamma1 * gamma3) / (
-        fminfRD * fminfRD + pow2_fDMgamma3
-    ).mT - (gamma2 * gamma1)
-    Damp = Damp.T / exp_times_lorentzian
-    return amp, Damp
-
-
-def phenom_d_int_amp(Mf, eta, eta2, Seta, chi1, chi2, chi12, chi22, xi):
-    # merger ringdown
-    fRD, fDM = fring_fdamp(eta, eta2, chi1, chi2)
-    # Geometric frequency definition from PhenomD header file
-    AMP_fJoin_INS = 0.014
-
-    Mf1 = AMP_fJoin_INS * torch.ones_like(Mf)
-    gamma2 = gamma2_fun(eta, eta2, xi)
-    gamma3 = gamma3_fun(eta, eta2, xi)
-
-    fpeak = fmaxCalc(fRD, fDM, gamma2, gamma3)
-    Mf3 = (torch.ones_like(Mf).mT * fpeak).mT
-    dfx = 0.5 * (Mf3 - Mf1)
-    Mf2 = Mf1 + dfx
-
-    v1, d1 = phenom_d_inspiral_amp(
-        Mf1, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
-    )
-    v3, d2 = phenom_d_mrd_amp(Mf3, eta, eta2, chi1, chi2, xi)
-    v2 = (torch.ones_like(Mf).mT * AmpIntColFitCoeff(eta, eta2, xi)).mT
-
-    delta_0, delta_1, delta_2, delta_3, delta_4 = delta_values(
-        f1=Mf1, f2=Mf2, f3=Mf3, v1=v1, v2=v2, v3=v3, d1=d1, d2=d2
-    )
-
-    amp = (
-        delta_0
-        + Mf * delta_1
-        + Mf**2 * (delta_2 + Mf * delta_3 + Mf**2 * delta_4)
-    )
-    Damp = delta_1 + Mf * (
-        2 * delta_2 + 3 * Mf * delta_3 + 4 * Mf**2 * delta_4
-    )
-    return amp, Damp
-
-
-def phenom_d_amp(
-    Mf, mass_1, mass_2, eta, eta2, Seta, chi1, chi2, chi12, chi22, xi, distance
-):
-    ins_amp, ins_Damp = phenom_d_inspiral_amp(
-        Mf, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
-    )
-    int_amp, int_Damp = phenom_d_int_amp(
-        Mf, eta, eta2, Seta, chi1, chi2, chi12, chi22, xi
-    )
-    mrd_amp, mrd_Damp = phenom_d_mrd_amp(Mf, eta, eta2, chi1, chi2, xi)
-
-    gamma2 = gamma2_fun(eta, eta2, xi)
-    gamma3 = gamma3_fun(eta, eta2, xi)
-    fRD, fDM = fring_fdamp(eta, eta2, chi1, chi2)
-    Mf_peak = fmaxCalc(fRD, fDM, gamma2, gamma3)
-    # Geometric peak and joining frequencies
-    Mf_peak = (torch.ones_like(Mf).mT * Mf_peak).mT
-    Mf_join_ins = 0.014 * torch.ones_like(Mf)
-
-    # construct full IMR Amp
-    theta_minus_f1 = torch.heaviside(
-        Mf_join_ins - Mf, torch.tensor(0.0, device=Mf.device)
-    )
-    theta_plus_f1 = torch.heaviside(
-        Mf - Mf_join_ins, torch.tensor(1.0, device=Mf.device)
-    )
-    theta_minus_f2 = torch.heaviside(
-        Mf_peak - Mf, torch.tensor(0.0, device=Mf.device)
-    )
-    theta_plus_f2 = torch.heaviside(
-        Mf - Mf_peak, torch.tensor(1.0, device=Mf.device)
-    )
-
-    amp = theta_minus_f1 * ins_amp
-    amp += theta_plus_f1 * int_amp * theta_minus_f2
-    amp += theta_plus_f2 * mrd_amp
-
-    Damp = theta_minus_f1 * ins_Damp
-    Damp += theta_plus_f1 * int_Damp * theta_minus_f2
-    Damp += theta_plus_f2 * mrd_Damp
-
-    return amp, Damp
-
-
-def phenom_d_htilde(
-    f: TensorType,
-    chirp_mass: TensorType,
-    mass_ratio: TensorType,
-    chi1: TensorType,
-    chi2: TensorType,
-    distance: TensorType,
-    phic: TensorType,
-    f_ref: float,
-):
-    total_mass = chirp_mass * (1 + mass_ratio) ** 1.2 / mass_ratio**0.6
-    mass_1 = total_mass / (1 + mass_ratio)
-    mass_2 = mass_1 * mass_ratio
-    eta = (chirp_mass / total_mass) ** (5 / 3)
-    eta2 = eta * eta
-    Seta = torch.sqrt(1.0 - 4.0 * eta)
-    chi = chiPN(Seta, eta, chi1, chi2)
-    chi22 = chi2 * chi2
-    chi12 = chi1 * chi1
-    xi = -1.0 + chi
-    M_s = total_mass * MTSUN_SI
-
-    gamma2 = gamma2_fun(eta, eta2, xi)
-    gamma3 = gamma3_fun(eta, eta2, xi)
-
-    fRD, fDM = fring_fdamp(eta, eta2, chi1, chi2)
-    Mf_peak = fmaxCalc(fRD, fDM, gamma2, gamma3)
-    _, t0 = phenom_d_mrd_phase(Mf_peak, eta, eta2, chi1, chi2, xi)
-
-    Mf = torch.outer(M_s, f)
-    Mf_ref = torch.outer(M_s, f_ref * torch.ones_like(f))
-
-    Psi, _ = phenom_d_phase(Mf, mass_1, mass_2, eta, eta2, chi1, chi2, xi)
-    Psi_ref, _ = phenom_d_phase(
-        Mf_ref, mass_1, mass_2, eta, eta2, chi1, chi2, xi
-    )
-
-    Psi = (Psi.T - 2 * phic).mT
-    Psi -= Psi_ref
-    Psi -= ((Mf - Mf_ref).mT * t0).mT
-
-    amp, _ = phenom_d_amp(
+    def phenom_d_amp(
+        self,
         Mf,
         mass_1,
         mass_2,
@@ -1310,53 +134,1232 @@ def phenom_d_htilde(
         chi22,
         xi,
         distance,
-    )
-
-    amp_0 = taylorf2_amplitude(
-        Mf, mass_1, mass_2, eta, distance
-    )  # this includes f^(-7/6) dependence
-
-    h0 = -amp_0 * amp * torch.exp(-1j * Psi)
-
-    return h0
-
-
-def IMRPhenomD(
-    f: TensorType,
-    chirp_mass: TensorType,
-    mass_ratio: TensorType,
-    chi1: TensorType,
-    chi2: TensorType,
-    distance: TensorType,
-    phic: TensorType,
-    inclination: TensorType,
-    f_ref: float,
-):
-    """
-    IMRPhenomD waveform
-
-    Returns:
-    --------
-      hp, hc
-    """
-    # shape assumed (n_batch, params)
-    if (
-        chirp_mass.shape[0] != mass_ratio.shape[0]
-        or mass_ratio.shape[0] != chi1.shape[0]
-        or chi1.shape[0] != chi2.shape[0]
-        or chi2.shape[0] != distance.shape[0]
-        or distance.shape[0] != phic.shape[0]
-        or phic.shape[0] != inclination.shape[0]
     ):
-        raise RuntimeError("Tensors should have same batch size")
-    cfac = torch.cos(inclination)
-    pfac = 0.5 * (1.0 + cfac * cfac)
+        ins_amp, ins_Damp = self.phenom_d_inspiral_amp(
+            Mf, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
+        )
+        int_amp, int_Damp = self.phenom_d_int_amp(
+            Mf, eta, eta2, Seta, chi1, chi2, chi12, chi22, xi
+        )
+        mrd_amp, mrd_Damp = self.phenom_d_mrd_amp(
+            Mf, eta, eta2, chi1, chi2, xi
+        )
 
-    htilde = phenom_d_htilde(
-        f, chirp_mass, mass_ratio, chi1, chi2, distance, phic, f_ref
-    )
+        gamma2 = self.gamma2_fun(eta, eta2, xi)
+        gamma3 = self.gamma3_fun(eta, eta2, xi)
+        fRD, fDM = self.fring_fdamp(eta, eta2, chi1, chi2)
+        Mf_peak = self.fmaxCalc(fRD, fDM, gamma2, gamma3)
+        # Geometric peak and joining frequencies
+        Mf_peak = (torch.ones_like(Mf).mT * Mf_peak).mT
+        Mf_join_ins = 0.014 * torch.ones_like(Mf)
 
-    hp = (htilde.mT * pfac).mT
-    hc = -1j * (htilde.mT * cfac).mT
+        # construct full IMR Amp
+        theta_minus_f1 = torch.heaviside(
+            Mf_join_ins - Mf, torch.tensor(0.0, device=Mf.device)
+        )
+        theta_plus_f1 = torch.heaviside(
+            Mf - Mf_join_ins, torch.tensor(1.0, device=Mf.device)
+        )
+        theta_minus_f2 = torch.heaviside(
+            Mf_peak - Mf, torch.tensor(0.0, device=Mf.device)
+        )
+        theta_plus_f2 = torch.heaviside(
+            Mf - Mf_peak, torch.tensor(1.0, device=Mf.device)
+        )
 
-    return hp, hc
+        amp = theta_minus_f1 * ins_amp
+        amp += theta_plus_f1 * int_amp * theta_minus_f2
+        amp += theta_plus_f2 * mrd_amp
+
+        Damp = theta_minus_f1 * ins_Damp
+        Damp += theta_plus_f1 * int_Damp * theta_minus_f2
+        Damp += theta_plus_f2 * mrd_Damp
+
+        return amp, Damp
+
+    def phenom_d_int_amp(
+        self, Mf, eta, eta2, Seta, chi1, chi2, chi12, chi22, xi
+    ):
+        # merger ringdown
+        fRD, fDM = self.fring_fdamp(eta, eta2, chi1, chi2)
+        # Geometric frequency definition from PhenomD header file
+        AMP_fJoin_INS = 0.014
+
+        Mf1 = AMP_fJoin_INS * torch.ones_like(Mf)
+        gamma2 = self.gamma2_fun(eta, eta2, xi)
+        gamma3 = self.gamma3_fun(eta, eta2, xi)
+
+        fpeak = self.fmaxCalc(fRD, fDM, gamma2, gamma3)
+        Mf3 = (torch.ones_like(Mf).mT * fpeak).mT
+        dfx = 0.5 * (Mf3 - Mf1)
+        Mf2 = Mf1 + dfx
+
+        v1, d1 = self.phenom_d_inspiral_amp(
+            Mf1, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
+        )
+        v3, d2 = self.phenom_d_mrd_amp(Mf3, eta, eta2, chi1, chi2, xi)
+        v2 = (
+            torch.ones_like(Mf).mT * self.AmpIntColFitCoeff(eta, eta2, xi)
+        ).mT
+
+        delta_0, delta_1, delta_2, delta_3, delta_4 = self.delta_values(
+            f1=Mf1, f2=Mf2, f3=Mf3, v1=v1, v2=v2, v3=v3, d1=d1, d2=d2
+        )
+
+        amp = (
+            delta_0
+            + Mf * delta_1
+            + Mf**2 * (delta_2 + Mf * delta_3 + Mf**2 * delta_4)
+        )
+        Damp = delta_1 + Mf * (
+            2 * delta_2 + 3 * Mf * delta_3 + 4 * Mf**2 * delta_4
+        )
+        return amp, Damp
+
+    def phenom_d_mrd_amp(self, Mf, eta, eta2, chi1, chi2, xi):
+        # merger ringdown
+        fRD, fDM = self.fring_fdamp(eta, eta2, chi1, chi2)
+
+        gamma1 = self.gamma1_fun(eta, eta2, xi)
+        gamma2 = self.gamma2_fun(eta, eta2, xi)
+        gamma3 = self.gamma3_fun(eta, eta2, xi)
+        fDMgamma3 = fDM * gamma3
+        pow2_fDMgamma3 = (torch.ones_like(Mf).mT * fDMgamma3 * fDMgamma3).mT
+        fminfRD = Mf - (torch.ones_like(Mf).mT * fRD).mT
+        exp_times_lorentzian = torch.exp(fminfRD.mT * gamma2 / fDMgamma3).mT
+        exp_times_lorentzian *= fminfRD**2 + pow2_fDMgamma3
+
+        amp = (1 / exp_times_lorentzian.T * gamma1 * gamma3 * fDM).mT
+        Damp = (fminfRD.mT * -2 * fDM * gamma1 * gamma3) / (
+            fminfRD * fminfRD + pow2_fDMgamma3
+        ).mT - (gamma2 * gamma1)
+        Damp = Damp.T / exp_times_lorentzian
+        return amp, Damp
+
+    def phenom_d_inspiral_amp(
+        self, Mf, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
+    ):
+        SetaPlus1 = 1 + Seta
+
+        Mf_one_third = Mf ** (1.0 / 3.0)
+        Mf_two_third = Mf_one_third * Mf_one_third
+        Mf_four_third = Mf_two_third * Mf_two_third
+        Mf_five_third = Mf_four_third * Mf_one_third
+        Mf_seven_third = Mf_five_third * Mf_two_third
+        MF_eight_third = Mf_seven_third * Mf_one_third
+        Mf_two = Mf * Mf
+        Mf_three = Mf_two * Mf
+
+        prefactors_two_thirds = ((-969 + 1804 * eta) * PI ** (2.0 / 3.0)) / 672
+        prefactors_one = (
+            (
+                chi1 * (81 * SetaPlus1 - 44 * eta)
+                + chi2 * (81 - 81 * Seta - 44 * eta)
+            )
+            * PI
+        ) / 48.0
+        prefactors_four_thirds = (
+            (
+                -27312085.0
+                - 10287648 * chi22
+                - 10287648 * chi12 * SetaPlus1
+                + 10287648 * chi22 * Seta
+                + 24
+                * (
+                    -1975055
+                    + 857304 * chi12
+                    - 994896 * chi1 * chi2
+                    + 857304 * chi22
+                )
+                * eta
+                + 35371056 * eta2
+            )
+            * PI ** (4.0 / 3.0)
+        ) / 8.128512e6
+        prefactors_five_thirds = (
+            PI ** (5.0 / 3.0)
+            * (
+                chi2
+                * (
+                    -285197 * (-1 + Seta)
+                    + 4 * (-91902 + 1579 * Seta) * eta
+                    - 35632 * eta2
+                )
+                + chi1
+                * (
+                    285197 * SetaPlus1
+                    - 4 * (91902 + 1579 * Seta) * eta
+                    - 35632 * eta2
+                )
+                + 42840 * (-1.0 + 4 * eta) * PI
+            )
+        ) / 32256.0
+        prefactors_two = (
+            -(
+                PI**2
+                * (
+                    -336
+                    * (
+                        -3248849057.0
+                        + 2943675504 * chi12
+                        - 3339284256 * chi1 * chi2
+                        + 2943675504 * chi22
+                    )
+                    * eta2
+                    - 324322727232 * eta2 * eta
+                    - 7
+                    * (
+                        -177520268561
+                        + 107414046432 * chi22
+                        + 107414046432 * chi12 * SetaPlus1
+                        - 107414046432 * chi22 * Seta
+                        + 11087290368
+                        * (chi1 + chi2 + chi1 * Seta - chi2 * Seta)
+                        * PI
+                    )
+                    + 12
+                    * eta
+                    * (
+                        -545384828789
+                        - 176491177632 * chi1 * chi2
+                        + 202603761360 * chi22
+                        + 77616 * chi12 * (2610335 + 995766 * Seta)
+                        - 77287373856 * chi22 * Seta
+                        + 5841690624 * (chi1 + chi2) * PI
+                        + 21384760320 * PI**2
+                    )
+                )
+            )
+            / 6.0085960704e10
+        )
+        prefactors_seven_thirds = self.rho1_fun(eta, eta2, xi)
+        prefactors_eight_thirds = self.rho2_fun(eta, eta2, xi)
+        prefactors_three = self.rho3_fun(eta, eta2, xi)
+
+        amp = torch.ones_like(Mf)
+        amp += (
+            Mf_two_third.T * prefactors_two_thirds
+            + Mf_four_third.T * prefactors_four_thirds
+            + Mf_five_third.T * prefactors_five_thirds
+            + Mf_seven_third.T * prefactors_seven_thirds
+            + MF_eight_third.T * prefactors_eight_thirds
+            + Mf.mT * prefactors_one
+            + Mf_two.T * prefactors_two
+            + Mf_three.T * prefactors_three
+        ).mT
+
+        Damp = (
+            (2.0 / 3.0) / Mf_one_third.T * prefactors_two_thirds
+            + (4.0 / 3.0) * Mf_one_third.T * prefactors_four_thirds
+            + (5.0 / 3.0) * Mf_two_third.T * prefactors_five_thirds
+            + (7.0 / 3.0) * Mf_four_third.T * prefactors_seven_thirds
+            + (8.0 / 3.0) * Mf_five_third.T * prefactors_eight_thirds
+            + prefactors_one
+            + 2.0 * Mf.mT * prefactors_two
+            + 3.0 * Mf_two.T * prefactors_three
+        ).mT
+
+        return amp, Damp
+
+    def phenom_d_phase(self, Mf, mass_1, mass_2, eta, eta2, chi1, chi2, xi):
+        ins_phase, ins_Dphase = self.phenom_d_inspiral_phase(
+            Mf, mass_1, mass_2, eta, eta2, xi, chi1, chi2
+        )
+        int_phase, int_Dphase = self.phenom_d_int_phase(Mf, eta, eta2, xi)
+        mrd_phase, mrd_Dphase = self.phenom_d_mrd_phase(
+            Mf, eta, eta2, chi1, chi2, xi
+        )
+
+        # merger ringdown
+        fRD, fDM = self.fring_fdamp(eta, eta2, chi1, chi2)
+        # definitions in Eq. (35) of arXiv:1508.07253
+        # PHI_fJoin_INS in header LALSimIMRPhenomD.h
+        # C1 continuity at intermediate region i.e. f_1
+        PHI_fJoin_INS = 0.018 * torch.ones_like(Mf)
+        ins_phase_f1, ins_Dphase_f1 = self.phenom_d_inspiral_phase(
+            PHI_fJoin_INS, mass_1, mass_2, eta, eta2, xi, chi1, chi2
+        )
+        int_phase_f1, int_Dphase_f1 = self.phenom_d_int_phase(
+            PHI_fJoin_INS, eta, eta2, xi
+        )
+        C2Int = ins_Dphase_f1 - int_Dphase_f1
+        C1Int = (
+            ins_phase_f1 - (int_phase_f1.T / eta).mT - C2Int * PHI_fJoin_INS
+        )
+        # C1 continuity at ringdown
+        fRDJoin = (0.5 * torch.ones_like(Mf).mT * fRD).mT
+        int_phase_rd, int_Dphase_rd = self.phenom_d_int_phase(
+            fRDJoin, eta, eta2, xi
+        )
+        mrd_phase_rd, mrd_Dphase_rd = self.phenom_d_mrd_phase(
+            fRDJoin, eta, eta2, chi1, chi2, xi
+        )
+        PhiIntTempVal = (int_phase_rd.T / eta).mT + C1Int + C2Int * fRDJoin
+        # C2MRD = int_Dphase_rd - mrd_Dphase_rd
+        C2MRD = C2Int + int_Dphase_rd - mrd_Dphase_rd
+        C1MRD = PhiIntTempVal - (mrd_phase_rd.T / eta).mT - C2MRD * fRDJoin
+
+        int_phase = (int_phase.T / eta).mT
+        int_phase += C1Int
+        int_phase += Mf * C2Int
+
+        mrd_phase = (mrd_phase.T / eta).mT
+        mrd_phase += C1MRD
+        mrd_phase += Mf * C2MRD
+
+        # construct full IMR phase
+        theta_minus_f1 = torch.heaviside(
+            PHI_fJoin_INS - Mf, torch.tensor(0.0, device=Mf.device)
+        )
+        theta_plus_f1 = torch.heaviside(
+            Mf - PHI_fJoin_INS, torch.tensor(1.0, device=Mf.device)
+        )
+        theta_minus_f2 = torch.heaviside(
+            fRDJoin - Mf, torch.tensor(0.0, device=Mf.device)
+        )
+        theta_plus_f2 = torch.heaviside(
+            Mf - fRDJoin, torch.tensor(1.0, device=Mf.device)
+        )
+
+        phasing = theta_minus_f1 * ins_phase
+        phasing += theta_plus_f1 * int_phase * theta_minus_f2
+        phasing += theta_plus_f2 * mrd_phase
+
+        Dphasing = theta_minus_f1 * ins_Dphase
+        Dphasing += theta_plus_f1 * int_Dphase * theta_minus_f2
+        Dphasing += theta_plus_f2 * mrd_Dphase
+
+        return phasing, Dphasing
+
+    def phenom_d_mrd_phase(self, Mf, eta, eta2, chi1, chi2, xi):
+        alpha1 = self.alpha1Fit(eta, eta2, xi)
+        alpha2 = self.alpha2Fit(eta, eta2, xi)
+        alpha3 = self.alpha3Fit(eta, eta2, xi)
+        alpha4 = self.alpha4Fit(eta, eta2, xi)
+        alpha5 = self.alpha5Fit(eta, eta2, xi)
+
+        # merger ringdown
+        fRD, fDM = self.fring_fdamp(eta, eta2, chi1, chi2)
+        f_minus_alpha5_fRD = (Mf.t() - alpha5 * fRD).t()
+
+        # Leading 1/eta is not multiplied at this stage
+        mrd_phasing = (Mf.t() * alpha1).t()
+        mrd_phasing -= (1 / Mf.t() * alpha2).t()
+        mrd_phasing += (4.0 / 3.0) * (Mf.t() ** (3.0 / 4.0) * alpha3).t()
+        mrd_phasing += (torch.atan(f_minus_alpha5_fRD.t() / fDM) * alpha4).t()
+
+        mrd_Dphasing = (
+            alpha4 * fDM / (f_minus_alpha5_fRD.t() ** 2 + fDM**2)
+        ).t()
+        mrd_Dphasing += (Mf.t() ** (-1.0 / 4.0) * alpha3).t()
+        mrd_Dphasing += (Mf.t() ** (-2.0) * alpha2).t()
+        mrd_Dphasing = (mrd_Dphasing.t() + alpha1).t()
+        mrd_Dphasing = (mrd_Dphasing.t() / eta).t()
+
+        return mrd_phasing, mrd_Dphasing
+
+    def phenom_d_int_phase(self, Mf, eta, eta2, xi):
+        beta1 = self.beta1Fit(eta, eta2, xi)
+        beta2 = self.beta2Fit(eta, eta2, xi)
+        beta3 = self.beta3Fit(eta, eta2, xi)
+        # Merger phase
+        # Leading beta0 is not added here
+        # overall 1/eta is not multiplied
+        int_phasing = (Mf.mT * beta1).mT
+        int_phasing += (torch.log(Mf).mT * beta2).mT
+        int_phasing -= (Mf.mT ** (-3.0) / 3.0 * beta3).mT
+
+        # overall 1/eta is multiple in derivative of
+        # intermediate phase
+        int_Dphasing = (Mf.mT ** (-4.0) * beta3).mT
+        int_Dphasing += (Mf.mT ** (-1.0) * beta2).mT
+        int_Dphasing = (int_Dphasing.T + beta1).mT
+        int_Dphasing = (int_Dphasing.T / eta).mT
+        return int_phasing, int_Dphasing
+
+    def phenom_d_inspiral_phase(
+        self, Mf, mass_1, mass_2, eta, eta2, xi, chi1, chi2
+    ):
+        ins_phasing, ins_Dphasing = self.taylorf2_phase(
+            Mf, mass_1, mass_2, chi1, chi2
+        )
+
+        sigma1 = self.sigma1Fit(eta, eta2, xi)
+        sigma2 = self.sigma2Fit(eta, eta2, xi)
+        sigma3 = self.sigma3Fit(eta, eta2, xi)
+        sigma4 = self.sigma4Fit(eta, eta2, xi)
+
+        ins_phasing += (Mf.mT * sigma1 / eta).mT
+        ins_phasing += (Mf.mT ** (4.0 / 3.0) * 0.75 * sigma2 / eta).mT
+        ins_phasing += (Mf.mT ** (5.0 / 3.0) * 0.6 * sigma3 / eta).mT
+        ins_phasing += (Mf.mT**2.0 * 0.5 * sigma4 / eta).mT
+
+        ins_Dphasing = (ins_Dphasing.T + sigma1 / eta).mT
+        ins_Dphasing += (Mf.mT ** (1.0 / 3.0) * sigma2 / eta).mT
+        ins_Dphasing += (Mf.mT ** (2.0 / 3.0) * sigma3 / eta).mT
+        ins_Dphasing += (Mf.mT * sigma4 / eta).mT
+
+        return ins_phasing, ins_Dphasing
+
+    def fring_fdamp(self, eta, eta2, chi1, chi2):
+        finspin = self.FinalSpin0815(eta, eta2, chi1, chi2)
+        Erad = self.PhenomInternal_EradRational0815(eta, eta2, chi1, chi2)
+
+        fRD, fDM = self._linear_interp_finspin(finspin)
+        fRD /= 1.0 - Erad
+        fDM /= 1.0 - Erad
+
+        return fRD, fDM
+
+    def fmaxCalc(fRD, fDM, gamma2, gamma3):
+        res = torch.zeros_like(gamma2)
+        res = torch.abs(fRD + (-fDM * gamma3) / gamma2) * (gamma2 > 1).to(
+            torch.int
+        ) + torch.abs(
+            fRD
+            + (fDM * (-1 + torch.sqrt(1 - gamma2 * gamma2)) * gamma3) / gamma2
+        ) * (
+            gamma2 <= 1
+        ).to(
+            torch.int
+        )
+        return res
+
+    def _linear_interp_finspin(finspin):
+        # chi is a batch of final spins i.e. torch.Size([n])
+        right_spin_idx = torch.bucketize(finspin, QNMData_a)
+        right_spin_val = QNMData_a[right_spin_idx]
+        # QNMData_a is sorted, hence take the previous index
+        left_spin_idx = right_spin_idx - 1
+        left_spin_val = QNMData_a[left_spin_idx]
+
+        if not torch.all(left_spin_val < right_spin_val):
+            raise RuntimeError(
+                "Left value in grid should be greater than right. "
+                "Maybe be caused for extremal spin values."
+            )
+        left_fring = QNMData_fring[left_spin_idx]
+        right_fring = QNMData_fring[right_spin_idx]
+        slope_fring = right_fring - left_fring
+        slope_fring /= right_spin_val - left_spin_val
+
+        left_fdamp = QNMData_fdamp[left_spin_idx]
+        right_fdamp = QNMData_fdamp[right_spin_idx]
+        slope_fdamp = right_fdamp - left_fdamp
+        slope_fdamp /= right_spin_val - left_spin_val
+
+        return (
+            slope_fring * (finspin - left_spin_val) + left_fring,
+            slope_fdamp * (finspin - left_spin_val) + left_fdamp,
+        )
+
+    # Utility functions taken from PhenomD utilities in lalsimulation
+    # https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimIMRPhenomD_internals.c
+    def sigma1Fit(eta, eta2, xi):
+        return (
+            2096.551999295543
+            + 1463.7493168261553 * eta
+            + (
+                1312.5493286098522
+                + 18307.330017082117 * eta
+                - 43534.1440746107 * eta2
+                + (
+                    -833.2889543511114
+                    + 32047.31997183187 * eta
+                    - 108609.45037520859 * eta2
+                )
+                * xi
+                + (
+                    452.25136398112204
+                    + 8353.439546391714 * eta
+                    - 44531.3250037322 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def sigma2Fit(eta, eta2, xi):
+        return (
+            -10114.056472621156
+            - 44631.01109458185 * eta
+            + (
+                -6541.308761668722
+                - 266959.23419307504 * eta
+                + 686328.3229317984 * eta2
+                + (
+                    3405.6372187679685
+                    - 437507.7208209015 * eta
+                    + 1.6318171307344697e6 * eta2
+                )
+                * xi
+                + (
+                    -7462.648563007646
+                    - 114585.25177153319 * eta
+                    + 674402.4689098676 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def sigma3Fit(eta, eta2, xi):
+        return (
+            22933.658273436497
+            + 230960.00814979506 * eta
+            + (
+                14961.083974183695
+                + 1.1940181342318142e6 * eta
+                - 3.1042239693052764e6 * eta2
+                + (
+                    -3038.166617199259
+                    + 1.8720322849093592e6 * eta
+                    - 7.309145012085539e6 * eta2
+                )
+                * xi
+                + (
+                    42738.22871475411
+                    + 467502.018616601 * eta
+                    - 3.064853498512499e6 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def sigma4Fit(eta, eta2, xi):
+        return (
+            -14621.71522218357
+            - 377812.8579387104 * eta
+            + (
+                -9608.682631509726
+                - 1.7108925257214056e6 * eta
+                + 4.332924601416521e6 * eta2
+                + (
+                    -22366.683262266528
+                    - 2.5019716386377467e6 * eta
+                    + 1.0274495902259542e7 * eta2
+                )
+                * xi
+                + (
+                    -85360.30079034246
+                    - 570025.3441737515 * eta
+                    + 4.396844346849777e6 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def gamma1_fun(eta, eta2, xi):
+        return (
+            0.006927402739328343
+            + 0.03020474290328911 * eta
+            + (
+                0.006308024337706171
+                - 0.12074130661131138 * eta
+                + 0.26271598905781324 * eta2
+                + (
+                    0.0034151773647198794
+                    - 0.10779338611188374 * eta
+                    + 0.27098966966891747 * eta2
+                )
+                * xi
+                + (
+                    0.0007374185938559283
+                    - 0.02749621038376281 * eta
+                    + 0.0733150789135702 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def gamma2_fun(eta, eta2, xi):
+        return (
+            1.010344404799477
+            + 0.0008993122007234548 * eta
+            + (
+                0.283949116804459
+                - 4.049752962958005 * eta
+                + 13.207828172665366 * eta2
+                + (
+                    0.10396278486805426
+                    - 7.025059158961947 * eta
+                    + 24.784892370130475 * eta2
+                )
+                * xi
+                + (
+                    0.03093202475605892
+                    - 2.6924023896851663 * eta
+                    + 9.609374464684983 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def gamma3_fun(eta, eta2, xi):
+        return (
+            1.3081615607036106
+            - 0.005537729694807678 * eta
+            + (
+                -0.06782917938621007
+                - 0.6689834970767117 * eta
+                + 3.403147966134083 * eta2
+                + (
+                    -0.05296577374411866
+                    - 0.9923793203111362 * eta
+                    + 4.820681208409587 * eta2
+                )
+                * xi
+                + (
+                    -0.006134139870393713
+                    - 0.38429253308696365 * eta
+                    + 1.7561754421985984 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def beta1Fit(eta, eta2, xi):
+        return (
+            97.89747327985583
+            - 42.659730877489224 * eta
+            + (
+                153.48421037904913
+                - 1417.0620760768954 * eta
+                + 2752.8614143665027 * eta2
+                + (
+                    138.7406469558649
+                    - 1433.6585075135881 * eta
+                    + 2857.7418952430758 * eta2
+                )
+                * xi
+                + (
+                    41.025109467376126
+                    - 423.680737974639 * eta
+                    + 850.3594335657173 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def beta2Fit(eta, eta2, xi):
+        return (
+            -3.282701958759534
+            - 9.051384468245866 * eta
+            + (
+                -12.415449742258042
+                + 55.4716447709787 * eta
+                - 106.05109938966335 * eta2
+                + (
+                    -11.953044553690658
+                    + 76.80704618365418 * eta
+                    - 155.33172948098394 * eta2
+                )
+                * xi
+                + (
+                    -3.4129261592393263
+                    + 25.572377569952536 * eta
+                    - 54.408036707740465 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def beta3Fit(eta, eta2, xi):
+        return (
+            -0.000025156429818799565
+            + 0.000019750256942201327 * eta
+            + (
+                -0.000018370671469295915
+                + 0.000021886317041311973 * eta
+                + 0.00008250240316860033 * eta2
+                + (
+                    7.157371250566708e-6
+                    - 0.000055780000112270685 * eta
+                    + 0.00019142082884072178 * eta2
+                )
+                * xi
+                + (
+                    5.447166261464217e-6
+                    - 0.00003220610095021982 * eta
+                    + 0.00007974016714984341 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def alpha1Fit(eta, eta2, xi):
+        return (
+            43.31514709695348
+            + 638.6332679188081 * eta
+            + (
+                -32.85768747216059
+                + 2415.8938269370315 * eta
+                - 5766.875169379177 * eta2
+                + (
+                    -61.85459307173841
+                    + 2953.967762459948 * eta
+                    - 8986.29057591497 * eta2
+                )
+                * xi
+                + (
+                    -21.571435779762044
+                    + 981.2158224673428 * eta
+                    - 3239.5664895930286 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def alpha2Fit(eta, eta2, xi):
+        return (
+            -0.07020209449091723
+            - 0.16269798450687084 * eta
+            + (
+                -0.1872514685185499
+                + 1.138313650449945 * eta
+                - 2.8334196304430046 * eta2
+                + (
+                    -0.17137955686840617
+                    + 1.7197549338119527 * eta
+                    - 4.539717148261272 * eta2
+                )
+                * xi
+                + (
+                    -0.049983437357548705
+                    + 0.6062072055948309 * eta
+                    - 1.682769616644546 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def alpha3Fit(eta, eta2, xi):
+        return (
+            9.5988072383479
+            - 397.05438595557433 * eta
+            + (
+                16.202126189517813
+                - 1574.8286986717037 * eta
+                + 3600.3410843831093 * eta2
+                + (
+                    27.092429659075467
+                    - 1786.482357315139 * eta
+                    + 5152.919378666511 * eta2
+                )
+                * xi
+                + (
+                    11.175710130033895
+                    - 577.7999423177481 * eta
+                    + 1808.730762932043 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def alpha4Fit(eta, eta2, xi):
+        return (
+            -0.02989487384493607
+            + 1.4022106448583738 * eta
+            + (
+                -0.07356049468633846
+                + 0.8337006542278661 * eta
+                + 0.2240008282397391 * eta2
+                + (
+                    -0.055202870001177226
+                    + 0.5667186343606578 * eta
+                    + 0.7186931973380503 * eta2
+                )
+                * xi
+                + (
+                    -0.015507437354325743
+                    + 0.15750322779277187 * eta
+                    + 0.21076815715176228 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def alpha5Fit(eta, eta2, xi):
+        return (
+            0.9974408278363099
+            - 0.007884449714907203 * eta
+            + (
+                -0.059046901195591035
+                + 1.3958712396764088 * eta
+                - 4.516631601676276 * eta2
+                + (
+                    -0.05585343136869692
+                    + 1.7516580039343603 * eta
+                    - 5.990208965347804 * eta2
+                )
+                * xi
+                + (
+                    -0.017945336522161195
+                    + 0.5965097794825992 * eta
+                    - 2.0608879367971804 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def rho1_fun(eta, eta2, xi):
+        return (
+            3931.8979897196696
+            - 17395.758706812805 * eta
+            + (
+                3132.375545898835
+                + 343965.86092361377 * eta
+                - 1.2162565819981997e6 * eta2
+                + (
+                    -70698.00600428853
+                    + 1.383907177859705e6 * eta
+                    - 3.9662761890979446e6 * eta2
+                )
+                * xi
+                + (
+                    -60017.52423652596
+                    + 803515.1181825735 * eta
+                    - 2.091710365941658e6 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def rho2_fun(eta, eta2, xi):
+        return (
+            -40105.47653771657
+            + 112253.0169706701 * eta
+            + (
+                23561.696065836168
+                - 3.476180699403351e6 * eta
+                + 1.137593670849482e7 * eta2
+                + (
+                    754313.1127166454
+                    - 1.308476044625268e7 * eta
+                    + 3.6444584853928134e7 * eta2
+                )
+                * xi
+                + (
+                    596226.612472288
+                    - 7.4277901143564405e6 * eta
+                    + 1.8928977514040343e7 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def rho3_fun(eta, eta2, xi):
+        return (
+            83208.35471266537
+            - 191237.7264145924 * eta
+            + (
+                -210916.2454782992
+                + 8.71797508352568e6 * eta
+                - 2.6914942420669552e7 * eta2
+                + (
+                    -1.9889806527362722e6
+                    + 3.0888029960154563e7 * eta
+                    - 8.390870279256162e7 * eta2
+                )
+                * xi
+                + (
+                    -1.4535031953446497e6
+                    + 1.7063528990822166e7 * eta
+                    - 4.2748659731120914e7 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def FinalSpin0815(eta, eta2, chi1, chi2):
+        Seta = torch.sqrt(1.0 - 4.0 * eta)
+        Seta = torch.nan_to_num(Seta)  # avoid nan around eta = 0.25
+        m1 = 0.5 * (1.0 + Seta)
+        m2 = 0.5 * (1.0 - Seta)
+        m1s = m1 * m1
+        m2s = m2 * m2
+        s = m1s * chi1 + m2s * chi2
+        eta3 = eta2 * eta
+        s2 = s * s
+        s3 = s2 * s
+        return eta * (
+            3.4641016151377544
+            - 4.399247300629289 * eta
+            + 9.397292189321194 * eta2
+            - 13.180949901606242 * eta3
+            + (
+                (1.0 / eta - 0.0850917821418767 - 5.837029316602263 * eta)
+                + (0.1014665242971878 - 2.0967746996832157 * eta) * s
+                + (-1.3546806617824356 + 4.108962025369336 * eta) * s2
+                + (-0.8676969352555539 + 2.064046835273906 * eta) * s3
+            )
+            * s
+        )
+
+    def PhenomInternal_EradRational0815(eta, eta2, chi1, chi2):
+        Seta = torch.sqrt(1.0 - 4.0 * eta)
+        m1 = 0.5 * (1.0 + Seta)
+        m2 = 0.5 * (1.0 - Seta)
+        m1s = m1 * m1
+        m2s = m2 * m2
+        s = (m1s * chi1 + m2s * chi2) / (m1s + m2s)
+
+        eta3 = eta2 * eta
+
+        return (
+            eta
+            * (
+                0.055974469826360077
+                + 0.5809510763115132 * eta
+                - 0.9606726679372312 * eta2
+                + 3.352411249771192 * eta3
+            )
+            * (
+                1.0
+                + (
+                    -0.0030302335878845507
+                    - 2.0066110851351073 * eta
+                    + 7.7050567802399215 * eta2
+                )
+                * s
+            )
+        ) / (
+            1.0
+            + (
+                -0.6714403054720589
+                - 1.4756929437702908 * eta
+                + 7.304676214885011 * eta2
+            )
+            * s
+        )
+
+    def AmpIntColFitCoeff(eta, eta2, xi):
+        return (
+            0.8149838730507785
+            + 2.5747553517454658 * eta
+            + (
+                1.1610198035496786
+                - 2.3627771785551537 * eta
+                + 6.771038707057573 * eta2
+                + (
+                    0.7570782938606834
+                    - 2.7256896890432474 * eta
+                    + 7.1140380397149965 * eta2
+                )
+                * xi
+                + (
+                    0.1766934149293479
+                    - 0.7978690983168183 * eta
+                    + 2.1162391502005153 * eta2
+                )
+                * xi
+                * xi
+            )
+            * xi
+        )
+
+    def delta_values(f1, f2, f3, v1, v2, v3, d1, d2):
+        f12 = f1 * f1
+        f13 = f1 * f12
+        f14 = f1 * f13
+        f15 = f1 * f14
+        f22 = f2 * f2
+        f23 = f2 * f22
+        f24 = f2 * f23
+        f32 = f3 * f3
+        f33 = f3 * f32
+        f34 = f3 * f33
+        f35 = f3 * f34
+        delta_0 = -(
+            (
+                d2 * f15 * f22 * f3
+                - 2 * d2 * f14 * f23 * f3
+                + d2 * f13 * f24 * f3
+                - d2 * f15 * f2 * f32
+                + d2 * f14 * f22 * f32
+                - d1 * f13 * f23 * f32
+                + d2 * f13 * f23 * f32
+                + d1 * f12 * f24 * f32
+                - d2 * f12 * f24 * f32
+                + d2 * f14 * f2 * f33
+                + 2 * d1 * f13 * f22 * f33
+                - 2 * d2 * f13 * f22 * f33
+                - d1 * f12 * f23 * f33
+                + d2 * f12 * f23 * f33
+                - d1 * f1 * f24 * f33
+                - d1 * f13 * f2 * f34
+                - d1 * f12 * f22 * f34
+                + 2 * d1 * f1 * f23 * f34
+                + d1 * f12 * f2 * f35
+                - d1 * f1 * f22 * f35
+                + 4 * f12 * f23 * f32 * v1
+                - 3 * f1 * f24 * f32 * v1
+                - 8 * f12 * f22 * f33 * v1
+                + 4 * f1 * f23 * f33 * v1
+                + f24 * f33 * v1
+                + 4 * f12 * f2 * f34 * v1
+                + f1 * f22 * f34 * v1
+                - 2 * f23 * f34 * v1
+                - 2 * f1 * f2 * f35 * v1
+                + f22 * f35 * v1
+                - f15 * f32 * v2
+                + 3 * f14 * f33 * v2
+                - 3 * f13 * f34 * v2
+                + f12 * f35 * v2
+                - f15 * f22 * v3
+                + 2 * f14 * f23 * v3
+                - f13 * f24 * v3
+                + 2 * f15 * f2 * f3 * v3
+                - f14 * f22 * f3 * v3
+                - 4 * f13 * f23 * f3 * v3
+                + 3 * f12 * f24 * f3 * v3
+                - 4 * f14 * f2 * f32 * v3
+                + 8 * f13 * f22 * f32 * v3
+                - 4 * f12 * f23 * f32 * v3
+            )
+            / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (f3 - f2) ** 2)
+        )
+
+        delta_1 = -(
+            (
+                -(d2 * f15 * f22)
+                + 2 * d2 * f14 * f23
+                - d2 * f13 * f24
+                - d2 * f14 * f22 * f3
+                + 2 * d1 * f13 * f23 * f3
+                + 2 * d2 * f13 * f23 * f3
+                - 2 * d1 * f12 * f24 * f3
+                - d2 * f12 * f24 * f3
+                + d2 * f15 * f32
+                - 3 * d1 * f13 * f22 * f32
+                - d2 * f13 * f22 * f32
+                + 2 * d1 * f12 * f23 * f32
+                - 2 * d2 * f12 * f23 * f32
+                + d1 * f1 * f24 * f32
+                + 2 * d2 * f1 * f24 * f32
+                - d2 * f14 * f33
+                + d1 * f12 * f22 * f33
+                + 3 * d2 * f12 * f22 * f33
+                - 2 * d1 * f1 * f23 * f33
+                - 2 * d2 * f1 * f23 * f33
+                + d1 * f24 * f33
+                + d1 * f13 * f34
+                + d1 * f1 * f22 * f34
+                - 2 * d1 * f23 * f34
+                - d1 * f12 * f35
+                + d1 * f22 * f35
+                - 8 * f12 * f23 * f3 * v1
+                + 6 * f1 * f24 * f3 * v1
+                + 12 * f12 * f22 * f32 * v1
+                - 8 * f1 * f23 * f32 * v1
+                - 4 * f12 * f34 * v1
+                + 2 * f1 * f35 * v1
+                + 2 * f15 * f3 * v2
+                - 4 * f14 * f32 * v2
+                + 4 * f12 * f34 * v2
+                - 2 * f1 * f35 * v2
+                - 2 * f15 * f3 * v3
+                + 8 * f12 * f23 * f3 * v3
+                - 6 * f1 * f24 * f3 * v3
+                + 4 * f14 * f32 * v3
+                - 12 * f12 * f22 * f32 * v3
+                + 8 * f1 * f23 * f32 * v3
+            )
+            / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
+        )
+
+        delta_2 = -(
+            (
+                d2 * f15 * f2
+                - d1 * f13 * f23
+                - 3 * d2 * f13 * f23
+                + d1 * f12 * f24
+                + 2 * d2 * f12 * f24
+                - d2 * f15 * f3
+                + d2 * f14 * f2 * f3
+                - d1 * f12 * f23 * f3
+                + d2 * f12 * f23 * f3
+                + d1 * f1 * f24 * f3
+                - d2 * f1 * f24 * f3
+                - d2 * f14 * f32
+                + 3 * d1 * f13 * f2 * f32
+                + d2 * f13 * f2 * f32
+                - d1 * f1 * f23 * f32
+                + d2 * f1 * f23 * f32
+                - 2 * d1 * f24 * f32
+                - d2 * f24 * f32
+                - 2 * d1 * f13 * f33
+                + 2 * d2 * f13 * f33
+                - d1 * f12 * f2 * f33
+                - 3 * d2 * f12 * f2 * f33
+                + 3 * d1 * f23 * f33
+                + d2 * f23 * f33
+                + d1 * f12 * f34
+                - d1 * f1 * f2 * f34
+                + d1 * f1 * f35
+                - d1 * f2 * f35
+                + 4 * f12 * f23 * v1
+                - 3 * f1 * f24 * v1
+                + 4 * f1 * f23 * f3 * v1
+                - 3 * f24 * f3 * v1
+                - 12 * f12 * f2 * f32 * v1
+                + 4 * f23 * f32 * v1
+                + 8 * f12 * f33 * v1
+                - f1 * f34 * v1
+                - f35 * v1
+                - f15 * v2
+                - f14 * f3 * v2
+                + 8 * f13 * f32 * v2
+                - 8 * f12 * f33 * v2
+                + f1 * f34 * v2
+                + f35 * v2
+                + f15 * v3
+                - 4 * f12 * f23 * v3
+                + 3 * f1 * f24 * v3
+                + f14 * f3 * v3
+                - 4 * f1 * f23 * f3 * v3
+                + 3 * f24 * f3 * v3
+                - 8 * f13 * f32 * v3
+                + 12 * f12 * f2 * f32 * v3
+                - 4 * f23 * f32 * v3
+            )
+            / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
+        )
+
+        delta_3 = -(
+            (
+                -2 * d2 * f14 * f2
+                + d1 * f13 * f22
+                + 3 * d2 * f13 * f22
+                - d1 * f1 * f24
+                - d2 * f1 * f24
+                + 2 * d2 * f14 * f3
+                - 2 * d1 * f13 * f2 * f3
+                - 2 * d2 * f13 * f2 * f3
+                + d1 * f12 * f22 * f3
+                - d2 * f12 * f22 * f3
+                + d1 * f24 * f3
+                + d2 * f24 * f3
+                + d1 * f13 * f32
+                - d2 * f13 * f32
+                - 2 * d1 * f12 * f2 * f32
+                + 2 * d2 * f12 * f2 * f32
+                + d1 * f1 * f22 * f32
+                - d2 * f1 * f22 * f32
+                + d1 * f12 * f33
+                - d2 * f12 * f33
+                + 2 * d1 * f1 * f2 * f33
+                + 2 * d2 * f1 * f2 * f33
+                - 3 * d1 * f22 * f33
+                - d2 * f22 * f33
+                - 2 * d1 * f1 * f34
+                + 2 * d1 * f2 * f34
+                - 4 * f12 * f22 * v1
+                + 2 * f24 * v1
+                + 8 * f12 * f2 * f3 * v1
+                - 4 * f1 * f22 * f3 * v1
+                - 4 * f12 * f32 * v1
+                + 8 * f1 * f2 * f32 * v1
+                - 4 * f22 * f32 * v1
+                - 4 * f1 * f33 * v1
+                + 2 * f34 * v1
+                + 2 * f14 * v2
+                - 4 * f13 * f3 * v2
+                + 4 * f1 * f33 * v2
+                - 2 * f34 * v2
+                - 2 * f14 * v3
+                + 4 * f12 * f22 * v3
+                - 2 * f24 * v3
+                + 4 * f13 * f3 * v3
+                - 8 * f12 * f2 * f3 * v3
+                + 4 * f1 * f22 * f3 * v3
+                + 4 * f12 * f32 * v3
+                - 8 * f1 * f2 * f32 * v3
+                + 4 * f22 * f32 * v3
+            )
+            / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
+        )
+
+        delta_4 = -(
+            (
+                d2 * f13 * f2
+                - d1 * f12 * f22
+                - 2 * d2 * f12 * f22
+                + d1 * f1 * f23
+                + d2 * f1 * f23
+                - d2 * f13 * f3
+                + 2 * d1 * f12 * f2 * f3
+                + d2 * f12 * f2 * f3
+                - d1 * f1 * f22 * f3
+                + d2 * f1 * f22 * f3
+                - d1 * f23 * f3
+                - d2 * f23 * f3
+                - d1 * f12 * f32
+                + d2 * f12 * f32
+                - d1 * f1 * f2 * f32
+                - 2 * d2 * f1 * f2 * f32
+                + 2 * d1 * f22 * f32
+                + d2 * f22 * f32
+                + d1 * f1 * f33
+                - d1 * f2 * f33
+                + 3 * f1 * f22 * v1
+                - 2 * f23 * v1
+                - 6 * f1 * f2 * f3 * v1
+                + 3 * f22 * f3 * v1
+                + 3 * f1 * f32 * v1
+                - f33 * v1
+                - f13 * v2
+                + 3 * f12 * f3 * v2
+                - 3 * f1 * f32 * v2
+                + f33 * v2
+                + f13 * v3
+                - 3 * f1 * f22 * v3
+                + 2 * f23 * v3
+                - 3 * f12 * f3 * v3
+                + 6 * f1 * f2 * f3 * v3
+                - 3 * f22 * f3 * v3
+            )
+            / ((f1 - f2) ** 2 * (f1 - f3) ** 3 * (-f2 + f3) ** 2)
+        )
+
+        return delta_0, delta_1, delta_2, delta_3, delta_4
+
+    def chiPN(Seta, eta, chi1, chi2):
+        chi_s = chi1 + chi2
+        chi_a = chi1 - chi2
+
+        return 0.5 * (chi_s * (1.0 - eta * 76.0 / 113.0) + Seta * chi_a)

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -511,7 +511,7 @@ class IMRPhenomD(TaylorF2):
 
         return fRD, fDM
 
-    def fmaxCalc(fRD, fDM, gamma2, gamma3):
+    def fmaxCalc(self, fRD, fDM, gamma2, gamma3):
         res = torch.zeros_like(gamma2)
         res = torch.abs(fRD + (-fDM * gamma3) / gamma2) * (gamma2 > 1).to(
             torch.int
@@ -525,7 +525,7 @@ class IMRPhenomD(TaylorF2):
         )
         return res
 
-    def _linear_interp_finspin(finspin):
+    def _linear_interp_finspin(self, finspin):
         # chi is a batch of final spins i.e. torch.Size([n])
         right_spin_idx = torch.bucketize(finspin, QNMData_a)
         right_spin_val = QNMData_a[right_spin_idx]
@@ -555,7 +555,7 @@ class IMRPhenomD(TaylorF2):
 
     # Utility functions taken from PhenomD utilities in lalsimulation
     # https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimIMRPhenomD_internals.c
-    def sigma1Fit(eta, eta2, xi):
+    def sigma1Fit(self, eta, eta2, xi):
         return (
             2096.551999295543
             + 1463.7493168261553 * eta
@@ -580,7 +580,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def sigma2Fit(eta, eta2, xi):
+    def sigma2Fit(self, eta, eta2, xi):
         return (
             -10114.056472621156
             - 44631.01109458185 * eta
@@ -605,7 +605,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def sigma3Fit(eta, eta2, xi):
+    def sigma3Fit(self, eta, eta2, xi):
         return (
             22933.658273436497
             + 230960.00814979506 * eta
@@ -630,7 +630,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def sigma4Fit(eta, eta2, xi):
+    def sigma4Fit(self, eta, eta2, xi):
         return (
             -14621.71522218357
             - 377812.8579387104 * eta
@@ -655,7 +655,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def gamma1_fun(eta, eta2, xi):
+    def gamma1_fun(self, eta, eta2, xi):
         return (
             0.006927402739328343
             + 0.03020474290328911 * eta
@@ -680,7 +680,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def gamma2_fun(eta, eta2, xi):
+    def gamma2_fun(self, eta, eta2, xi):
         return (
             1.010344404799477
             + 0.0008993122007234548 * eta
@@ -705,7 +705,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def gamma3_fun(eta, eta2, xi):
+    def gamma3_fun(self, eta, eta2, xi):
         return (
             1.3081615607036106
             - 0.005537729694807678 * eta
@@ -730,7 +730,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def beta1Fit(eta, eta2, xi):
+    def beta1Fit(self, eta, eta2, xi):
         return (
             97.89747327985583
             - 42.659730877489224 * eta
@@ -755,7 +755,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def beta2Fit(eta, eta2, xi):
+    def beta2Fit(self, eta, eta2, xi):
         return (
             -3.282701958759534
             - 9.051384468245866 * eta
@@ -780,7 +780,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def beta3Fit(eta, eta2, xi):
+    def beta3Fit(self, eta, eta2, xi):
         return (
             -0.000025156429818799565
             + 0.000019750256942201327 * eta
@@ -805,7 +805,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def alpha1Fit(eta, eta2, xi):
+    def alpha1Fit(self, eta, eta2, xi):
         return (
             43.31514709695348
             + 638.6332679188081 * eta
@@ -830,7 +830,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def alpha2Fit(eta, eta2, xi):
+    def alpha2Fit(self, eta, eta2, xi):
         return (
             -0.07020209449091723
             - 0.16269798450687084 * eta
@@ -855,7 +855,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def alpha3Fit(eta, eta2, xi):
+    def alpha3Fit(self, eta, eta2, xi):
         return (
             9.5988072383479
             - 397.05438595557433 * eta
@@ -880,7 +880,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def alpha4Fit(eta, eta2, xi):
+    def alpha4Fit(self, eta, eta2, xi):
         return (
             -0.02989487384493607
             + 1.4022106448583738 * eta
@@ -905,7 +905,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def alpha5Fit(eta, eta2, xi):
+    def alpha5Fit(self, eta, eta2, xi):
         return (
             0.9974408278363099
             - 0.007884449714907203 * eta
@@ -930,7 +930,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def rho1_fun(eta, eta2, xi):
+    def rho1_fun(self, eta, eta2, xi):
         return (
             3931.8979897196696
             - 17395.758706812805 * eta
@@ -955,7 +955,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def rho2_fun(eta, eta2, xi):
+    def rho2_fun(self, eta, eta2, xi):
         return (
             -40105.47653771657
             + 112253.0169706701 * eta
@@ -980,7 +980,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def rho3_fun(eta, eta2, xi):
+    def rho3_fun(self, eta, eta2, xi):
         return (
             83208.35471266537
             - 191237.7264145924 * eta
@@ -1005,7 +1005,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def FinalSpin0815(eta, eta2, chi1, chi2):
+    def FinalSpin0815(self, eta, eta2, chi1, chi2):
         Seta = torch.sqrt(1.0 - 4.0 * eta)
         Seta = torch.nan_to_num(Seta)  # avoid nan around eta = 0.25
         m1 = 0.5 * (1.0 + Seta)
@@ -1030,7 +1030,7 @@ class IMRPhenomD(TaylorF2):
             * s
         )
 
-    def PhenomInternal_EradRational0815(eta, eta2, chi1, chi2):
+    def PhenomInternal_EradRational0815(self, eta, eta2, chi1, chi2):
         Seta = torch.sqrt(1.0 - 4.0 * eta)
         m1 = 0.5 * (1.0 + Seta)
         m2 = 0.5 * (1.0 - Seta)
@@ -1067,7 +1067,7 @@ class IMRPhenomD(TaylorF2):
             * s
         )
 
-    def AmpIntColFitCoeff(eta, eta2, xi):
+    def AmpIntColFitCoeff(self, eta, eta2, xi):
         return (
             0.8149838730507785
             + 2.5747553517454658 * eta
@@ -1092,7 +1092,7 @@ class IMRPhenomD(TaylorF2):
             * xi
         )
 
-    def delta_values(f1, f2, f3, v1, v2, v3, d1, d2):
+    def delta_values(self, f1, f2, f3, v1, v2, v3, d1, d2):
         f12 = f1 * f1
         f13 = f1 * f12
         f14 = f1 * f13
@@ -1358,7 +1358,7 @@ class IMRPhenomD(TaylorF2):
 
         return delta_0, delta_1, delta_2, delta_3, delta_4
 
-    def chiPN(Seta, eta, chi1, chi2):
+    def chiPN(self, Seta, eta, chi1, chi2):
         chi_s = chi1 + chi2
         chi_a = chi1 - chi2
 

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -1,8 +1,9 @@
 import torch
-from .taylorf2 import TaylorF2
 from torchtyping import TensorType
+
 from ..constants import MTSUN_SI, PI
 from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
+from .taylorf2 import TaylorF2
 
 
 class IMRPhenomD(TaylorF2):

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -9,9 +9,9 @@ from .taylorf2 import TaylorF2
 class IMRPhenomD(TaylorF2):
     def __init__(self):
         super().__init__()
-        self.register_buffer("QNMData_a", QNMData_a)
-        self.register_buffer("QNMData_fdamp", QNMData_fdamp)
-        self.register_buffer("QNMData_fring", QNMData_fring)
+        self.register_buffer("qnmdata_a", QNMData_a)
+        self.register_buffer("qnmdata_fdamp", QNMData_fdamp)
+        self.register_buffer("qnmdata_fring", QNMData_fring)
 
     def forward(
         self,
@@ -579,26 +579,37 @@ class IMRPhenomD(TaylorF2):
         )
         return res
 
+    def parse_buffers(self, recursive=False):
+        bufs = {}
+        for name, buf in self.named_buffers(recurse=recursive):
+            bufs[name] = buf
+        return bufs
+
     def _linear_interp_finspin(self, finspin):
         # chi is a batch of final spins i.e. torch.Size([n])
-        right_spin_idx = torch.bucketize(finspin, QNMData_a)
-        right_spin_val = QNMData_a[right_spin_idx]
+        buffers = self.parse_buffers()
+        qnmdata_a = buffers["qnmdata_a"]
+        qnmdata_fring = buffers["qnmdata_fring"]
+        qnmdata_fdamp = buffers["qnmdata_fdamp"]
+
+        right_spin_idx = torch.bucketize(finspin, qnmdata_a)
+        right_spin_val = qnmdata_a[right_spin_idx]
         # QNMData_a is sorted, hence take the previous index
         left_spin_idx = right_spin_idx - 1
-        left_spin_val = QNMData_a[left_spin_idx]
+        left_spin_val = qnmdata_a[left_spin_idx]
 
         if not torch.all(left_spin_val < right_spin_val):
             raise RuntimeError(
                 "Left value in grid should be greater than right. "
                 "Maybe be caused for extremal spin values."
             )
-        left_fring = QNMData_fring[left_spin_idx]
-        right_fring = QNMData_fring[right_spin_idx]
+        left_fring = qnmdata_fring[left_spin_idx]
+        right_fring = qnmdata_fring[right_spin_idx]
         slope_fring = right_fring - left_fring
         slope_fring /= right_spin_val - left_spin_val
 
-        left_fdamp = QNMData_fdamp[left_spin_idx]
-        right_fdamp = QNMData_fdamp[right_spin_idx]
+        left_fdamp = qnmdata_fdamp[left_spin_idx]
+        right_fdamp = qnmdata_fdamp[right_spin_idx]
         slope_fdamp = right_fdamp - left_fdamp
         slope_fdamp /= right_spin_val - left_spin_val
 

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -529,9 +529,9 @@ class IMRPhenomD(TaylorF2):
         ins_phasing, ins_Dphasing = self.taylorf2_phase(
             Mf, mass_1, mass_2, chi1, chi2
         )
-        # subtract 3PN spin-spin term as this is in LAL's TaylorF2 implementation,
-        #  but was not available when PhenomD was tuned.
-        # refer https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimIMRPhenomD.c#L397-398
+        # subtract 3PN spin-spin term as this is in LAL's TaylorF2
+        # implementation, but was not available when PhenomD was tuned.
+        # refer https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimIMRPhenomD.c#L397-398 # noqa: E501
         pn_ss3, Dpn_ss3 = self.subtract3PNSS(
             Mf, mass_1, mass_2, eta, eta2, xi, chi1, chi2
         )

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -265,7 +265,7 @@ class IMRPhenomPv2(IMRPhenomD):
     ):
         """
         m1, m2: in solar masses
-        phic: Orbital phase at the peak of the underlying non precessing model (rad)
+        phic: Orbital phase at the peak of the underlying non precessing model
         M: Total mass (Solar masses)
         """
 
@@ -315,13 +315,13 @@ class IMRPhenomPv2(IMRPhenomD):
         increasing sample points.
 
         Returns the one-dimensional piecewise linear interpolant to a function
-        with given discrete data points :math:`(xp, fp)`, evaluated at :math:`x`
+        with given discrete data points :math:`(xp, fp)` evaluated at :math:`x`
 
         Args:
             x: the :math:`x`-coordinates at which to evaluate the interpolated
                 values.
-            xp: the :math:`x`-coordinates of the data points, must be increasing.
-            fp: the :math:`y`-coordinates of the data points, same length as `xp`
+            xp: the :math:`x`-coordinates of data points, must be increasing.
+            fp: the :math:`y`-coordinates of data points, same length as `xp`
 
         Returns:
             the interpolated values, same size as `x`.
@@ -502,10 +502,10 @@ class IMRPhenomPv2(IMRPhenomD):
         return chi1_l, chi2_l, chip, thetaJN, alpha0, phi_aligned, zeta_polariz
 
     # TODO: add input and output types
-    def SpinWeightedY(self, theta, phi, s, l, m):
+    def SpinWeightedY(self, theta, phi, s, l, m):  # noqa: E741
         "copied from SphericalHarmonics.c in LAL"
         if s == -2:
-            if l == 2:
+            if l == 2:  # noqa: E741
                 if m == -2:
                     fac = (
                         torch.sqrt(torch.tensor(5.0 / (64.0 * PI)))

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -169,7 +169,8 @@ class IMRPhenomPv2(IMRPhenomD):
         m2 = q / (1.0 + q)  # Mass of the larger BH for unit total mass M=1.
         Sperp = chip * (
             m2 * m2
-        )  # Dimensionfull spin component in the orbital plane. S_perp = S_2_perp
+        )  # Dimensionfull spin component in the orbital plane.
+        # S_perp = S_2_perp
         # chi_eff = m1 * chi1_l + m2 * chi2_l  # effective spin for M=1
 
         SL = chi1_l * m1 * m1 + chi2_l * m2 * m2  # Dimensionfull aligned spin.
@@ -299,7 +300,9 @@ class IMRPhenomPv2(IMRPhenomD):
         diffRDphase = -diffRDphase[:, 50]
         # MfRD = torch.outer(M_s, fRD)
         # Dphase = torch.diag(
-        #     -self.phenom_d_phase(MfRD, m1, m2, eta, eta2, chi1, chi2, xi)[1] * M_s
+        #     -self.phenom_d_phase(
+        # MfRD, m1, m2, eta, eta2, chi1, chi2, xi
+        # )[1] * M_s
         # ).view(-1, 1)
         return hPhenom, diffRDphase
 
@@ -308,17 +311,17 @@ class IMRPhenomPv2(IMRPhenomD):
     def interpolate(
         self, x: TensorType, xp: TensorType, fp: TensorType
     ) -> TensorType:
-        """One-dimensional linear interpolation for monotonically increasing sample
-        points.
+        """One-dimensional linear interpolation for monotonically
+        increasing sample points.
 
-        Returns the one-dimensional piecewise linear interpolant to a function with
-        given discrete data points :math:`(xp, fp)`, evaluated at :math:`x`.
+        Returns the one-dimensional piecewise linear interpolant to a function
+        with given discrete data points :math:`(xp, fp)`, evaluated at :math:`x`
 
         Args:
             x: the :math:`x`-coordinates at which to evaluate the interpolated
                 values.
             xp: the :math:`x`-coordinates of the data points, must be increasing.
-            fp: the :math:`y`-coordinates of the data points, same length as `xp`.
+            fp: the :math:`y`-coordinates of the data points, same length as `xp`
 
         Returns:
             the interpolated values, same size as `x`.
@@ -426,7 +429,8 @@ class IMRPhenomPv2(IMRPhenomD):
         phi_aligned = -phiJ_sf
 
         # First we determine kappa
-        # in the source frame, the components of N are given in Eq (35c) of T1500606-v6
+        # in the source frame, the components of N are given in
+        # Eq (35c) of T1500606-v6
         Nx_sf = torch.sin(incl) * torch.cos(PI / 2.0 - phiRef)
         Ny_sf = torch.sin(incl) * torch.sin(PI / 2.0 - phiRef)
         Nz_sf = torch.cos(incl)
@@ -457,14 +461,17 @@ class IMRPhenomPv2(IMRPhenomD):
         thetaJN = torch.arccos(Nz_Jf)
 
         # Finally, we need to redefine the polarizations:
-        # PhenomP's polarizations are defined following Arun et al (arXiv:0810.5336)
-        # i.e. projecting the metric onto the P,Q,N triad defined with P=NxJ/|NxJ| (see (2.6) in there).
+        # PhenomP's polarizations are defined following Arun et al
+        # (arXiv:0810.5336)
+        # i.e. projecting the metric onto the P,Q,N triad defined with
+        # P=NxJ/|NxJ| (see (2.6) in there).
         # By contrast, the triad X,Y,N used in LAL
         # ("waveframe" in the nomenclature of T1500606-v6)
         # is defined in e.g. eq (35) of this document
-        # (via its components in the source frame; note we use the defautl Omega=Pi/2).
-        # Both triads differ from each other by a rotation around N by an angle \zeta
-        # and we need to rotate the polarizations accordingly by 2\zeta
+        # (via its components in the source frame;
+        # note we use the default Omega=Pi/2).
+        # Both triads differ from each other by a rotation around N by an angle
+        # \zeta and we need to rotate the polarizations accordingly by 2\zeta
 
         Xx_sf = -torch.cos(incl) * torch.sin(phiRef)
         Xy_sf = -torch.cos(incl) * torch.cos(phiRef)
@@ -476,7 +483,8 @@ class IMRPhenomPv2(IMRPhenomD):
 
         # Now the tmp_a are the components of X in the J frame
         # We need the polar angle of that vector in the P,Q basis of Arun et al
-        # P = NxJ/|NxJ| and since we put N in the (pos x)z half plane of the J frame
+        # P = NxJ/|NxJ| and since we put N in the (pos x)z half plane of the J
+        # frame
         PArunx_Jf = 0.0
         PAruny_Jf = -1.0
         PArunz_Jf = 0.0

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -5,15 +5,11 @@ from torchtyping import TensorType
 
 from ..constants import MPC_SEC, MTSUN_SI, PI
 from .phenom_d import IMRPhenomD
-from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
 
 
 class IMRPhenomPv2(IMRPhenomD):
     def __init__(self):
         super().__init__()
-        self.register_buffer("QNMData_a", QNMData_a)
-        self.register_buffer("QNMData_fring", QNMData_fring)
-        self.register_buffer("QNMData_fdamp", QNMData_fdamp)
 
     def forward(
         self,
@@ -719,10 +715,14 @@ class IMRPhenomPv2(IMRPhenomD):
         Erad = self.PhenomInternal_EradRational0815(
             eta_s, eta_s2, chi1_l, chi2_l
         )
-        fRD = self.interpolate(finspin, QNMData_a, QNMData_fring) / (
+        buffers = self.parse_buffers()
+        qnmdata_a = buffers["qnmdata_a"]
+        qnmdata_fring = buffers["qnmdata_fring"]
+        qnmdata_fdamp = buffers["qnmdata_fdamp"]
+        fRD = self.interpolate(finspin, qnmdata_a, qnmdata_fring) / (
             1.0 - Erad
         )
-        fdamp = self.interpolate(finspin, QNMData_a, QNMData_fdamp) / (
+        fdamp = self.interpolate(finspin, qnmdata_a, qnmdata_fdamp) / (
             1.0 - Erad
         )
         return fRD / M_s, fdamp / M_s

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -60,7 +60,7 @@ class IMRPhenomPv2(IMRPhenomD):
         eta = m1 * m2 / (M * M)
         eta2 = eta * eta
         Seta = torch.sqrt(1.0 - 4.0 * eta)
-        chi = self.chiPN(Seta, eta, chi1_l, chi2_l)
+        chi = self.chiPN(Seta, eta, chi2_l, chi1_l)
         chi22 = chi2_l * chi2_l
         chi12 = chi1_l * chi1_l
         xi = -1.0 + chi

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -1,0 +1,763 @@
+import torch
+from typing import Tuple
+from .phenom_d import IMRPhenomD
+from torchtyping import TensorType
+from ..constants import MTSUN_SI, PI, MPC_SEC
+from .phenom_d_data import QNMData_a, QNMData_fring, QNMData_fdamp
+
+
+class IMRPhenomPv2(IMRPhenomD):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("QNMData_a", QNMData_a)
+        self.register_buffer("QNMData_fring", QNMData_fring)
+        self.register_buffer("QNMData_fdamp", QNMData_fdamp)
+
+    def forward(
+        self,
+        fs: TensorType,
+        m1: TensorType,
+        m2: TensorType,
+        s1x: TensorType,
+        s1y: TensorType,
+        s1z: TensorType,
+        s2x: TensorType,
+        s2y: TensorType,
+        s2z: TensorType,
+        dist_mpc: TensorType,
+        tc: TensorType,
+        phiRef: TensorType,
+        incl: TensorType,
+        f_ref: TensorType,
+    ):
+        """
+        m1 must be larger than m2.
+        """
+
+        # # flip m1 m2. For some reason LAL uses this convention for PhenomPv2
+        m1, m2 = m2, m1
+        s1x, s2x = s2x, s1x
+        s1y, s2y = s2y, s1y
+        s1z, s2z = s2z, s1z
+
+        (
+            chi1_l,
+            chi2_l,
+            chip,
+            thetaJN,
+            alpha0,
+            phi_aligned,
+            zeta_polariz,
+        ) = self.convert_spins(
+            m1, m2, f_ref, phiRef, incl, s1x, s1y, s1z, s2x, s2y, s2z
+        )
+
+        phic = 2 * phi_aligned
+        q = m2 / m1  # q>=1
+        M = m1 + m2
+        chi_eff = (m1 * chi1_l + m2 * chi2_l) / M
+        chil = (1.0 + q) / q * chi_eff
+        eta = m1 * m2 / (M * M)
+        eta2 = eta * eta
+        Seta = torch.sqrt(1.0 - 4.0 * eta)
+        chi = self.chiPN(Seta, eta, chi1_l, chi2_l)
+        chi22 = chi2_l * chi2_l
+        chi12 = chi1_l * chi1_l
+        xi = -1.0 + chi
+        m_sec = M * MTSUN_SI
+        piM = PI * m_sec
+
+        omega_ref = piM * f_ref
+        logomega_ref = torch.log(omega_ref)
+        omega_ref_cbrt = (piM * f_ref) ** (1 / 3)  # == v0
+        omega_ref_cbrt2 = omega_ref_cbrt * omega_ref_cbrt
+
+        angcoeffs = self.ComputeNNLOanglecoeffs(q, chil, chip)
+
+        alphaNNLOoffset = (
+            angcoeffs["alphacoeff1"] / omega_ref
+            + angcoeffs["alphacoeff2"] / omega_ref_cbrt2
+            + angcoeffs["alphacoeff3"] / omega_ref_cbrt
+            + angcoeffs["alphacoeff4"] * logomega_ref
+            + angcoeffs["alphacoeff5"] * omega_ref_cbrt
+        )
+
+        epsilonNNLOoffset = (
+            angcoeffs["epsiloncoeff1"] / omega_ref
+            + angcoeffs["epsiloncoeff2"] / omega_ref_cbrt2
+            + angcoeffs["epsiloncoeff3"] / omega_ref_cbrt
+            + angcoeffs["epsiloncoeff4"] * logomega_ref
+            + angcoeffs["epsiloncoeff5"] * omega_ref_cbrt
+        )
+
+        Y2m2 = self.SpinWeightedY(thetaJN, 0, -2, 2, -2)
+        Y2m1 = self.SpinWeightedY(thetaJN, 0, -2, 2, -1)
+        Y20 = self.SpinWeightedY(thetaJN, 0, -2, 2, -0)
+        Y21 = self.SpinWeightedY(thetaJN, 0, -2, 2, 1)
+        Y22 = self.SpinWeightedY(thetaJN, 0, -2, 2, 2)
+        Y2 = torch.tensor([Y2m2, Y2m1, Y20, Y21, Y22])
+
+        hPhenomDs, Dphase = self.PhenomPOneFrequency(
+            fs,
+            m2,
+            m1,
+            eta,
+            eta2,
+            Seta,
+            chi2_l,
+            chi1_l,
+            chi12,
+            chi22,
+            chip,
+            phic,
+            M,
+            xi,
+            dist_mpc,
+        )
+
+        hp, hc = self.PhenomPCoreTwistUp(
+            fs,
+            hPhenomDs,
+            eta,
+            chi1_l,
+            chi2_l,
+            chip,
+            M,
+            angcoeffs,
+            Y2,
+            alphaNNLOoffset - alpha0,
+            epsilonNNLOoffset,
+        )
+        t0 = (Dphase) / (2 * PI)
+        phase_corr = torch.cos(2 * PI * fs * (t0)) - 1j * torch.sin(
+            2 * PI * fs * (t0)
+        )
+        M_s = (m1 + m2) * MTSUN_SI
+        phase_corr_tc = torch.exp(-1j * fs * M_s * tc)
+        hp *= phase_corr * phase_corr_tc
+        hc *= phase_corr * phase_corr_tc
+
+        c2z = torch.cos(2 * zeta_polariz)
+        s2z = torch.sin(2 * zeta_polariz)
+        hplus = c2z * hp + s2z * hc
+        hcross = c2z * hc - s2z * hp
+        return hplus, hcross
+
+    def PhenomPCoreTwistUp(
+        self,
+        fHz: TensorType,
+        hPhenom: TensorType,
+        eta: TensorType,
+        chi1_l: TensorType,
+        chi2_l: TensorType,
+        chip: TensorType,
+        M: TensorType,
+        angcoeffs: dict[str, TensorType],
+        Y2m: TensorType,
+        alphaoffset: TensorType,
+        epsilonoffset: TensorType,
+    ) -> Tuple[TensorType, TensorType]:
+        assert angcoeffs is not None
+        assert Y2m is not None
+        f = fHz * MTSUN_SI * M  # Frequency in geometric units
+        q = (1.0 + torch.sqrt(1.0 - 4.0 * eta) - 2.0 * eta) / (2.0 * eta)
+        m1 = 1.0 / (1.0 + q)  # Mass of the smaller BH for unit total mass M=1.
+        m2 = q / (1.0 + q)  # Mass of the larger BH for unit total mass M=1.
+        Sperp = chip * (
+            m2 * m2
+        )  # Dimensionfull spin component in the orbital plane. S_perp = S_2_perp
+        # chi_eff = m1 * chi1_l + m2 * chi2_l  # effective spin for M=1
+
+        SL = chi1_l * m1 * m1 + chi2_l * m2 * m2  # Dimensionfull aligned spin.
+
+        omega = PI * f
+        logomega = torch.log(omega)
+        omega_cbrt = (omega) ** (1 / 3)
+        omega_cbrt2 = omega_cbrt * omega_cbrt
+
+        alpha = (
+            angcoeffs["alphacoeff1"] / omega
+            + angcoeffs["alphacoeff2"] / omega_cbrt2
+            + angcoeffs["alphacoeff3"] / omega_cbrt
+            + angcoeffs["alphacoeff4"] * logomega
+            + angcoeffs["alphacoeff5"] * omega_cbrt
+        ) - alphaoffset
+
+        epsilon = (
+            angcoeffs["epsiloncoeff1"] / omega
+            + angcoeffs["epsiloncoeff2"] / omega_cbrt2
+            + angcoeffs["epsiloncoeff3"] / omega_cbrt
+            + angcoeffs["epsiloncoeff4"] * logomega
+            + angcoeffs["epsiloncoeff5"] * omega_cbrt
+        ) - epsilonoffset
+
+        cBetah, sBetah = self.WignerdCoefficients(omega_cbrt, SL, eta, Sperp)
+
+        cBetah2 = cBetah * cBetah
+        cBetah3 = cBetah2 * cBetah
+        cBetah4 = cBetah3 * cBetah
+        sBetah2 = sBetah * sBetah
+        sBetah3 = sBetah2 * sBetah
+        sBetah4 = sBetah3 * sBetah
+
+        hp_sum = 0
+        hc_sum = 0
+
+        cexp_i_alpha = torch.exp(1j * alpha)
+        cexp_2i_alpha = cexp_i_alpha * cexp_i_alpha
+        cexp_mi_alpha = 1.0 / cexp_i_alpha
+        cexp_m2i_alpha = cexp_mi_alpha * cexp_mi_alpha
+        T2m = (
+            cexp_2i_alpha * cBetah4 * Y2m[0]
+            - cexp_i_alpha * 2 * cBetah3 * sBetah * Y2m[1]
+            + 1 * torch.sqrt(torch.tensor(6)) * sBetah2 * cBetah2 * Y2m[2]
+            - cexp_mi_alpha * 2 * cBetah * sBetah3 * Y2m[3]
+            + cexp_m2i_alpha * sBetah4 * Y2m[4]
+        )
+        Tm2m = (
+            cexp_m2i_alpha * sBetah4 * torch.conj(Y2m[0])
+            + cexp_mi_alpha * 2 * cBetah * sBetah3 * torch.conj(Y2m[1])
+            + 1
+            * torch.sqrt(torch.tensor(6))
+            * sBetah2
+            * cBetah2
+            * torch.conj(Y2m[2])
+            + cexp_i_alpha * 2 * cBetah3 * sBetah * torch.conj(Y2m[3])
+            + cexp_2i_alpha * cBetah4 * torch.conj(Y2m[4])
+        )
+        hp_sum = T2m + Tm2m
+        hc_sum = 1j * (T2m - Tm2m)
+
+        eps_phase_hP = torch.exp(-2j * epsilon) * hPhenom / 2.0
+
+        hp = eps_phase_hP * hp_sum
+        hc = eps_phase_hP * hc_sum
+
+        return hp, hc
+
+    def PhenomPOneFrequency(
+        self,
+        fs,
+        m1,
+        m2,
+        eta,
+        eta2,
+        Seta,
+        chi1,
+        chi2,
+        chi12,
+        chi22,
+        chip,
+        phic,
+        M,
+        xi,
+        dist_mpc,
+    ):
+        """
+        m1, m2: in solar masses
+        phic: Orbital phase at the peak of the underlying non precessing model (rad)
+        M: Total mass (Solar masses)
+        """
+
+        M_s = M * MTSUN_SI
+        Mf = torch.outer(M_s, fs)
+        fRD, _ = self.phP_get_fRD_fdamp(m2, m1, chi2, chi1, chip)
+        MfRD = torch.outer(M_s, fRD)
+
+        phase, _ = self.phenom_d_phase(Mf, m1, m2, eta, eta2, chi1, chi2, xi)
+        Dphase = (
+            -self.phenom_d_phase(MfRD, m1, m2, eta, eta2, chi1, chi2, xi)[1]
+            * M_s
+        )
+        phase -= phic + PI / 4.0
+        Amp = self.phenom_d_amp(
+            Mf, m1, m2, eta, eta2, Seta, chi1, chi2, chi12, chi22, xi, dist_mpc
+        )[0]
+        Amp0 = self.get_Amp0(Mf, eta)
+        dist_s = dist_mpc * MPC_SEC
+        Amp = Amp0 * Amp * (M_s**2.0) / dist_s
+
+        # phase -= 2. * phic; # line 1316 ???
+        hPhenom = Amp * (torch.exp(-1j * phase))
+        return hPhenom, Dphase
+
+    # Utility functions
+
+    def interpolate(
+        self, x: TensorType, xp: TensorType, fp: TensorType
+    ) -> TensorType:
+        """One-dimensional linear interpolation for monotonically increasing sample
+        points.
+
+        Returns the one-dimensional piecewise linear interpolant to a function with
+        given discrete data points :math:`(xp, fp)`, evaluated at :math:`x`.
+
+        Args:
+            x: the :math:`x`-coordinates at which to evaluate the interpolated
+                values.
+            xp: the :math:`x`-coordinates of the data points, must be increasing.
+            fp: the :math:`y`-coordinates of the data points, same length as `xp`.
+
+        Returns:
+            the interpolated values, same size as `x`.
+        """
+        original_shape = x.shape
+        x = x.flatten()
+        xp = xp.flatten()
+        fp = fp.flatten()
+
+        m = (fp[1:] - fp[:-1]) / (xp[1:] - xp[:-1])  # slope
+        b = fp[:-1] - (m * xp[:-1])
+
+        indicies = torch.searchsorted(xp, x, right=False) - 1
+
+        interpolated = m[indicies] * x + b[indicies]
+
+        return interpolated.reshape(original_shape)
+
+    def ROTATEZ(self, angle: TensorType, x, y, z):
+        tmp_x = x * torch.cos(angle) - y * torch.sin(angle)
+        tmp_y = x * torch.sin(angle) + y * torch.cos(angle)
+        return tmp_x, tmp_y, z
+
+    def ROTATEY(self, angle, x, y, z):
+        tmp_x = x * torch.cos(angle) + z * torch.sin(angle)
+        tmp_z = -x * torch.sin(angle) + z * torch.cos(angle)
+        return tmp_x, y, tmp_z
+
+    def L2PNR(self, v: TensorType, eta: TensorType) -> TensorType:
+        eta2 = eta**2
+        x = v**2
+        x2 = x**2
+        tmp = (
+            eta
+            * (
+                1.0
+                + (1.5 + eta / 6.0) * x
+                + (3.375 - (19.0 * eta) / 8.0 - eta2 / 24.0) * x2
+            )
+        ) / x**0.5
+
+        return tmp
+
+    def convert_spins(
+        self,
+        m1: TensorType,
+        m2: TensorType,
+        f_ref: TensorType,
+        phiRef: TensorType,
+        incl: TensorType,
+        s1x: TensorType,
+        s1y: TensorType,
+        s1z: TensorType,
+        s2x: TensorType,
+        s2y: TensorType,
+        s2z: TensorType,
+    ) -> Tuple[
+        TensorType,
+        TensorType,
+        TensorType,
+        TensorType,
+        TensorType,
+        TensorType,
+        TensorType,
+    ]:
+        M = m1 + m2
+        m1_2 = m1 * m1
+        m2_2 = m2 * m2
+        eta = m1 * m2 / (M * M)  # Symmetric mass-ratio
+
+        # From the components in the source frame, we can easily determine
+        # chi1_l, chi2_l, chip and phi_aligned, which we need to return.
+        # We also compute the spherical angles of J,
+        # which we need to transform to the J frame
+
+        # Aligned spins
+        chi1_l = s1z  # Dimensionless aligned spin on BH 1
+        chi2_l = s2z  # Dimensionless aligned spin on BH 2
+
+        # Magnitude of the spin projections in the orbital plane
+        S1_perp = m1_2 * torch.sqrt(s1x**2 + s1y**2)
+        S2_perp = m2_2 * torch.sqrt(s2x**2 + s2y**2)
+
+        A1 = 2 + (3 * m2) / (2 * m1)
+        A2 = 2 + (3 * m1) / (2 * m2)
+        ASp1 = A1 * S1_perp
+        ASp2 = A2 * S2_perp
+        num = torch.maximum(ASp1, ASp2)
+        den = A2 * m2_2  # warning: this assumes m2 > m1
+        chip = num / den
+
+        m_sec = M * MTSUN_SI
+        piM = PI * m_sec
+        v_ref = (piM * f_ref) ** (1 / 3)
+        L0 = M * M * self.L2PNR(v_ref, eta)
+        J0x_sf = m1_2 * s1x + m2_2 * s2x
+        J0y_sf = m1_2 * s1y + m2_2 * s2y
+        J0z_sf = L0 + m1_2 * s1z + m2_2 * s2z
+        J0 = torch.sqrt(J0x_sf * J0x_sf + J0y_sf * J0y_sf + J0z_sf * J0z_sf)
+
+        thetaJ_sf = torch.arccos(J0z_sf / J0)
+
+        phiJ_sf = torch.arctan2(J0y_sf, J0x_sf)
+
+        phi_aligned = -phiJ_sf
+
+        # First we determine kappa
+        # in the source frame, the components of N are given in Eq (35c) of T1500606-v6
+        Nx_sf = torch.sin(incl) * torch.cos(PI / 2.0 - phiRef)
+        Ny_sf = torch.sin(incl) * torch.sin(PI / 2.0 - phiRef)
+        Nz_sf = torch.cos(incl)
+
+        tmp_x = Nx_sf
+        tmp_y = Ny_sf
+        tmp_z = Nz_sf
+
+        tmp_x, tmp_y, tmp_z = self.ROTATEZ(-phiJ_sf, tmp_x, tmp_y, tmp_z)
+        tmp_x, tmp_y, tmp_z = self.ROTATEY(-thetaJ_sf, tmp_x, tmp_y, tmp_z)
+
+        kappa = -torch.arctan2(tmp_y, tmp_x)
+
+        # Then we determine alpha0, by rotating LN
+        tmp_x, tmp_y, tmp_z = 0, 0, 1
+        tmp_x, tmp_y, tmp_z = self.ROTATEZ(-phiJ_sf, tmp_x, tmp_y, tmp_z)
+        tmp_x, tmp_y, tmp_z = self.ROTATEY(-thetaJ_sf, tmp_x, tmp_y, tmp_z)
+        tmp_x, tmp_y, tmp_z = self.ROTATEZ(kappa, tmp_x, tmp_y, tmp_z)
+
+        alpha0 = torch.arctan2(tmp_y, tmp_x)
+
+        # Finally we determine thetaJ, by rotating N
+        tmp_x, tmp_y, tmp_z = Nx_sf, Ny_sf, Nz_sf
+        tmp_x, tmp_y, tmp_z = self.ROTATEZ(-phiJ_sf, tmp_x, tmp_y, tmp_z)
+        tmp_x, tmp_y, tmp_z = self.ROTATEY(-thetaJ_sf, tmp_x, tmp_y, tmp_z)
+        tmp_x, tmp_y, tmp_z = self.ROTATEZ(kappa, tmp_x, tmp_y, tmp_z)
+        Nx_Jf, Nz_Jf = tmp_x, tmp_z
+        thetaJN = torch.arccos(Nz_Jf)
+
+        # Finally, we need to redefine the polarizations:
+        # PhenomP's polarizations are defined following Arun et al (arXiv:0810.5336)
+        # i.e. projecting the metric onto the P,Q,N triad defined with P=NxJ/|NxJ| (see (2.6) in there).
+        # By contrast, the triad X,Y,N used in LAL
+        # ("waveframe" in the nomenclature of T1500606-v6)
+        # is defined in e.g. eq (35) of this document
+        # (via its components in the source frame; note we use the defautl Omega=Pi/2).
+        # Both triads differ from each other by a rotation around N by an angle \zeta
+        # and we need to rotate the polarizations accordingly by 2\zeta
+
+        Xx_sf = -torch.cos(incl) * torch.sin(phiRef)
+        Xy_sf = -torch.cos(incl) * torch.cos(phiRef)
+        Xz_sf = torch.sin(incl)
+        tmp_x, tmp_y, tmp_z = Xx_sf, Xy_sf, Xz_sf
+        tmp_x, tmp_y, tmp_z = self.ROTATEZ(-phiJ_sf, tmp_x, tmp_y, tmp_z)
+        tmp_x, tmp_y, tmp_z = self.ROTATEY(-thetaJ_sf, tmp_x, tmp_y, tmp_z)
+        tmp_x, tmp_y, tmp_z = self.ROTATEZ(kappa, tmp_x, tmp_y, tmp_z)
+
+        # Now the tmp_a are the components of X in the J frame
+        # We need the polar angle of that vector in the P,Q basis of Arun et al
+        # P = NxJ/|NxJ| and since we put N in the (pos x)z half plane of the J frame
+        PArunx_Jf = 0.0
+        PAruny_Jf = -1.0
+        PArunz_Jf = 0.0
+
+        # Q = NxP
+        QArunx_Jf = Nz_Jf
+        QAruny_Jf = 0.0
+        QArunz_Jf = -Nx_Jf
+
+        # Calculate the dot products XdotPArun and XdotQArun
+        XdotPArun = tmp_x * PArunx_Jf + tmp_y * PAruny_Jf + tmp_z * PArunz_Jf
+        XdotQArun = tmp_x * QArunx_Jf + tmp_y * QAruny_Jf + tmp_z * QArunz_Jf
+
+        zeta_polariz = torch.arctan2(XdotQArun, XdotPArun)
+        return chi1_l, chi2_l, chip, thetaJN, alpha0, phi_aligned, zeta_polariz
+
+    # TODO: add input and output types
+    def SpinWeightedY(self, theta, phi, s, l, m):
+        "copied from SphericalHarmonics.c in LAL"
+        if s == -2:
+            if l == 2:
+                if m == -2:
+                    fac = (
+                        torch.sqrt(torch.tensor(5.0 / (64.0 * PI)))
+                        * (1.0 - torch.cos(theta))
+                        * (1.0 - torch.cos(theta))
+                    )
+                elif m == -1:
+                    fac = (
+                        torch.sqrt(torch.tensor(5.0 / (16.0 * PI)))
+                        * torch.sin(theta)
+                        * (1.0 - torch.cos(theta))
+                    )
+                elif m == 0:
+                    fac = (
+                        torch.sqrt(torch.tensor(15.0 / (32.0 * PI)))
+                        * torch.sin(theta)
+                        * torch.sin(theta)
+                    )
+                elif m == 1:
+                    fac = (
+                        torch.sqrt(torch.tensor(5.0 / (16.0 * PI)))
+                        * torch.sin(theta)
+                        * (1.0 + torch.cos(theta))
+                    )
+                elif m == 2:
+                    fac = (
+                        torch.sqrt(torch.tensor(5.0 / (64.0 * PI)))
+                        * (1.0 + torch.cos(theta))
+                        * (1.0 + torch.cos(theta))
+                    )
+                else:
+                    raise ValueError(
+                        f"Invalid mode s={s}, l={l}, m={m} - require |m| <= l"
+                    )
+                return fac * torch.complex(
+                    torch.cos(torch.tensor(m * phi)),
+                    torch.sin(torch.tensor(m * phi)),
+                )
+
+    def WignerdCoefficients(
+        self, v: TensorType, SL: TensorType, eta: TensorType, Sp: TensorType
+    ) -> Tuple[TensorType, TensorType]:
+        # We define the shorthand s := Sp / (L + SL)
+        L = self.L2PNR(v, eta)
+        s = Sp / (L + SL)
+        s2 = s**2
+        cos_beta = 1.0 / (1.0 + s2) ** 0.5
+        cos_beta_half = ((1.0 + cos_beta) / 2.0) ** 0.5  # cos(beta/2)
+        sin_beta_half = ((1.0 - cos_beta) / 2.0) ** 0.5  # sin(beta/2)
+
+        return cos_beta_half, sin_beta_half
+
+    def ComputeNNLOanglecoeffs(
+        self, q: TensorType, chil: TensorType, chip: TensorType
+    ) -> dict[str, TensorType]:
+        m2 = q / (1.0 + q)
+        m1 = 1.0 / (1.0 + q)
+        dm = m1 - m2
+        mtot = 1.0
+        eta = m1 * m2  # mtot = 1
+        eta2 = eta * eta
+        eta3 = eta2 * eta
+        eta4 = eta3 * eta
+        mtot2 = mtot * mtot
+        mtot4 = mtot2 * mtot2
+        mtot6 = mtot4 * mtot2
+        mtot8 = mtot6 * mtot2
+        chil2 = chil * chil
+        chip2 = chip * chip
+        chip4 = chip2 * chip2
+        dm2 = dm * dm
+        dm3 = dm2 * dm
+        m2_2 = m2 * m2
+        m2_3 = m2_2 * m2
+        m2_4 = m2_3 * m2
+        m2_5 = m2_4 * m2
+        m2_6 = m2_5 * m2
+        m2_7 = m2_6 * m2
+        m2_8 = m2_7 * m2
+
+        angcoeffs = {}
+        angcoeffs["alphacoeff1"] = -0.18229166666666666 - (5 * dm) / (
+            64.0 * m2
+        )
+
+        angcoeffs["alphacoeff2"] = (-15 * dm * m2 * chil) / (
+            128.0 * mtot2 * eta
+        ) - (35 * m2_2 * chil) / (128.0 * mtot2 * eta)
+
+        angcoeffs["alphacoeff3"] = (
+            -1.7952473958333333
+            - (4555 * dm) / (7168.0 * m2)
+            - (15 * chip2 * dm * m2_3) / (128.0 * mtot4 * eta2)
+            - (35 * chip2 * m2_4) / (128.0 * mtot4 * eta2)
+            - (515 * eta) / 384.0
+            - (15 * dm2 * eta) / (256.0 * m2_2)
+            - (175 * dm * eta) / (256.0 * m2)
+        )
+
+        angcoeffs["alphacoeff4"] = (
+            -(35 * PI) / 48.0
+            - (5 * dm * PI) / (16.0 * m2)
+            + (5 * dm2 * chil) / (16.0 * mtot2)
+            + (5 * dm * m2 * chil) / (3.0 * mtot2)
+            + (2545 * m2_2 * chil) / (1152.0 * mtot2)
+            - (5 * chip2 * dm * m2_5 * chil) / (128.0 * mtot6 * eta3)
+            - (35 * chip2 * m2_6 * chil) / (384.0 * mtot6 * eta3)
+            + (2035 * dm * m2 * chil) / (21504.0 * mtot2 * eta)
+            + (2995 * m2_2 * chil) / (9216.0 * mtot2 * eta)
+        )
+
+        angcoeffs["alphacoeff5"] = (
+            4.318908476114694
+            + (27895885 * dm) / (2.1676032e7 * m2)
+            - (15 * chip4 * dm * m2_7) / (512.0 * mtot8 * eta4)
+            - (35 * chip4 * m2_8) / (512.0 * mtot8 * eta4)
+            - (485 * chip2 * dm * m2_3) / (14336.0 * mtot4 * eta2)
+            + (475 * chip2 * m2_4) / (6144.0 * mtot4 * eta2)
+            + (15 * chip2 * dm2 * m2_2) / (256.0 * mtot4 * eta)
+            + (145 * chip2 * dm * m2_3) / (512.0 * mtot4 * eta)
+            + (575 * chip2 * m2_4) / (1536.0 * mtot4 * eta)
+            + (39695 * eta) / 86016.0
+            + (1615 * dm2 * eta) / (28672.0 * m2_2)
+            - (265 * dm * eta) / (14336.0 * m2)
+            + (955 * eta2) / 576.0
+            + (15 * dm3 * eta2) / (1024.0 * m2_3)
+            + (35 * dm2 * eta2) / (256.0 * m2_2)
+            + (2725 * dm * eta2) / (3072.0 * m2)
+            - (15 * dm * m2 * PI * chil) / (16.0 * mtot2 * eta)
+            - (35 * m2_2 * PI * chil) / (16.0 * mtot2 * eta)
+            + (15 * chip2 * dm * m2_7 * chil2) / (128.0 * mtot8 * eta4)
+            + (35 * chip2 * m2_8 * chil2) / (128.0 * mtot8 * eta4)
+            + (375 * dm2 * m2_2 * chil2) / (256.0 * mtot4 * eta)
+            + (1815 * dm * m2_3 * chil2) / (256.0 * mtot4 * eta)
+            + (1645 * m2_4 * chil2) / (192.0 * mtot4 * eta)
+        )
+
+        angcoeffs["epsiloncoeff1"] = -0.18229166666666666 - (5 * dm) / (
+            64.0 * m2
+        )
+        angcoeffs["epsiloncoeff2"] = (-15 * dm * m2 * chil) / (
+            128.0 * mtot2 * eta
+        ) - (35 * m2_2 * chil) / (128.0 * mtot2 * eta)
+        angcoeffs["epsiloncoeff3"] = (
+            -1.7952473958333333
+            - (4555 * dm) / (7168.0 * m2)
+            - (515 * eta) / 384.0
+            - (15 * dm2 * eta) / (256.0 * m2_2)
+            - (175 * dm * eta) / (256.0 * m2)
+        )
+        angcoeffs["epsiloncoeff4"] = (
+            -(35 * PI) / 48.0
+            - (5 * dm * PI) / (16.0 * m2)
+            + (5 * dm2 * chil) / (16.0 * mtot2)
+            + (5 * dm * m2 * chil) / (3.0 * mtot2)
+            + (2545 * m2_2 * chil) / (1152.0 * mtot2)
+            + (2035 * dm * m2 * chil) / (21504.0 * mtot2 * eta)
+            + (2995 * m2_2 * chil) / (9216.0 * mtot2 * eta)
+        )
+        angcoeffs["epsiloncoeff5"] = (
+            4.318908476114694
+            + (27895885 * dm) / (2.1676032e7 * m2)
+            + (39695 * eta) / 86016.0
+            + (1615 * dm2 * eta) / (28672.0 * m2_2)
+            - (265 * dm * eta) / (14336.0 * m2)
+            + (955 * eta2) / 576.0
+            + (15 * dm3 * eta2) / (1024.0 * m2_3)
+            + (35 * dm2 * eta2) / (256.0 * m2_2)
+            + (2725 * dm * eta2) / (3072.0 * m2)
+            - (15 * dm * m2 * PI * chil) / (16.0 * mtot2 * eta)
+            - (35 * m2_2 * PI * chil) / (16.0 * mtot2 * eta)
+            + (375 * dm2 * m2_2 * chil2) / (256.0 * mtot4 * eta)
+            + (1815 * dm * m2_3 * chil2) / (256.0 * mtot4 * eta)
+            + (1645 * m2_4 * chil2) / (192.0 * mtot4 * eta)
+        )
+        return angcoeffs
+
+    def FinalSpin_inplane(
+        self,
+        m1: TensorType,
+        m2: TensorType,
+        chi1_l: TensorType,
+        chi2_l: TensorType,
+        chip: TensorType,
+    ) -> TensorType:
+        M = m1 + m2
+        eta = m1 * m2 / (M * M)
+        eta2 = eta * eta
+        if m1 >= m2:
+            q_factor = m1 / M
+            af_parallel = self.FinalSpin0815(eta, eta2, chi1_l, chi2_l)
+        else:
+            q_factor = m2 / M
+            af_parallel = self.FinalSpin0815(eta, eta2, chi2_l, chi1_l)
+        Sperp = chip * q_factor * q_factor
+        af = torch.copysign(
+            torch.ones_like(af_parallel), af_parallel
+        ) * torch.sqrt(Sperp * Sperp + af_parallel * af_parallel)
+        return af
+
+    def phP_get_fRD_fdamp(
+        self, m1, m2, chi1_l, chi2_l, chip
+    ) -> Tuple[TensorType, TensorType]:
+        # m1 > m2 should hold here
+        finspin = self.FinalSpin_inplane(m1, m2, chi1_l, chi2_l, chip)
+        m1_s = m1 * MTSUN_SI
+        m2_s = m2 * MTSUN_SI
+        M_s = m1_s + m2_s
+        eta_s = m1_s * m2_s / (M_s**2.0)
+        eta_s2 = eta_s * eta_s
+        Erad = self.PhenomInternal_EradRational0815(
+            eta_s, eta_s2, chi1_l, chi2_l
+        )
+        fRD = self.interpolate(finspin, QNMData_a, QNMData_fring) / (
+            1.0 - Erad
+        )
+        fdamp = self.interpolate(finspin, QNMData_a, QNMData_fdamp) / (
+            1.0 - Erad
+        )
+        return fRD / M_s, fdamp / M_s
+
+    def phP_get_transition_frequencies(
+        self,
+        theta: TensorType,
+        gamma2: TensorType,
+        gamma3: TensorType,
+        chip: TensorType,
+    ) -> Tuple[
+        TensorType, TensorType, TensorType, TensorType, TensorType, TensorType
+    ]:
+        # m1 > m2 should hold here
+
+        m1, m2, chi1, chi2 = theta
+        M = m1 + m2
+        f_RD, f_damp = self.phP_get_fRD_fdamp(m1, m2, chi1, chi2, chip)
+
+        # Phase transition frequencies
+        f1 = 0.018 / (M * MTSUN_SI)
+        f2 = 0.5 * f_RD
+
+        # Amplitude transition frequencies
+        f3 = 0.014 / (M * MTSUN_SI)
+
+        def f4_gammaneg_gtr_1(
+            f_RD_: TensorType,
+            f_damp_: TensorType,
+            gamma3_: TensorType,
+            gamma2_: TensorType,
+        ) -> TensorType:
+            return torch.abs(f_RD_ + (-f_damp_ * gamma3_) / gamma2_)
+
+        def f4_gammaneg_less_1(
+            f_RD_: TensorType,
+            f_damp_: TensorType,
+            gamma3_: TensorType,
+            gamma2_: TensorType,
+        ) -> TensorType:
+            return torch.abs(
+                f_RD_
+                + (f_damp_ * (-1 + torch.sqrt(1 - (gamma2_) ** 2.0)) * gamma3_)
+                / gamma2_
+            )
+
+        f4 = torch.tensor(
+            torch.cond(
+                gamma2 >= 1,
+                f4_gammaneg_gtr_1,
+                f4_gammaneg_less_1,
+                (
+                    f_RD,
+                    f_damp,
+                    gamma3,
+                    gamma2,
+                ),
+            )
+        )
+        return f1, f2, f3, f4, f_RD, f_damp
+
+    def get_Amp0(self, fM_s: TensorType, eta: TensorType) -> TensorType:
+        Amp0 = (
+            (2.0 / 3.0 * eta) ** (1.0 / 2.0)
+            * (fM_s) ** (-7.0 / 6.0)
+            * PI ** (-1.0 / 6.0)
+        )
+        return Amp0

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -1,9 +1,11 @@
-import torch
 from typing import Tuple
-from .phenom_d import IMRPhenomD
+
+import torch
 from torchtyping import TensorType
-from ..constants import MTSUN_SI, PI, MPC_SEC
-from .phenom_d_data import QNMData_a, QNMData_fring, QNMData_fdamp
+
+from ..constants import MPC_SEC, MTSUN_SI, PI
+from .phenom_d import IMRPhenomD
+from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
 
 
 class IMRPhenomPv2(IMRPhenomD):

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -1,22 +1,6 @@
 import torch
 from torchtyping import TensorType
-
-GAMMA = 0.577215664901532860606512090082402431
-"""Euler-Mascheroni constant. Same as lal.GAMMA"""
-
-MSUN_SI = 1.988409870698050731911960804878414216e30
-"""Solar mass in kg. Same as lal.MSUN_SI"""
-
-MTSUN_SI = 4.925490947641266978197229498498379006e-6
-"""1 solar mass in seconds. Same value as lal.MTSUN_SI"""
-
-PI = 3.141592653589793238462643383279502884
-"""Archimedes constant. Same as lal.PI"""
-
-MPC_SEC = 1.02927125e14
-"""
-1 Mpc in seconds.
-"""
+from ..constants import GAMMA, MTSUN_SI, PI, MPC_SEC
 
 
 class TaylorF2(torch.nn.Module):

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -1,6 +1,6 @@
 import torch
 from torchtyping import TensorType
-from ..constants import GAMMA, MTSUN_SI, PI, MPC_SEC
+from ..constants import EulerGamma as GAMMA, MTSUN_SI, PI, MPC_SEC
 
 
 class TaylorF2(torch.nn.Module):

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -40,7 +40,7 @@ class TaylorF2(torch.nn.Module):
         pfac = 0.5 * (1.0 + cfac * cfac)
 
         htilde = self.taylorf2_htilde(
-            self, f, mass1, mass2, chi1, chi2, distance, phic, f_ref
+            f, mass1, mass2, chi1, chi2, distance, phic, f_ref
         )
 
         hp = (htilde.T * pfac).T

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -78,7 +78,7 @@ class TaylorF2(torch.nn.Module):
         return h0
 
     def taylorf2_amplitude(
-        Mf: TensorType, mass1, mass2, eta, distance
+        self, Mf: TensorType, mass1, mass2, eta, distance
     ) -> TensorType:
         mass1_s = mass1 * MTSUN_SI
         mass2_s = mass2 * MTSUN_SI
@@ -100,6 +100,7 @@ class TaylorF2(torch.nn.Module):
         return amp
 
     def taylorf2_phase(
+        self,
         Mf: TensorType,
         mass1: TensorType,
         mass2: TensorType,

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -1,6 +1,8 @@
 import torch
 from torchtyping import TensorType
-from ..constants import EulerGamma as GAMMA, MTSUN_SI, PI, MPC_SEC
+
+from ..constants import MPC_SEC, MTSUN_SI, PI
+from ..constants import EulerGamma as GAMMA
 
 
 class TaylorF2(torch.nn.Module):

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -19,288 +19,297 @@ MPC_SEC = 1.02927125e14
 """
 
 
-def taylorf2_phase(
-    Mf: TensorType,
-    mass1: TensorType,
-    mass2: TensorType,
-    chi1: TensorType,
-    chi2: TensorType,
-) -> TensorType:
-    """
-    Calculate the inspiral phase for the TaylorF2.
-    """
-    M = mass1 + mass2
-    eta = mass1 * mass2 / M / M
-    m1byM = mass1 / M
-    m2byM = mass2 / M
-    chi1sq = chi1 * chi1
-    chi2sq = chi2 * chi2
+class TaylorF2(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
 
-    v0 = torch.ones_like(Mf)
-    v1 = (PI * Mf) ** (1.0 / 3.0)
-    v2 = v1 * v1
-    v3 = v2 * v1
-    v4 = v3 * v1
-    v5 = v4 * v1
-    v6 = v5 * v1
-    v7 = v6 * v1
-    logv = torch.log(v1)
-    v5_logv = v5 * logv
-    v6_logv = v6 * logv
-
-    # Phase coeffeciencts from https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimInspiralPNCoefficients.c  # noqa E501
-    pfaN = 3.0 / (128.0 * eta)
-    pfa_v0 = 1.0
-    pfa_v1 = 0.0
-    pfa_v2 = 5.0 * (74.3 / 8.4 + 11.0 * eta) / 9.0
-    pfa_v3 = -16.0 * PI
-    # SO contributions at 1.5 PN
-    pfa_v3 += (
-        m1byM * (25.0 + 38.0 / 3.0 * m1byM) * chi1
-        + m2byM * (25.0 + 38.0 / 3.0 * m2byM) * chi2
-    )
-    pfa_v4 = (
-        5.0
-        * (3058.673 / 7.056 + 5429.0 / 7.0 * eta + 617.0 * eta * eta)
-        / 72.0
-    )
-    # SO, SS, S1,2-squared contributions
-    pfa_v4 += (
-        247.0 / 4.8 * eta * chi1 * chi2
-        + -721.0 / 4.8 * eta * chi1 * chi2
-        + (-720.0 / 9.6 * m1byM * m1byM + 1.0 / 9.6 * m1byM * m1byM) * chi1sq
-        + (-720.0 / 9.6 * m2byM * m2byM + 1.0 / 9.6 * m2byM * m2byM) * chi2sq
-        + (240.0 / 9.6 * m1byM * m1byM + -7.0 / 9.6 * m1byM * m1byM) * chi1sq
-        + (240.0 / 9.6 * m2byM * m2byM + -7.0 / 9.6 * m2byM * m2byM) * chi2sq
-    )
-    pfa_v5logv = 5.0 / 3.0 * (772.9 / 8.4 - 13.0 * eta) * PI
-    pfa_v5 = 5.0 / 9.0 * (772.9 / 8.4 - 13.0 * eta) * PI
-    # SO coefficient for 2.5 PN
-    pfa_v5logv += 3.0 * (
-        -m1byM
-        * (
-            1391.5 / 8.4
-            - 10.0 / 3.0 * m1byM * (1.0 - m1byM)
-            + m1byM * (1276.0 / 8.1 + 170.0 / 9.0 * m1byM * (1.0 - m1byM))
-        )
-        * chi1
-        - m2byM
-        * (
-            1391.5 / 8.4
-            - 10.0 / 3.0 * m2byM * (1.0 - m2byM)
-            + m2byM * (1276.0 / 8.1 + 170.0 / 9.0 * m2byM * (1.0 - m2byM))
-        )
-        * chi2
-    )
-    pfa_v5 += (
-        -m1byM
-        * (
-            1391.5 / 8.4
-            - 10.0 / 3.0 * m1byM * (1.0 - m1byM)
-            + m1byM * (1276.0 / 8.1 + 170.0 / 9.0 * m1byM * (1.0 - m1byM))
-        )
-        * chi1
-        + -m2byM
-        * (
-            1391.5 / 8.4
-            - 10.0 / 3.0 * m2byM * (1.0 - m2byM)
-            + m2byM * (1276.0 / 8.1 + 170.0 / 9.0 * m2byM * (1.0 - m2byM))
-        )
-        * chi2
-    )
-    pfa_v6logv = -684.8 / 2.1
-    pfa_v6 = (
-        11583.231236531 / 4.694215680
-        - 640.0 / 3.0 * PI * PI
-        - 684.8 / 2.1 * GAMMA
-        + eta * (-15737.765635 / 3.048192 + 225.5 / 1.2 * PI * PI)
-        + eta * eta * 76.055 / 1.728
-        - eta * eta * eta * 127.825 / 1.296
-        + pfa_v6logv * torch.log(torch.tensor(4.0))
-    )
-    # SO + S1-S2 + S-squared contribution at 3 PN
-    pfa_v6 += (
-        PI * m1byM * (1490.0 / 3.0 + m1byM * 260.0) * chi1
-        + PI * m2byM * (1490.0 / 3.0 + m2byM * 260.0) * chi2
-        + (326.75 / 1.12 + 557.5 / 1.8 * eta) * eta * chi1 * chi2
-        + (
-            (4703.5 / 8.4 + 2935.0 / 6.0 * m1byM - 120.0 * m1byM * m1byM)
-            * m1byM
-            * m1byM
-            + (
-                -4108.25 / 6.72
-                - 108.5 / 1.2 * m1byM
-                + 125.5 / 3.6 * m1byM * m1byM
-            )
-            * m1byM
-            * m1byM
-        )
-        * chi1sq
-        + (
-            (4703.5 / 8.4 + 2935.0 / 6.0 * m2byM - 120.0 * m2byM * m2byM)
-            * m2byM
-            * m2byM
-            + (
-                -4108.25 / 6.72
-                - 108.5 / 1.2 * m2byM
-                + 125.5 / 3.6 * m2byM * m2byM
-            )
-            * m2byM
-            * m2byM
-        )
-        * chi2sq
-    )
-    pfa_v7 = PI * (
-        770.96675 / 2.54016 + 378.515 / 1.512 * eta - 740.45 / 7.56 * eta * eta
-    )
-    # SO contribution at 3.5 PN
-    pfa_v7 += (
-        m1byM
-        * (
-            -17097.8035 / 4.8384
-            + eta * 28764.25 / 6.72
-            + eta * eta * 47.35 / 1.44
-            + m1byM
-            * (
-                -7189.233785 / 1.524096
-                + eta * 458.555 / 3.024
-                - eta * eta * 534.5 / 7.2
-            )
-        )
-    ) * chi1 + (
-        m2byM
-        * (
-            -17097.8035 / 4.8384
-            + eta * 28764.25 / 6.72
-            + eta * eta * 47.35 / 1.44
-            + m2byM
-            * (
-                -7189.233785 / 1.524096
-                + eta * 458.555 / 3.024
-                - eta * eta * 534.5 / 7.2
-            )
-        )
-    ) * chi2
-    # construct power series
-    phasing = (v7.T * pfa_v7).T
-    phasing += (v6.T * pfa_v6 + v6_logv.T * pfa_v6logv).T
-    phasing += (v5.T * pfa_v5 + v5_logv.T * pfa_v5logv).T
-    phasing += (v4.T * pfa_v4).T
-    phasing += (v3.T * pfa_v3).T
-    phasing += (v2.T * pfa_v2).T
-    phasing += (v1.T * pfa_v1).T
-    phasing += (v0.T * pfa_v0).T
-    # Divide by 0PN v-dependence
-    phasing /= v5
-    # Multiply by 0PN coefficient
-    phasing = (phasing.T * pfaN).T
-
-    # Derivative of phase w.r.t Mf
-    # dPhi/dMf = dPhi/dv dv/dMf
-    Dphasing = (2.0 * v7.T * pfa_v7).T
-    Dphasing += (v6.T * (pfa_v6 + pfa_v6logv)).T
-    Dphasing += (v6_logv.T * pfa_v6logv).T
-    Dphasing += (v5.T * pfa_v5logv).T
-    Dphasing += (-1.0 * v4.T * pfa_v4).T
-    Dphasing += (-2.0 * v3.T * pfa_v3).T
-    Dphasing += (-3.0 * v2.T * pfa_v2).T
-    Dphasing += (-4.0 * v1.T * pfa_v1).T
-    Dphasing += -5.0 * v0
-    Dphasing /= 3.0 * v1 * v7
-    Dphasing *= PI
-    Dphasing = (Dphasing.T * pfaN).T
-
-    return phasing, Dphasing
-
-
-def taylorf2_amplitude(
-    Mf: TensorType, mass1, mass2, eta, distance
-) -> TensorType:
-    mass1_s = mass1 * MTSUN_SI
-    mass2_s = mass2 * MTSUN_SI
-    v = (PI * Mf) ** (1.0 / 3.0)
-    v10 = v**10
-
-    # Flux and energy coefficient at newtonian
-    FTaN = 32.0 * eta * eta / 5.0
-    dETaN = 2 * (-eta / 2.0)
-
-    amp0 = -4.0 * mass1_s * mass2_s * (PI / 12.0) ** 0.5
-
-    amp0 /= distance * MPC_SEC
-    flux = (v10.T * FTaN).T
-    dEnergy = (v.T * dETaN).T
-    amp = torch.sqrt(-dEnergy / flux) * v
-    amp = (amp.T * amp0).T
-
-    return amp
-
-
-def taylorf2_htilde(
-    f: TensorType,
-    mass1: TensorType,
-    mass2: TensorType,
-    chi1: TensorType,
-    chi2: TensorType,
-    distance: TensorType,
-    phic: TensorType,
-    f_ref: float,
-):
-    mass1_s = mass1 * MTSUN_SI
-    mass2_s = mass2 * MTSUN_SI
-    M_s = mass1_s + mass2_s
-    eta = mass1_s * mass2_s / M_s / M_s
-
-    Mf = torch.outer(M_s, f)
-    Mf_ref = torch.outer(M_s, f_ref * torch.ones_like(f))
-
-    Psi, _ = taylorf2_phase(Mf, mass1, mass2, chi1, chi2)
-    Psi_ref, _ = taylorf2_phase(Mf_ref, mass1, mass2, chi1, chi2)
-
-    Psi = (Psi.T - 2 * phic).T
-    Psi -= Psi_ref
-
-    amp0 = taylorf2_amplitude(Mf, mass1, mass2, eta, distance)
-    h0 = amp0 * torch.exp(-1j * (Psi - PI / 4))
-    return h0
-
-
-def TaylorF2(
-    f: TensorType,
-    mass1: TensorType,
-    mass2: TensorType,
-    chi1: TensorType,
-    chi2: TensorType,
-    distance: TensorType,
-    phic: TensorType,
-    inclination: TensorType,
-    f_ref: float,
-):
-    """
-    TaylorF2 up to 3.5 PN in phase. Newtonian SPA amplitude.
-
-    Returns:
-    --------
-      hp, hc
-    """
-    # shape assumed (n_batch, params)
-    if (
-        mass1.shape[0] != mass2.shape[0]
-        or mass2.shape[0] != chi1.shape[0]
-        or chi1.shape[0] != chi2.shape[0]
-        or chi2.shape[0] != distance.shape[0]
-        or distance.shape[0] != phic.shape[0]
-        or phic.shape[0] != inclination.shape[0]
+    def forward(
+        self,
+        f: TensorType,
+        mass1: TensorType,
+        mass2: TensorType,
+        chi1: TensorType,
+        chi2: TensorType,
+        distance: TensorType,
+        phic: TensorType,
+        inclination: TensorType,
+        f_ref: float,
     ):
-        raise RuntimeError("Tensors should have same batch size")
-    cfac = torch.cos(inclination)
-    pfac = 0.5 * (1.0 + cfac * cfac)
+        """
+        TaylorF2 up to 3.5 PN in phase. Newtonian SPA amplitude.
 
-    htilde = taylorf2_htilde(
-        f, mass1, mass2, chi1, chi2, distance, phic, f_ref
-    )
+        Returns:
+        --------
+        hp, hc
+        """
+        # shape assumed (n_batch, params)
+        if (
+            mass1.shape[0] != mass2.shape[0]
+            or mass2.shape[0] != chi1.shape[0]
+            or chi1.shape[0] != chi2.shape[0]
+            or chi2.shape[0] != distance.shape[0]
+            or distance.shape[0] != phic.shape[0]
+            or phic.shape[0] != inclination.shape[0]
+        ):
+            raise RuntimeError("Tensors should have same batch size")
+        cfac = torch.cos(inclination)
+        pfac = 0.5 * (1.0 + cfac * cfac)
 
-    hp = (htilde.T * pfac).T
-    hc = -1j * (htilde.T * cfac).T
+        htilde = self.taylorf2_htilde(
+            self, f, mass1, mass2, chi1, chi2, distance, phic, f_ref
+        )
 
-    return hp, hc
+        hp = (htilde.T * pfac).T
+        hc = -1j * (htilde.T * cfac).T
+
+        return hp, hc
+
+    def taylorf2_htilde(
+        self,
+        f: TensorType,
+        mass1: TensorType,
+        mass2: TensorType,
+        chi1: TensorType,
+        chi2: TensorType,
+        distance: TensorType,
+        phic: TensorType,
+        f_ref: float,
+    ):
+        mass1_s = mass1 * MTSUN_SI
+        mass2_s = mass2 * MTSUN_SI
+        M_s = mass1_s + mass2_s
+        eta = mass1_s * mass2_s / M_s / M_s
+
+        Mf = torch.outer(M_s, f)
+        Mf_ref = torch.outer(M_s, f_ref * torch.ones_like(f))
+
+        Psi, _ = self.taylorf2_phase(Mf, mass1, mass2, chi1, chi2)
+        Psi_ref, _ = self.taylorf2_phase(Mf_ref, mass1, mass2, chi1, chi2)
+
+        Psi = (Psi.T - 2 * phic).T
+        Psi -= Psi_ref
+
+        amp0 = self.taylorf2_amplitude(Mf, mass1, mass2, eta, distance)
+        h0 = amp0 * torch.exp(-1j * (Psi - PI / 4))
+        return h0
+
+    def taylorf2_amplitude(
+        Mf: TensorType, mass1, mass2, eta, distance
+    ) -> TensorType:
+        mass1_s = mass1 * MTSUN_SI
+        mass2_s = mass2 * MTSUN_SI
+        v = (PI * Mf) ** (1.0 / 3.0)
+        v10 = v**10
+
+        # Flux and energy coefficient at newtonian
+        FTaN = 32.0 * eta * eta / 5.0
+        dETaN = 2 * (-eta / 2.0)
+
+        amp0 = -4.0 * mass1_s * mass2_s * (PI / 12.0) ** 0.5
+
+        amp0 /= distance * MPC_SEC
+        flux = (v10.T * FTaN).T
+        dEnergy = (v.T * dETaN).T
+        amp = torch.sqrt(-dEnergy / flux) * v
+        amp = (amp.T * amp0).T
+
+        return amp
+
+    def taylorf2_phase(
+        Mf: TensorType,
+        mass1: TensorType,
+        mass2: TensorType,
+        chi1: TensorType,
+        chi2: TensorType,
+    ) -> TensorType:
+        """
+        Calculate the inspiral phase for the TaylorF2.
+        """
+        M = mass1 + mass2
+        eta = mass1 * mass2 / M / M
+        m1byM = mass1 / M
+        m2byM = mass2 / M
+        chi1sq = chi1 * chi1
+        chi2sq = chi2 * chi2
+
+        v0 = torch.ones_like(Mf)
+        v1 = (PI * Mf) ** (1.0 / 3.0)
+        v2 = v1 * v1
+        v3 = v2 * v1
+        v4 = v3 * v1
+        v5 = v4 * v1
+        v6 = v5 * v1
+        v7 = v6 * v1
+        logv = torch.log(v1)
+        v5_logv = v5 * logv
+        v6_logv = v6 * logv
+
+        # Phase coeffeciencts from https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimInspiralPNCoefficients.c  # noqa E501
+        pfaN = 3.0 / (128.0 * eta)
+        pfa_v0 = 1.0
+        pfa_v1 = 0.0
+        pfa_v2 = 5.0 * (74.3 / 8.4 + 11.0 * eta) / 9.0
+        pfa_v3 = -16.0 * PI
+        # SO contributions at 1.5 PN
+        pfa_v3 += (
+            m1byM * (25.0 + 38.0 / 3.0 * m1byM) * chi1
+            + m2byM * (25.0 + 38.0 / 3.0 * m2byM) * chi2
+        )
+        pfa_v4 = (
+            5.0
+            * (3058.673 / 7.056 + 5429.0 / 7.0 * eta + 617.0 * eta * eta)
+            / 72.0
+        )
+        # SO, SS, S1,2-squared contributions
+        pfa_v4 += (
+            247.0 / 4.8 * eta * chi1 * chi2
+            + -721.0 / 4.8 * eta * chi1 * chi2
+            + (-720.0 / 9.6 * m1byM * m1byM + 1.0 / 9.6 * m1byM * m1byM)
+            * chi1sq
+            + (-720.0 / 9.6 * m2byM * m2byM + 1.0 / 9.6 * m2byM * m2byM)
+            * chi2sq
+            + (240.0 / 9.6 * m1byM * m1byM + -7.0 / 9.6 * m1byM * m1byM)
+            * chi1sq
+            + (240.0 / 9.6 * m2byM * m2byM + -7.0 / 9.6 * m2byM * m2byM)
+            * chi2sq
+        )
+        pfa_v5logv = 5.0 / 3.0 * (772.9 / 8.4 - 13.0 * eta) * PI
+        pfa_v5 = 5.0 / 9.0 * (772.9 / 8.4 - 13.0 * eta) * PI
+        # SO coefficient for 2.5 PN
+        pfa_v5logv += 3.0 * (
+            -m1byM
+            * (
+                1391.5 / 8.4
+                - 10.0 / 3.0 * m1byM * (1.0 - m1byM)
+                + m1byM * (1276.0 / 8.1 + 170.0 / 9.0 * m1byM * (1.0 - m1byM))
+            )
+            * chi1
+            - m2byM
+            * (
+                1391.5 / 8.4
+                - 10.0 / 3.0 * m2byM * (1.0 - m2byM)
+                + m2byM * (1276.0 / 8.1 + 170.0 / 9.0 * m2byM * (1.0 - m2byM))
+            )
+            * chi2
+        )
+        pfa_v5 += (
+            -m1byM
+            * (
+                1391.5 / 8.4
+                - 10.0 / 3.0 * m1byM * (1.0 - m1byM)
+                + m1byM * (1276.0 / 8.1 + 170.0 / 9.0 * m1byM * (1.0 - m1byM))
+            )
+            * chi1
+            + -m2byM
+            * (
+                1391.5 / 8.4
+                - 10.0 / 3.0 * m2byM * (1.0 - m2byM)
+                + m2byM * (1276.0 / 8.1 + 170.0 / 9.0 * m2byM * (1.0 - m2byM))
+            )
+            * chi2
+        )
+        pfa_v6logv = -684.8 / 2.1
+        pfa_v6 = (
+            11583.231236531 / 4.694215680
+            - 640.0 / 3.0 * PI * PI
+            - 684.8 / 2.1 * GAMMA
+            + eta * (-15737.765635 / 3.048192 + 225.5 / 1.2 * PI * PI)
+            + eta * eta * 76.055 / 1.728
+            - eta * eta * eta * 127.825 / 1.296
+            + pfa_v6logv * torch.log(torch.tensor(4.0))
+        )
+        # SO + S1-S2 + S-squared contribution at 3 PN
+        pfa_v6 += (
+            PI * m1byM * (1490.0 / 3.0 + m1byM * 260.0) * chi1
+            + PI * m2byM * (1490.0 / 3.0 + m2byM * 260.0) * chi2
+            + (326.75 / 1.12 + 557.5 / 1.8 * eta) * eta * chi1 * chi2
+            + (
+                (4703.5 / 8.4 + 2935.0 / 6.0 * m1byM - 120.0 * m1byM * m1byM)
+                * m1byM
+                * m1byM
+                + (
+                    -4108.25 / 6.72
+                    - 108.5 / 1.2 * m1byM
+                    + 125.5 / 3.6 * m1byM * m1byM
+                )
+                * m1byM
+                * m1byM
+            )
+            * chi1sq
+            + (
+                (4703.5 / 8.4 + 2935.0 / 6.0 * m2byM - 120.0 * m2byM * m2byM)
+                * m2byM
+                * m2byM
+                + (
+                    -4108.25 / 6.72
+                    - 108.5 / 1.2 * m2byM
+                    + 125.5 / 3.6 * m2byM * m2byM
+                )
+                * m2byM
+                * m2byM
+            )
+            * chi2sq
+        )
+        pfa_v7 = PI * (
+            770.96675 / 2.54016
+            + 378.515 / 1.512 * eta
+            - 740.45 / 7.56 * eta * eta
+        )
+        # SO contribution at 3.5 PN
+        pfa_v7 += (
+            m1byM
+            * (
+                -17097.8035 / 4.8384
+                + eta * 28764.25 / 6.72
+                + eta * eta * 47.35 / 1.44
+                + m1byM
+                * (
+                    -7189.233785 / 1.524096
+                    + eta * 458.555 / 3.024
+                    - eta * eta * 534.5 / 7.2
+                )
+            )
+        ) * chi1 + (
+            m2byM
+            * (
+                -17097.8035 / 4.8384
+                + eta * 28764.25 / 6.72
+                + eta * eta * 47.35 / 1.44
+                + m2byM
+                * (
+                    -7189.233785 / 1.524096
+                    + eta * 458.555 / 3.024
+                    - eta * eta * 534.5 / 7.2
+                )
+            )
+        ) * chi2
+        # construct power series
+        phasing = (v7.T * pfa_v7).T
+        phasing += (v6.T * pfa_v6 + v6_logv.T * pfa_v6logv).T
+        phasing += (v5.T * pfa_v5 + v5_logv.T * pfa_v5logv).T
+        phasing += (v4.T * pfa_v4).T
+        phasing += (v3.T * pfa_v3).T
+        phasing += (v2.T * pfa_v2).T
+        phasing += (v1.T * pfa_v1).T
+        phasing += (v0.T * pfa_v0).T
+        # Divide by 0PN v-dependence
+        phasing /= v5
+        # Multiply by 0PN coefficient
+        phasing = (phasing.T * pfaN).T
+
+        # Derivative of phase w.r.t Mf
+        # dPhi/dMf = dPhi/dv dv/dMf
+        Dphasing = (2.0 * v7.T * pfa_v7).T
+        Dphasing += (v6.T * (pfa_v6 + pfa_v6logv)).T
+        Dphasing += (v6_logv.T * pfa_v6logv).T
+        Dphasing += (v5.T * pfa_v5logv).T
+        Dphasing += (-1.0 * v4.T * pfa_v4).T
+        Dphasing += (-2.0 * v3.T * pfa_v3).T
+        Dphasing += (-3.0 * v2.T * pfa_v2).T
+        Dphasing += (-4.0 * v1.T * pfa_v1).T
+        Dphasing += -5.0 * v0
+        Dphasing /= 3.0 * v1 * v7
+        Dphasing *= PI
+        Dphasing = (Dphasing.T * pfaN).T
+
+        return phasing, Dphasing

--- a/tests/waveforms/test_cbc_waveforms.py
+++ b/tests/waveforms/test_cbc_waveforms.py
@@ -223,14 +223,14 @@ def test_phenom_d(
     hc_torch = hc_torch[torch_mask]
 
     assert np.allclose(
-        1e21 * hp_lal_data.real, 1e21 * hp_torch.real.numpy(), atol=2e-1
+        1e21 * hp_lal_data.real, 1e21 * hp_torch.real.numpy(), atol=2e-4
     )
     assert np.allclose(
-        1e21 * hp_lal_data.imag, 1e21 * hp_torch.imag.numpy(), atol=2e-1
+        1e21 * hp_lal_data.imag, 1e21 * hp_torch.imag.numpy(), atol=2e-4
     )
     assert np.allclose(
-        1e21 * hc_lal_data.real, 1e21 * hc_torch.real.numpy(), atol=2e-1
+        1e21 * hc_lal_data.real, 1e21 * hc_torch.real.numpy(), atol=2e-4
     )
     assert np.allclose(
-        1e21 * hc_lal_data.imag, 1e21 * hc_torch.imag.numpy(), atol=2e-1
+        1e21 * hc_lal_data.imag, 1e21 * hc_torch.imag.numpy(), atol=2e-4
     )

--- a/tests/waveforms/test_cbc_waveforms.py
+++ b/tests/waveforms/test_cbc_waveforms.py
@@ -234,3 +234,119 @@ def test_phenom_d(
     assert np.allclose(
         1e21 * hc_lal_data.imag, 1e21 * hc_torch.imag.numpy(), atol=2e-4
     )
+
+
+def test_phenom_p(chirp_mass, mass_ratio, chi1z, chi2z, distance, sample_rate):
+    mass_1 = chirp_mass * (1 + mass_ratio) ** 0.2 / mass_ratio**0.6
+    mass_2 = mass_1 * mass_ratio
+    if mass_2 > mass_1:
+        mass_1, mass_2 = mass_2, mass_1
+    f_ref = 20.0
+    phic = 0.0
+    tc = 0.0
+    inclination = 0.0
+    params = dict(
+        m1=mass_1 * lal.MSUN_SI,
+        m2=mass_2 * lal.MSUN_SI,
+        S1x=0,
+        S1y=0,
+        S1z=chi1z,
+        S2x=0,
+        S2y=0,
+        S2z=chi2z,
+        distance=(distance * u.Mpc).to("m").value,
+        inclination=inclination,
+        phiRef=phic,
+        longAscNodes=0.0,
+        eccentricity=0.0,
+        meanPerAno=0.0,
+        deltaF=1.0 / sample_rate,
+        f_min=10.0,
+        f_ref=f_ref,
+        f_max=300,
+        approximant=lalsimulation.IMRPhenomPv2,
+        LALpars=lal.CreateDict(),
+    )
+    hp_lal, hc_lal = lalsimulation.SimInspiralChooseFDWaveform(**params)
+    lal_freqs = np.array(
+        [hp_lal.f0 + ii * hp_lal.deltaF for ii in range(len(hp_lal.data.data))]
+    )
+
+    torch_freqs = torch.arange(
+        params["f_min"], params["f_max"], params["deltaF"]
+    )
+    _params = torch.tensor(
+        [
+            mass_1,
+            mass_2,
+            0,
+            0,
+            chi1z,
+            0,
+            0,
+            chi2z,
+            distance,
+            tc,
+            phic,
+            inclination,
+        ]
+    ).repeat(10, 1)
+    # repeat along batch dim for testing
+    batched_mass1 = _params[:, 0]
+    batched_mass2 = _params[:, 1]
+    batched_chi1x = _params[:, 2]
+    batched_chi1y = _params[:, 3]
+    batched_chi1z = _params[:, 4]
+    batched_chi2x = _params[:, 5]
+    batched_chi2y = _params[:, 6]
+    batched_chi2z = _params[:, 7]
+    batched_distance = _params[:, 8]
+    batched_tc = _params[:, 9]
+    batched_phic = _params[:, 10]
+    batched_inclination = _params[:, 11]
+    hp_torch, hc_torch = waveforms.IMRPhenomPv2().forward(
+        torch_freqs,
+        batched_mass1,
+        batched_mass2,
+        batched_chi1x,
+        batched_chi1y,
+        batched_chi1z,
+        batched_chi2x,
+        batched_chi2y,
+        batched_chi2z,
+        batched_distance,
+        batched_tc,
+        batched_phic,
+        batched_inclination,
+        f_ref,
+    )
+
+    assert hp_torch.shape[0] == 10  # entire batch is returned
+
+    # select only first element of the batch for further testing since
+    # all are repeated
+    hp_torch = hp_torch[0]
+    hc_torch = hc_torch[0]
+    # restrict between fmin and fmax
+    lal_mask = (lal_freqs > params["f_min"]) & (lal_freqs < params["f_max"])
+    torch_mask = (torch_freqs > params["f_min"]) & (
+        torch_freqs < params["f_max"]
+    )
+
+    hp_lal_data = hp_lal.data.data[lal_mask]
+    hc_lal_data = hc_lal.data.data[lal_mask]
+    hp_torch = hp_torch[torch_mask]
+    hc_torch = hc_torch[torch_mask]
+
+    assert np.allclose(
+        1e21 * hp_lal_data.real, 1e21 * hp_torch.real.numpy(), atol=2e-3
+    )
+    assert np.allclose(
+        1e21 * hp_lal_data.imag, 1e21 * hp_torch.imag.numpy(), atol=2e-3
+    )
+    assert np.allclose(
+        1e21 * hc_lal_data.real, 1e21 * hc_torch.real.numpy(), atol=2e-3
+    )
+    assert np.allclose(
+        1e21 * hc_lal_data.imag, 1e21 * hc_torch.imag.numpy(), atol=2e-3
+    )

--- a/tests/waveforms/test_cbc_waveforms.py
+++ b/tests/waveforms/test_cbc_waveforms.py
@@ -100,7 +100,7 @@ def test_taylor_f2(
     batched_distance = _params[:, 4]
     batched_phic = _params[:, 5]
     batched_inclination = _params[:, 6]
-    hp_torch, hc_torch = waveforms.TaylorF2(
+    hp_torch, hc_torch = waveforms.TaylorF2().forward(
         torch_freqs,
         batched_mass1,
         batched_mass2,
@@ -193,7 +193,7 @@ def test_phenom_d(
     batched_distance = _params[:, 4]
     batched_phic = _params[:, 5]
     batched_inclination = _params[:, 6]
-    hp_torch, hc_torch = waveforms.IMRPhenomD(
+    hp_torch, hc_torch = waveforms.IMRPhenomD().forward(
         torch_freqs,
         batched_mass1,
         batched_mass2,


### PR DESCRIPTION
This PR add the following: 
- Refactor the existing TaylorF2, PhenomD waveforms into `torch.nn.Module` classes, making use of `self.register_buffer` to avoid tensor initializations on the CPU.
- The PhenomD has been made into a subclass of TaylorF2 in order to use its functions without too many imports. 
- Addition of a constants.py file to keep everything in one place
- Fixing the TaylorF2 phase term used in PhenomD by subtracting off its 3PN term. Refer https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimIMRPhenomD.c#L397-398. 
- Addition of the IMRPhenomPv2 waveform implementation in torch. This waveform is subclassed from PhenomD, again for easy use of PhenomD and TaylorF2 functions. 