### PR TITLE
forward/__call__ and cross/plus refactor

### DIFF
--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -49,8 +49,8 @@ class IMRPhenomD(TaylorF2):
                 Reference frequency
 
         Returns:
-            hp, hc: Tuple[torch.Tensor, torch.Tensor]
-                Plus and cross polarizations
+            hc, hp: Tuple[torch.Tensor, torch.Tensor]
+                Cross and plus polarizations
         """
         # shape assumed (n_batch, params)
         if (
@@ -72,7 +72,7 @@ class IMRPhenomD(TaylorF2):
         hp = (htilde.mT * pfac).mT
         hc = -1j * (htilde.mT * cfac).mT
 
-        return hp, hc
+        return hc, hp
 
     def phenom_d_htilde(
         self,

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -62,8 +62,8 @@ class IMRPhenomPv2(IMRPhenomD):
                 Reference frequency in Hz.
 
         Returns:
-            hp, hc: Tuple[torch.Tensor, torch.Tensor]
-                Plus and cross polarizations
+            hc, hp: Tuple[torch.Tensor, torch.Tensor]
+                Cross and plus polarizations
 
         Note: m1 must be larger than m2.
         """
@@ -180,7 +180,7 @@ class IMRPhenomPv2(IMRPhenomD):
         s2z = torch.sin(2 * zeta_polariz).unsqueeze(1)
         hplus = c2z * hp + s2z * hc
         hcross = c2z * hc - s2z * hp
-        return hplus, hcross
+        return hcross, hplus
 
     def PhenomPCoreTwistUp(
         self,

--- a/ml4gw/waveforms/ringdown.py
+++ b/ml4gw/waveforms/ringdown.py
@@ -25,7 +25,7 @@ class Ringdown(torch.nn.Module):
 
         self.register_buffer("times", times)
 
-    def __call__(
+    def forward(
         self,
         frequency: ScalarTensor,
         quality: ScalarTensor,

--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -30,7 +30,7 @@ class SineGaussian(torch.nn.Module):
 
         self.register_buffer("times", times)
 
-    def __call__(
+    def forward(
         self,
         quality: ScalarTensor,
         frequency: ScalarTensor,

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -45,8 +45,8 @@ class TaylorF2(torch.nn.Module):
                 Reference frequency
 
         Returns:
-            hp, hc: Tuple[torch.Tensor, torch.Tensor]
-                Plus and cross polarizations
+            hc, hp: Tuple[torch.Tensor, torch.Tensor]
+                Cross and plus polarizations
         """
 
         # shape assumed (n_batch, params)
@@ -71,7 +71,7 @@ class TaylorF2(torch.nn.Module):
         hp = (htilde.mT * pfac).mT
         hc = -1j * (htilde.mT * cfac).mT
 
-        return hp, hc
+        return hc, hp
 
     def taylorf2_htilde(
         self,

--- a/tests/waveforms/test_cbc_waveforms.py
+++ b/tests/waveforms/test_cbc_waveforms.py
@@ -102,7 +102,7 @@ def test_taylor_f2(
     batched_distance = _params[:, 4]
     batched_phic = _params[:, 5]
     batched_inclination = _params[:, 6]
-    hp_torch, hc_torch = waveforms.TaylorF2()(
+    hc_torch, hp_torch = waveforms.TaylorF2()(
         torch_freqs,
         batched_chirp_mass,
         batched_mass_ratio,
@@ -195,7 +195,7 @@ def test_phenom_d(
     batched_distance = _params[:, 4]
     batched_phic = _params[:, 5]
     batched_inclination = _params[:, 6]
-    hp_torch, hc_torch = waveforms.IMRPhenomD()(
+    hc_torch, hp_torch = waveforms.IMRPhenomD()(
         torch_freqs,
         batched_chirp_mass,
         batched_mass_ratio,
@@ -307,7 +307,7 @@ def test_phenom_p(chirp_mass, mass_ratio, chi1z, chi2z, distance, sample_rate):
     batched_tc = _params[:, 9]
     batched_phic = _params[:, 10]
     batched_inclination = _params[:, 11]
-    hp_torch, hc_torch = waveforms.IMRPhenomPv2()(
+    hc_torch, hp_torch = waveforms.IMRPhenomPv2()(
         torch_freqs,
         batched_chirp_mass,
         batched_mass_ratio,

--- a/tests/waveforms/test_cbc_waveforms.py
+++ b/tests/waveforms/test_cbc_waveforms.py
@@ -102,7 +102,7 @@ def test_taylor_f2(
     batched_distance = _params[:, 4]
     batched_phic = _params[:, 5]
     batched_inclination = _params[:, 6]
-    hp_torch, hc_torch = waveforms.TaylorF2().forward(
+    hp_torch, hc_torch = waveforms.TaylorF2()(
         torch_freqs,
         batched_chirp_mass,
         batched_mass_ratio,
@@ -195,7 +195,7 @@ def test_phenom_d(
     batched_distance = _params[:, 4]
     batched_phic = _params[:, 5]
     batched_inclination = _params[:, 6]
-    hp_torch, hc_torch = waveforms.IMRPhenomD().forward(
+    hp_torch, hc_torch = waveforms.IMRPhenomD()(
         torch_freqs,
         batched_chirp_mass,
         batched_mass_ratio,
@@ -307,7 +307,7 @@ def test_phenom_p(chirp_mass, mass_ratio, chi1z, chi2z, distance, sample_rate):
     batched_tc = _params[:, 9]
     batched_phic = _params[:, 10]
     batched_inclination = _params[:, 11]
-    hp_torch, hc_torch = waveforms.IMRPhenomPv2().forward(
+    hp_torch, hc_torch = waveforms.IMRPhenomPv2()(
         torch_freqs,
         batched_chirp_mass,
         batched_mass_ratio,


### PR DESCRIPTION
This PR adds the following:
1. Refactor the `sine_gaussian` and `ringdown` functions to use `.forward` instead of `__call__`.
2. Change order of output of waveforms to (cross, plus) for `phenom_d`, `phenom_p` and `taylorf2`. 