### PR TITLE
Sine gaussian `dtype`

### DIFF
--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -60,7 +60,7 @@ class SineGaussian(torch.nn.Module):
         Returns:
             Tensors of cross and plus polarizations
         """
-
+        dtype = frequency.dtype
         # add dimension for calculating waveforms in batch
         frequency = frequency.view(-1, 1)
         quality = quality.view(-1, 1)
@@ -105,8 +105,7 @@ class SineGaussian(torch.nn.Module):
         cross = fac.imag * h0_cross
         plus = fac.real * h0_plus
 
-        # TODO dtype as argument?
-        cross = cross.double()
-        plus = plus.double()
+        cross = cross.to(dtype)
+        plus = plus.to(dtype)
 
         return cross, plus


### PR DESCRIPTION
Return the `cross` and `plus` polarizations using the `dtype` of the passed parameters. This is the best way to ensure `dtypes` match for downstream tasks