### PR TITLE
Jaxtyping

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-ignore = W503, E203  # ignore for consistency with black
+ignore = W503, E203, F722  # ignore for consistency with black and jaxtyping
 
 # ignore asterisk imports and unused
 # import errors in __init__ files

--- a/ml4gw/augmentations.py
+++ b/ml4gw/augmentations.py
@@ -1,4 +1,6 @@
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
 
 class SignalInverter(torch.nn.Module):
@@ -16,7 +18,9 @@ class SignalInverter(torch.nn.Module):
         super().__init__()
         self.prob = prob
 
-    def forward(self, X):
+    def forward(
+        self, X: Float[Tensor, "*batch time"]
+    ) -> Float[Tensor, "*batch time"]:
         mask = torch.rand(size=X.shape[:-1]) < self.prob
         X[mask] *= -1
         return X
@@ -37,7 +41,9 @@ class SignalReverser(torch.nn.Module):
         super().__init__()
         self.prob = prob
 
-    def forward(self, X):
+    def forward(
+        self, X: Float[Tensor, "*batch time"]
+    ) -> Float[Tensor, "*batch time"]:
         mask = torch.rand(size=X.shape[:-1]) < self.prob
         X[mask] = X[mask].flip(-1)
         return X

--- a/ml4gw/dataloading/chunked_dataset.py
+++ b/ml4gw/dataloading/chunked_dataset.py
@@ -2,6 +2,8 @@ from collections.abc import Iterable
 
 import torch
 
+from ml4gw.types import WaveformTensor
+
 
 class ChunkedTimeSeriesDataset(torch.utils.data.IterableDataset):
     """
@@ -55,10 +57,10 @@ class ChunkedTimeSeriesDataset(torch.utils.data.IterableDataset):
         self.coincident = coincident
         self.device = device
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.chunk_it) * self.batches_per_chunk
 
-    def __iter__(self):
+    def __iter__(self) -> WaveformTensor:
         it = iter(self.chunk_it)
         chunk = next(it)
         num_chunks, num_channels, chunk_size = chunk.shape

--- a/ml4gw/dataloading/hdf5_dataset.py
+++ b/ml4gw/dataloading/hdf5_dataset.py
@@ -161,7 +161,7 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
                     x[b, c] = f[self.channels[c]][i : i + self.kernel_size]
         return torch.Tensor(x)
 
-    def __iter__(self) -> torch.Tensor:
+    def __iter__(self) -> WaveformTensor:
         worker_info = torch.utils.data.get_worker_info()
         if worker_info is None:
             num_batches = self.batches_per_epoch

--- a/ml4gw/dataloading/in_memory_dataset.py
+++ b/ml4gw/dataloading/in_memory_dataset.py
@@ -2,8 +2,9 @@ import itertools
 from typing import Optional, Tuple, Union
 
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
-from ml4gw import types
 from ml4gw.utils.slicing import slice_kernels
 
 
@@ -76,9 +77,9 @@ class InMemoryDataset(torch.utils.data.IterableDataset):
 
     def __init__(
         self,
-        X: types.TimeSeriesTensor,
+        X: Float[Tensor, "channels time"],
         kernel_size: int,
-        y: Optional[types.ScalarTensor] = None,
+        y: Optional[Float[Tensor, " time"]] = None,
         batch_size: int = 32,
         stride: int = 1,
         batches_per_epoch: Optional[int] = None,
@@ -207,7 +208,10 @@ class InMemoryDataset(torch.utils.data.IterableDataset):
 
     def __iter__(
         self,
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    ) -> Union[
+        Float[Tensor, "batch channel time"],
+        Tuple[Float[Tensor, "batch channel time"], Float[Tensor, " batch"]],
+    ]:
 
         indices = self.init_indices()
         for i in range(len(self)):

--- a/ml4gw/distributions.py
+++ b/ml4gw/distributions.py
@@ -9,6 +9,8 @@ from typing import Optional
 
 import torch
 import torch.distributions as dist
+from jaxtyping import Float
+from torch import Tensor
 
 
 class Cosine(dist.Distribution):
@@ -31,11 +33,11 @@ class Cosine(dist.Distribution):
         self.high = torch.as_tensor(high)
         self.norm = 1 / (torch.sin(self.high) - torch.sin(self.low))
 
-    def rsample(self, sample_shape: torch.Size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: torch.Size = torch.Size()) -> Tensor:
         u = torch.rand(sample_shape, device=self.low.device)
         return torch.arcsin(u / self.norm + torch.sin(self.low))
 
-    def log_prob(self, value):
+    def log_prob(self, value: float) -> Float[Tensor, ""]:
         value = torch.as_tensor(value)
         inside_range = (value >= self.low) & (value <= self.high)
         return value.cos().log() * inside_range
@@ -164,7 +166,7 @@ class DeltaFunction(dist.Distribution):
         super().__init__(batch_shape, validate_args=validate_args)
         self.peak = torch.as_tensor(peak)
 
-    def rsample(self, sample_shape: torch.Size = torch.Size()) -> torch.Tensor:
+    def rsample(self, sample_shape: torch.Size = torch.Size()) -> Tensor:
         return self.peak * torch.ones(
             sample_shape, device=self.peak.device, dtype=torch.float32
         )

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -13,7 +13,8 @@ https://github.com/lscsoft/bilby/blob/master/bilby/gw/detector/interferometer.py
 from typing import List, Tuple, Union
 
 import torch
-from jaxtyping import Array, Float
+from jaxtyping import Float
+from torch import Tensor
 
 from ml4gw.types import (
     NetworkDetectorTensors,
@@ -67,7 +68,7 @@ def compute_antenna_responses(
     phi: ScalarTensor,
     detector_tensors: NetworkDetectorTensors,
     modes: List[str],
-) -> Float[Array, "batch polarizations num_ifos"]:
+) -> Float[Tensor, "batch polarizations num_ifos"]:
     """
     Compute the antenna pattern factors of a batch of
     waveforms as a function of the sky parameters of
@@ -197,7 +198,7 @@ def compute_observed_strain(
     detector_tensors: NetworkDetectorTensors,
     detector_vertices: NetworkVertices,
     sample_rate: float,
-    **polarizations: Float[Array, "batch time"],
+    **polarizations: Float[Tensor, "batch time"],
 ) -> WaveformTensor:
     """
     Compute the strain timeseries $h(t)$ observed by a network
@@ -289,8 +290,8 @@ def compute_ifo_snr(
     responses: WaveformTensor,
     psd: PSDTensor,
     sample_rate: float,
-    highpass: Union[float, Float[Array, " frequency"], None] = None,
-) -> Float[Array, "batch num_ifos"]:
+    highpass: Union[float, Float[Tensor, " frequency"], None] = None,
+) -> Float[Tensor, "batch num_ifos"]:
     r"""Compute the SNRs of a batch of interferometer responses
 
     Compute the signal to noise ratio (SNR) of individual
@@ -390,7 +391,7 @@ def compute_network_snr(
     responses: WaveformTensor,
     psd: PSDTensor,
     sample_rate: float,
-    highpass: Union[float, Float[Array, " frequency"], None] = None,
+    highpass: Union[float, Float[Tensor, " frequency"], None] = None,
 ) -> ScalarTensor:
     r"""
     Compute the total SNR from a gravitational waveform
@@ -440,7 +441,7 @@ def reweight_snrs(
     target_snrs: Union[float, ScalarTensor],
     psd: PSDTensor,
     sample_rate: float,
-    highpass: Union[float, Float[Array, " frequency"], None] = None,
+    highpass: Union[float, Float[Tensor, " frequency"], None] = None,
 ) -> WaveformTensor:
     """Scale interferometer responses such that they have a desired SNR
 

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -30,12 +30,6 @@ from ml4gw.utils.interferometer import InterferometerGeometry
 SPEED_OF_LIGHT = 299792458.0  # m/s
 
 
-# define some tensor shapes we'll reuse a bit
-# up front. Need to assign these variables so
-# that static linters don't give us name errors
-# batch = num_ifos = polarizations = time = frequency = space = None  # noqa
-
-
 def outer(x: VectorGeometry, y: VectorGeometry) -> TensorGeometry:
     """
     Compute the outer product of two batches of vectors

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -18,10 +18,10 @@ from torch import Tensor
 
 from ml4gw.constants import C
 from ml4gw.types import (
+    BatchTensor,
     NetworkDetectorTensors,
     NetworkVertices,
     PSDTensor,
-    ScalarTensor,
     TensorGeometry,
     VectorGeometry,
     WaveformTensor,
@@ -56,9 +56,9 @@ polarization_funcs = {
 
 
 def compute_antenna_responses(
-    theta: ScalarTensor,
-    psi: ScalarTensor,
-    phi: ScalarTensor,
+    theta: BatchTensor,
+    psi: BatchTensor,
+    phi: BatchTensor,
     detector_tensors: NetworkDetectorTensors,
     modes: List[str],
 ) -> Float[Tensor, "batch polarizations num_ifos"]:
@@ -141,8 +141,8 @@ def compute_antenna_responses(
 
 def shift_responses(
     responses: WaveformTensor,
-    theta: ScalarTensor,
-    phi: ScalarTensor,
+    theta: BatchTensor,
+    phi: BatchTensor,
     vertices: NetworkVertices,
     sample_rate: float,
 ) -> WaveformTensor:
@@ -185,9 +185,9 @@ def shift_responses(
 
 
 def compute_observed_strain(
-    dec: ScalarTensor,
-    psi: ScalarTensor,
-    phi: ScalarTensor,
+    dec: BatchTensor,
+    psi: BatchTensor,
+    phi: BatchTensor,
     detector_tensors: NetworkDetectorTensors,
     detector_vertices: NetworkVertices,
     sample_rate: float,
@@ -385,7 +385,7 @@ def compute_network_snr(
     psd: PSDTensor,
     sample_rate: float,
     highpass: Union[float, Float[Tensor, " frequency"], None] = None,
-) -> ScalarTensor:
+) -> BatchTensor:
     r"""
     Compute the total SNR from a gravitational waveform
     from a network of interferometers. The total SNR for
@@ -431,7 +431,7 @@ def compute_network_snr(
 
 def reweight_snrs(
     responses: WaveformTensor,
-    target_snrs: Union[float, ScalarTensor],
+    target_snrs: Union[float, BatchTensor],
     psd: PSDTensor,
     sample_rate: float,
     highpass: Union[float, Float[Tensor, " frequency"], None] = None,

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -16,6 +16,7 @@ import torch
 from jaxtyping import Float
 from torch import Tensor
 
+from ml4gw.constants import C
 from ml4gw.types import (
     NetworkDetectorTensors,
     NetworkVertices,
@@ -26,8 +27,6 @@ from ml4gw.types import (
     WaveformTensor,
 )
 from ml4gw.utils.interferometer import InterferometerGeometry
-
-SPEED_OF_LIGHT = 299792458.0  # m/s
 
 
 def outer(x: VectorGeometry, y: VectorGeometry) -> TensorGeometry:
@@ -161,7 +160,7 @@ def shift_responses(
     # Divide by c in the second line so that we only
     # need to multiply the array by a single float
     dt = -(omega * vertices).sum(axis=-1)
-    dt *= sample_rate / SPEED_OF_LIGHT
+    dt *= sample_rate / C
     dt = torch.trunc(dt).type(torch.int64)
 
     # rolling by gathering implementation based on

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -13,7 +13,7 @@ https://github.com/lscsoft/bilby/blob/master/bilby/gw/detector/interferometer.py
 from typing import List, Tuple, Union
 
 import torch
-from torchtyping import TensorType
+from jaxtyping import Array, Float
 
 from ml4gw.types import (
     NetworkDetectorTensors,
@@ -32,7 +32,7 @@ SPEED_OF_LIGHT = 299792458.0  # m/s
 # define some tensor shapes we'll reuse a bit
 # up front. Need to assign these variables so
 # that static linters don't give us name errors
-batch = num_ifos = polarizations = time = frequency = space = None  # noqa
+# batch = num_ifos = polarizations = time = frequency = space = None  # noqa
 
 
 def outer(x: VectorGeometry, y: VectorGeometry) -> TensorGeometry:
@@ -67,7 +67,7 @@ def compute_antenna_responses(
     phi: ScalarTensor,
     detector_tensors: NetworkDetectorTensors,
     modes: List[str],
-) -> TensorType["batch", "polarizations", "num_ifos"]:
+) -> Float[Array, "batch polarizations num_ifos"]:
     """
     Compute the antenna pattern factors of a batch of
     waveforms as a function of the sky parameters of
@@ -197,7 +197,7 @@ def compute_observed_strain(
     detector_tensors: NetworkDetectorTensors,
     detector_vertices: NetworkVertices,
     sample_rate: float,
-    **polarizations: TensorType["batch", "time"],
+    **polarizations: Float[Array, "batch time"],
 ) -> WaveformTensor:
     """
     Compute the strain timeseries $h(t)$ observed by a network
@@ -289,8 +289,8 @@ def compute_ifo_snr(
     responses: WaveformTensor,
     psd: PSDTensor,
     sample_rate: float,
-    highpass: Union[float, TensorType["frequency"], None] = None,
-) -> TensorType["batch", "num_ifos"]:
+    highpass: Union[float, Float[Array, " frequency"], None] = None,
+) -> Float[Array, "batch num_ifos"]:
     r"""Compute the SNRs of a batch of interferometer responses
 
     Compute the signal to noise ratio (SNR) of individual
@@ -390,7 +390,7 @@ def compute_network_snr(
     responses: WaveformTensor,
     psd: PSDTensor,
     sample_rate: float,
-    highpass: Union[float, TensorType["frequency"], None] = None,
+    highpass: Union[float, Float[Array, " frequency"], None] = None,
 ) -> ScalarTensor:
     r"""
     Compute the total SNR from a gravitational waveform
@@ -440,7 +440,7 @@ def reweight_snrs(
     target_snrs: Union[float, ScalarTensor],
     psd: PSDTensor,
     sample_rate: float,
-    highpass: Union[float, TensorType["frequency"], None] = None,
+    highpass: Union[float, Float[Array, " frequency"], None] = None,
 ) -> WaveformTensor:
     """Scale interferometer responses such that they have a desired SNR
 

--- a/ml4gw/nn/autoencoder/base.py
+++ b/ml4gw/nn/autoencoder/base.py
@@ -1,7 +1,8 @@
 from collections.abc import Sequence
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import torch
+from torch import Tensor
 
 from ml4gw.nn.autoencoder.skip_connection import SkipConnection
 
@@ -27,12 +28,16 @@ class Autoencoder(torch.nn.Module):
     and how they operate.
     """
 
-    def __init__(self, skip_connection: Optional[SkipConnection] = None):
+    def __init__(
+        self, skip_connection: Optional[SkipConnection] = None
+    ) -> None:
         super().__init__()
         self.skip_connection = skip_connection
         self.blocks = torch.nn.ModuleList()
 
-    def encode(self, *X: torch.Tensor, return_states: bool = False):
+    def encode(
+        self, *X: Tensor, return_states: bool = False
+    ) -> Union[Tensor, Tuple[Tensor, Sequence]]:
         states = []
         for block in self.blocks:
             if isinstance(X, tuple):
@@ -48,7 +53,7 @@ class Autoencoder(torch.nn.Module):
             return X, states[:-1]
         return X
 
-    def decode(self, *X, states: Optional[Sequence[torch.Tensor]] = None):
+    def decode(self, *X, states: Optional[Sequence[Tensor]] = None) -> Tensor:
         if self.skip_connection is not None and states is None:
             raise ValueError(
                 "Must pass intermediate states when autoencoder "
@@ -76,7 +81,7 @@ class Autoencoder(torch.nn.Module):
                 X = self.skip_connection(X, state)
         return X
 
-    def forward(self, *X):
+    def forward(self, *X: Tensor) -> Tensor:
         return_states = self.skip_connection is not None
         X = self.encode(*X, return_states=return_states)
         if return_states:
@@ -84,6 +89,6 @@ class Autoencoder(torch.nn.Module):
         else:
             states = None
 
-        if isinstance(X, torch.Tensor):
+        if isinstance(X, Tensor):
             X = (X,)
         return self.decode(*X, states=states)

--- a/ml4gw/nn/autoencoder/convolutional.py
+++ b/ml4gw/nn/autoencoder/convolutional.py
@@ -2,6 +2,7 @@ from collections.abc import Callable, Sequence
 from typing import Optional
 
 import torch
+from torch import Tensor
 
 from ml4gw.nn.autoencoder.base import Autoencoder
 from ml4gw.nn.autoencoder.skip_connection import SkipConnection
@@ -64,12 +65,12 @@ class ConvBlock(Autoencoder):
         self.encode_norm = norm(out_channels)
         self.decode_norm = norm(decode_channels)
 
-    def encode(self, X):
+    def encode(self, X: Tensor) -> Tensor:
         X = self.encode_layer(X)
         X = self.encode_norm(X)
         return self.activation(X)
 
-    def decode(self, X):
+    def decode(self, X: Tensor) -> Tensor:
         X = self.decode_layer(X)
         X = self.decode_norm(X)
         return self.output_activation(X)
@@ -144,13 +145,15 @@ class ConvolutionalAutoencoder(Autoencoder):
             self.blocks.append(block)
             in_channels = channels * groups
 
-    def decode(self, *X, states=None, input_size: Optional[int] = None):
+    def decode(
+        self, *X, states=None, input_size: Optional[int] = None
+    ) -> Tensor:
         X = super().decode(*X, states=states)
         if input_size is not None:
             return match_size(X, input_size)
         return X
 
-    def forward(self, X):
+    def forward(self, X: Tensor) -> Tensor:
         input_size = X.size(-1)
         X = super().forward(X)
         return match_size(X, input_size)

--- a/ml4gw/nn/autoencoder/skip_connection.py
+++ b/ml4gw/nn/autoencoder/skip_connection.py
@@ -1,31 +1,32 @@
 import torch
+from torch import Tensor
 
 from ml4gw.nn.autoencoder.utils import match_size
 
 
 class SkipConnection(torch.nn.Module):
-    def forward(self, X: torch.Tensor, state: torch.Tensor):
+    def forward(self, X: Tensor, state: Tensor) -> Tensor:
         return match_size(X, state.size(-1))
 
-    def get_out_channels(self, in_channels):
+    def get_out_channels(self, in_channels: int) -> int:
         return in_channels
 
 
 class AddSkipConnect(SkipConnection):
-    def forward(self, X, state):
+    def forward(self, X: Tensor, state: Tensor) -> Tensor:
         X = super().forward(X, state)
         return X + state
 
 
 class ConcatSkipConnect(SkipConnection):
-    def __init__(self, groups: int = 1):
+    def __init__(self, groups: int = 1) -> None:
         super().__init__()
         self.groups = groups
 
-    def get_out_channels(self, in_channels):
+    def get_out_channels(self, in_channels: int) -> int:
         return 2 * in_channels
 
-    def forward(self, X, state):
+    def forward(self, X: Tensor, state: Tensor) -> Tensor:
         X = super().forward(X, state)
         if self.groups == 1:
             return torch.cat([X, state], dim=1)

--- a/ml4gw/nn/autoencoder/utils.py
+++ b/ml4gw/nn/autoencoder/utils.py
@@ -1,7 +1,8 @@
 import torch
+from torch import Tensor
 
 
-def match_size(X: torch.Tensor, target_size: int):
+def match_size(X: Tensor, target_size: int) -> Tensor:
     diff = target_size - X.size(-1)
     left = int(diff // 2)
     right = diff - left

--- a/ml4gw/nn/norm.py
+++ b/ml4gw/nn/norm.py
@@ -1,6 +1,8 @@
 from typing import Callable, Optional
 
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
 NormLayer = Callable[[int], torch.nn.Module]
 
@@ -31,7 +33,9 @@ class GroupNorm1D(torch.nn.Module):
         self.weight = torch.nn.Parameter(torch.ones(shape))
         self.bias = torch.nn.Parameter(torch.zeros(shape))
 
-    def forward(self, x):
+    def forward(
+        self, x: Float[Tensor, "batch channel length"]
+    ) -> Float[Tensor, "batch channel length"]:
         if len(x.shape) != 3:
             raise ValueError(
                 "GroupNorm1D requires 3-dimensional input, "

--- a/ml4gw/nn/streaming/online_average.py
+++ b/ml4gw/nn/streaming/online_average.py
@@ -1,10 +1,9 @@
 from typing import Optional, Tuple
 
 import torch
+from torch import Tensor
 
 from ml4gw.utils.slicing import unfold_windows
-
-Tensor = torch.Tensor
 
 
 class OnlineAverager(torch.nn.Module):
@@ -70,12 +69,12 @@ class OnlineAverager(torch.nn.Module):
         weights = unfold_windows(weights, weight_size, update_size)
         self.register_buffer("weights", weights)
 
-    def get_initial_state(self):
+    def get_initial_state(self) -> Tensor:
         return torch.zeros((self.num_channels, self.state_size))
 
     def forward(
-        self, update: torch.Tensor, state: Optional[torch.Tensor] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self, update: Tensor, state: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Tensor]:
         if state is None:
             state = self.get_initial_state()
 

--- a/ml4gw/nn/streaming/online_average.py
+++ b/ml4gw/nn/streaming/online_average.py
@@ -1,6 +1,7 @@
 from typing import Optional, Tuple
 
 import torch
+from jaxtyping import Float
 from torch import Tensor
 
 from ml4gw.utils.slicing import unfold_windows
@@ -69,12 +70,14 @@ class OnlineAverager(torch.nn.Module):
         weights = unfold_windows(weights, weight_size, update_size)
         self.register_buffer("weights", weights)
 
-    def get_initial_state(self) -> Tensor:
+    def get_initial_state(self) -> Float[Tensor, "channel time"]:
         return torch.zeros((self.num_channels, self.state_size))
 
     def forward(
-        self, update: Tensor, state: Optional[Tensor] = None
-    ) -> Tuple[Tensor, Tensor]:
+        self,
+        update: Float[Tensor, "batch channel time1"],
+        state: Optional[Float[Tensor, "channel time2"]] = None,
+    ) -> Tuple[Float[Tensor, "channel time3"], Float[Tensor, "channel time4"]]:
         if state is None:
             state = self.get_initial_state()
 

--- a/ml4gw/nn/streaming/snapshotter.py
+++ b/ml4gw/nn/streaming/snapshotter.py
@@ -1,6 +1,7 @@
 from typing import Optional, Sequence, Tuple
 
 import torch
+from jaxtyping import Float
 from torch import Tensor
 
 from ml4gw.utils.slicing import unfold_windows
@@ -83,13 +84,13 @@ class Snapshotter(torch.nn.Module):
         self.channels_per_snapshot = channels_per_snapshot
         self.num_channels = num_channels
 
-    def get_initial_state(self) -> Tensor:
+    def get_initial_state(self) -> Float[Tensor, "channel time"]:
         return torch.zeros((self.num_channels, self.state_size))
 
-    # TODO: use jaxtyping annotations to make
-    # clear what the expected shapes are
     def forward(
-        self, update: Tensor, snapshot: Optional[Tensor] = None
+        self,
+        update: Float[Tensor, "channel time1"],
+        snapshot: Optional[Float[Tensor, "channel time2"]] = None,
     ) -> Tuple[Tensor, ...]:
         if snapshot is None:
             snapshot = self.get_initial_state()

--- a/ml4gw/nn/streaming/snapshotter.py
+++ b/ml4gw/nn/streaming/snapshotter.py
@@ -1,6 +1,7 @@
 from typing import Optional, Sequence, Tuple
 
 import torch
+from torch import Tensor
 
 from ml4gw.utils.slicing import unfold_windows
 
@@ -82,14 +83,14 @@ class Snapshotter(torch.nn.Module):
         self.channels_per_snapshot = channels_per_snapshot
         self.num_channels = num_channels
 
-    def get_initial_state(self):
+    def get_initial_state(self) -> Tensor:
         return torch.zeros((self.num_channels, self.state_size))
 
     # TODO: use jaxtyping annotations to make
     # clear what the expected shapes are
     def forward(
-        self, update: torch.Tensor, snapshot: Optional[torch.Tensor] = None
-    ) -> Tuple[torch.Tensor, ...]:
+        self, update: Tensor, snapshot: Optional[Tensor] = None
+    ) -> Tuple[Tensor, ...]:
         if snapshot is None:
             snapshot = self.get_initial_state()
 

--- a/ml4gw/nn/streaming/snapshotter.py
+++ b/ml4gw/nn/streaming/snapshotter.py
@@ -85,7 +85,7 @@ class Snapshotter(torch.nn.Module):
     def get_initial_state(self):
         return torch.zeros((self.num_channels, self.state_size))
 
-    # TODO: use torchtyping annotations to make
+    # TODO: use jaxtyping annotations to make
     # clear what the expected shapes are
     def forward(
         self, update: torch.Tensor, snapshot: Optional[torch.Tensor] = None

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -12,7 +12,7 @@ https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.csd.html
 from typing import Optional, Union
 
 import torch
-from torchtyping import TensorType
+from jaxtyping import Array, Float
 
 from ml4gw import types
 
@@ -337,7 +337,7 @@ def spectral_density(
 
 def truncate_inverse_power_spectrum(
     psd: types.PSDTensor,
-    fduration: Union[TensorType["time"], float],
+    fduration: Union[Float[Array, "time"], float],
     sample_rate: float,
     highpass: Optional[float] = None,
 ) -> types.PSDTensor:
@@ -449,7 +449,7 @@ def normalize_by_psd(
 def whiten(
     X: types.WaveformTensor,
     psd: types.PSDTensor,
-    fduration: Union[TensorType["time"], float],
+    fduration: Union[Float[Array, "time"], float],
     sample_rate: float,
     highpass: Optional[float] = None,
 ) -> types.WaveformTensor:

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -12,7 +12,8 @@ https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.csd.html
 from typing import Optional, Union
 
 import torch
-from jaxtyping import Array, Float
+from jaxtyping import Float
+from torch import Tensor
 
 from ml4gw import types
 
@@ -337,7 +338,7 @@ def spectral_density(
 
 def truncate_inverse_power_spectrum(
     psd: types.PSDTensor,
-    fduration: Union[Float[Array, "time"], float],
+    fduration: Union[Float[Tensor, "time"], float],
     sample_rate: float,
     highpass: Optional[float] = None,
 ) -> types.PSDTensor:
@@ -449,7 +450,7 @@ def normalize_by_psd(
 def whiten(
     X: types.WaveformTensor,
     psd: types.PSDTensor,
-    fduration: Union[Float[Array, "time"], float],
+    fduration: Union[Float[Tensor, "time"], float],
     sample_rate: float,
     highpass: Optional[float] = None,
 ) -> types.WaveformTensor:

--- a/ml4gw/transforms/pearson.py
+++ b/ml4gw/transforms/pearson.py
@@ -61,7 +61,7 @@ class ShiftedPearsonCorrelation(torch.nn.Module):
                     )
                 )
 
-    # TODO: torchtyping annotate
+    # TODO: jaxtyping annotate
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         self._shape_checks(x, y)
         dim = x.size(-1)

--- a/ml4gw/transforms/pearson.py
+++ b/ml4gw/transforms/pearson.py
@@ -1,5 +1,8 @@
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
+from ml4gw.types import TimeSeries1to3d
 from ml4gw.utils.slicing import unfold_windows
 
 
@@ -40,7 +43,7 @@ class ShiftedPearsonCorrelation(torch.nn.Module):
         super().__init__()
         self.max_shift = max_shift
 
-    def _shape_checks(self, x: torch.Tensor, y: torch.Tensor):
+    def _shape_checks(self, x: TimeSeries1to3d, y: TimeSeries1to3d):
         if x.ndim > 3:
             raise ValueError(
                 "Tensor x can only have up to 3 dimensions "
@@ -61,8 +64,9 @@ class ShiftedPearsonCorrelation(torch.nn.Module):
                     )
                 )
 
-    # TODO: jaxtyping annotate
-    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: TimeSeries1to3d, y: TimeSeries1to3d
+    ) -> Float[Tensor, "windows ..."]:
         self._shape_checks(x, y)
         dim = x.size(-1)
 

--- a/ml4gw/transforms/scaler.py
+++ b/ml4gw/transforms/scaler.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
 from ml4gw.transforms.transform import FittableTransform
 
@@ -34,7 +36,7 @@ class ChannelWiseScaler(FittableTransform):
         self.register_buffer("mean", mean)
         self.register_buffer("std", std)
 
-    def fit(self, X: torch.Tensor) -> None:
+    def fit(self, X: Float[Tensor, "... time"]) -> None:
         """Fit the scaling parameters to a timeseries
 
         Computes the channel-wise mean and standard deviation
@@ -60,7 +62,9 @@ class ChannelWiseScaler(FittableTransform):
 
         super().build(mean=mean, std=std)
 
-    def forward(self, X: torch.Tensor, reverse: bool = False) -> torch.Tensor:
+    def forward(
+        self, X: Float[Tensor, "... time"], reverse: bool = False
+    ) -> Float[Tensor, "... time"]:
         if not reverse:
             return (X - self.mean) / self.std
         else:

--- a/ml4gw/transforms/snr_rescaler.py
+++ b/ml4gw/transforms/snr_rescaler.py
@@ -4,7 +4,7 @@ import torch
 
 from ml4gw.gw import compute_network_snr
 from ml4gw.transforms.transform import FittableSpectralTransform
-from ml4gw.types import ScalarTensor, TimeSeries2d, WaveformTensor
+from ml4gw.types import BatchTensor, TimeSeries2d, WaveformTensor
 
 
 class SnrRescaler(FittableSpectralTransform):
@@ -60,7 +60,7 @@ class SnrRescaler(FittableSpectralTransform):
     def forward(
         self,
         responses: WaveformTensor,
-        target_snrs: Optional[ScalarTensor] = None,
+        target_snrs: Optional[BatchTensor] = None,
     ):
         snrs = compute_network_snr(
             responses, self.background, self.sample_rate, self.mask

--- a/ml4gw/transforms/snr_rescaler.py
+++ b/ml4gw/transforms/snr_rescaler.py
@@ -2,8 +2,9 @@ from typing import Optional
 
 import torch
 
-from ml4gw import gw
+from ml4gw.gw import compute_network_snr
 from ml4gw.transforms.transform import FittableSpectralTransform
+from ml4gw.types import ScalarTensor, TimeSeries2d, WaveformTensor
 
 
 class SnrRescaler(FittableSpectralTransform):
@@ -34,7 +35,7 @@ class SnrRescaler(FittableSpectralTransform):
 
     def fit(
         self,
-        *background: torch.Tensor,
+        *background: TimeSeries2d,
         fftlength: Optional[float] = None,
         overlap: Optional[float] = None,
     ):
@@ -58,10 +59,10 @@ class SnrRescaler(FittableSpectralTransform):
 
     def forward(
         self,
-        responses: gw.WaveformTensor,
-        target_snrs: Optional[gw.ScalarTensor] = None,
+        responses: WaveformTensor,
+        target_snrs: Optional[ScalarTensor] = None,
     ):
-        snrs = gw.compute_network_snr(
+        snrs = compute_network_snr(
             responses, self.background, self.sample_rate, self.mask
         )
         if target_snrs is None:

--- a/ml4gw/transforms/spectral.py
+++ b/ml4gw/transforms/spectral.py
@@ -1,8 +1,11 @@
 from typing import Optional
 
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
 from ml4gw.spectral import fast_spectral_density, spectral_density
+from ml4gw.types import FrequencySeries1to3d, TimeSeries1to3d
 
 
 class SpectralDensity(torch.nn.Module):
@@ -51,7 +54,9 @@ class SpectralDensity(torch.nn.Module):
         fftlength: float,
         overlap: Optional[float] = None,
         average: str = "mean",
-        window: Optional[torch.Tensor] = None,
+        window: Optional[
+            Float[Tensor, " {int(fftlength*sample_rate)}"]
+        ] = None,
         fast: bool = False,
     ) -> None:
         if overlap is None:
@@ -93,7 +98,9 @@ class SpectralDensity(torch.nn.Module):
         self.average = average
         self.fast = fast
 
-    def forward(self, x: torch.Tensor, y: Optional[torch.Tensor] = None):
+    def forward(
+        self, x: TimeSeries1to3d, y: Optional[TimeSeries1to3d] = None
+    ) -> FrequencySeries1to3d:
         if self.fast:
             return fast_spectral_density(
                 x,

--- a/ml4gw/transforms/spectrogram.py
+++ b/ml4gw/transforms/spectrogram.py
@@ -3,7 +3,11 @@ from typing import Dict, List
 
 import torch
 import torch.nn.functional as F
+from jaxtyping import Float
+from torch import Tensor
 from torchaudio.transforms import Spectrogram
+
+from ml4gw.types import TimeSeries3d
 
 
 class MultiResolutionSpectrogram(torch.nn.Module):
@@ -122,7 +126,9 @@ class MultiResolutionSpectrogram(torch.nn.Module):
 
         return [dict(zip(kwargs, col)) for col in zip(*kwargs.values())]
 
-    def forward(self, X: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, X: TimeSeries3d
+    ) -> Float[Tensor, "batch channel frequency time"]:
         """
         Calculate spectrograms of the input tensor and
         combine them into a single spectrogram

--- a/ml4gw/transforms/transform.py
+++ b/ml4gw/transforms/transform.py
@@ -3,6 +3,7 @@ from typing import Optional
 import torch
 
 from ml4gw.spectral import spectral_density
+from ml4gw.types import FrequencySeries1to3d, TimeSeries1to3d
 
 
 class FittableTransform(torch.nn.Module):
@@ -43,12 +44,12 @@ class FittableTransform(torch.nn.Module):
 class FittableSpectralTransform(FittableTransform):
     def normalize_psd(
         self,
-        x,
+        x: TimeSeries1to3d,
         sample_rate: float,
         num_freqs: int,
         fftlength: Optional[float] = None,
         overlap: Optional[float] = None,
-    ):
+    ) -> FrequencySeries1to3d:
         # if we specified an FFT length, convert
         # the (assumed) time-domain data to the
         # frequency domain
@@ -68,7 +69,7 @@ class FittableSpectralTransform(FittableTransform):
                 scale=scale,
             )
 
-        # add two dummy dimensions in case we need to inerpolate
+        # add two dummy dimensions in case we need to interpolate
         # the frequency dimension, since `interpolate` expects
         # a (batch, channel, spatial) formatted tensor as input
         x = x.view(1, 1, -1)

--- a/ml4gw/transforms/waveforms.py
+++ b/ml4gw/transforms/waveforms.py
@@ -1,8 +1,11 @@
 from typing import List, Optional
 
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
 from ml4gw import gw
+from ml4gw.types import ScalarTensor
 
 
 # TODO: should these live in ml4gw.waveforms submodule?
@@ -10,8 +13,8 @@ from ml4gw import gw
 class WaveformSampler(torch.nn.Module):
     def __init__(
         self,
-        parameters: Optional[torch.Tensor] = None,
-        **polarizations: torch.Tensor,
+        parameters: Optional[Float[Tensor, "batch num_params"]] = None,
+        **polarizations: Float[Tensor, "batch time"],
     ):
         super().__init__()
         # make sure we have the same number of waveforms
@@ -29,7 +32,7 @@ class WaveformSampler(torch.nn.Module):
             elif num_waveforms is None:
                 num_waveforms = tensor.shape[0]
 
-            self.polarizations[polarization] = torch.Tensor(tensor)
+            self.polarizations[polarization] = Tensor(tensor)
 
         if parameters is not None and len(parameters) != num_waveforms:
             raise ValueError(
@@ -73,10 +76,10 @@ class WaveformProjector(torch.nn.Module):
 
     def forward(
         self,
-        dec: gw.ScalarTensor,
-        psi: gw.ScalarTensor,
-        phi: gw.ScalarTensor,
-        **polarizations,
+        dec: ScalarTensor,
+        psi: ScalarTensor,
+        phi: ScalarTensor,
+        **polarizations: Float[Tensor, "batch time"],
     ):
         ifo_responses = gw.compute_observed_strain(
             dec,

--- a/ml4gw/transforms/waveforms.py
+++ b/ml4gw/transforms/waveforms.py
@@ -5,7 +5,7 @@ from jaxtyping import Float
 from torch import Tensor
 
 from ml4gw import gw
-from ml4gw.types import ScalarTensor
+from ml4gw.types import BatchTensor
 
 
 # TODO: should these live in ml4gw.waveforms submodule?
@@ -76,9 +76,9 @@ class WaveformProjector(torch.nn.Module):
 
     def forward(
         self,
-        dec: ScalarTensor,
-        psi: ScalarTensor,
-        phi: ScalarTensor,
+        dec: BatchTensor,
+        psi: BatchTensor,
+        phi: BatchTensor,
         **polarizations: Float[Tensor, "batch time"],
     ):
         ifo_responses = gw.compute_observed_strain(

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -1,9 +1,15 @@
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 
 from ml4gw import spectral
 from ml4gw.transforms.transform import FittableSpectralTransform
+from ml4gw.types import (
+    FrequencySeries1d,
+    FrequencySeries1to3d,
+    TimeSeries1d,
+    TimeSeries3d,
+)
 
 
 class Whiten(torch.nn.Module):
@@ -58,7 +64,9 @@ class Whiten(torch.nn.Module):
         window = torch.hann_window(size, dtype=torch.float64)
         self.register_buffer("window", window)
 
-    def forward(self, X: torch.Tensor, psd: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, X: TimeSeries3d, psd: FrequencySeries1to3d
+    ) -> TimeSeries3d:
         """
         Whiten a batch of multichannel timeseries by a
         background power spectral density.
@@ -142,7 +150,7 @@ class FixedWhiten(FittableSpectralTransform):
     def fit(
         self,
         fduration: float,
-        *background: torch.Tensor,
+        *background: Union[TimeSeries1d, FrequencySeries1d],
         fftlength: Optional[float] = None,
         highpass: Optional[float] = None,
         overlap: Optional[float] = None
@@ -224,7 +232,7 @@ class FixedWhiten(FittableSpectralTransform):
         fduration = torch.Tensor([fduration])
         self.build(psd=psd, fduration=fduration)
 
-    def forward(self, X: torch.Tensor) -> torch.Tensor:
+    def forward(self, X: TimeSeries3d) -> TimeSeries3d:
         """
         Whiten the input timeseries tensor using the
         PSD fit by the `.fit` method, which must be

--- a/ml4gw/types.py
+++ b/ml4gw/types.py
@@ -10,10 +10,16 @@ VectorGeometry = Float[Tensor, "batch space"]
 TensorGeometry = Float[Tensor, "batch space space"]
 NetworkVertices = Float[Tensor, "num_ifos 3"]
 NetworkDetectorTensors = Float[Tensor, "num_ifos 3 3"]
-TimeSeriesTensor = Float[Tensor, "num_channels time"]
 
 
 TimeSeries1d = Float[Tensor, "time"]
 TimeSeries2d = Float[TimeSeries1d, "channel"]
 TimeSeries3d = Float[TimeSeries2d, "batch"]
 TimeSeries1to3d = Union[TimeSeries1d, TimeSeries2d, TimeSeries3d]
+
+FrequencySeries1d = Float[Tensor, "frequency"]
+FrequencySeries2d = Float[FrequencySeries1d, "channel"]
+FrequencySeries3d = Float[FrequencySeries2d, "batch"]
+FrequencySeries1to3d = Union[
+    FrequencySeries1d, FrequencySeries2d, FrequencySeries3d
+]

--- a/ml4gw/types.py
+++ b/ml4gw/types.py
@@ -1,10 +1,11 @@
-from jaxtyping import Array, Float
+from jaxtyping import Float
+from torch import Tensor
 
-WaveformTensor = Float[Array, "batch num_ifos time"]
-PSDTensor = Float[Array, "num_ifos frequency"]
-ScalarTensor = Float[Array, "batch"]
-VectorGeometry = Float[Array, "batch space"]
-TensorGeometry = Float[Array, "batch space space"]
-NetworkVertices = Float[Array, "num_ifos 3"]
-NetworkDetectorTensors = Float[Array, "num_ifos 3 3"]
-TimeSeriesTensor = Float[Array, "num_channels time"]
+WaveformTensor = Float[Tensor, "batch num_ifos time"]
+PSDTensor = Float[Tensor, "num_ifos frequency"]
+ScalarTensor = Float[Tensor, "batch"]
+VectorGeometry = Float[Tensor, "batch space"]
+TensorGeometry = Float[Tensor, "batch space space"]
+NetworkVertices = Float[Tensor, "num_ifos 3"]
+NetworkDetectorTensors = Float[Tensor, "num_ifos 3 3"]
+TimeSeriesTensor = Float[Tensor, "num_channels time"]

--- a/ml4gw/types.py
+++ b/ml4gw/types.py
@@ -5,7 +5,7 @@ from torch import Tensor
 
 WaveformTensor = Float[Tensor, "batch num_ifos time"]
 PSDTensor = Float[Tensor, "num_ifos frequency"]
-ScalarTensor = Float[Tensor, "batch"]
+BatchTensor = Float[Tensor, "batch"]
 VectorGeometry = Float[Tensor, "batch space"]
 TensorGeometry = Float[Tensor, "batch space space"]
 NetworkVertices = Float[Tensor, "num_ifos 3"]

--- a/ml4gw/types.py
+++ b/ml4gw/types.py
@@ -1,10 +1,10 @@
-from torchtyping import TensorType
+from jaxtyping import Array, Float
 
-WaveformTensor = TensorType["batch", "num_ifos", "time"]
-PSDTensor = TensorType["num_ifos", "frequency"]
-ScalarTensor = TensorType["batch"]
-VectorGeometry = TensorType["batch", "space"]
-TensorGeometry = TensorType["batch", "space", "space"]
-NetworkVertices = TensorType["num_ifos", 3]
-NetworkDetectorTensors = TensorType["num_ifos", 3, 3]
-TimeSeriesTensor = TensorType["num_channels", "time"]
+WaveformTensor = Float[Array, "batch num_ifos time"]
+PSDTensor = Float[Array, "num_ifos frequency"]
+ScalarTensor = Float[Array, "batch"]
+VectorGeometry = Float[Array, "batch space"]
+TensorGeometry = Float[Array, "batch space space"]
+NetworkVertices = Float[Array, "num_ifos 3"]
+NetworkDetectorTensors = Float[Array, "num_ifos 3 3"]
+TimeSeriesTensor = Float[Array, "num_channels time"]

--- a/ml4gw/types.py
+++ b/ml4gw/types.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from jaxtyping import Float
 from torch import Tensor
 
@@ -9,3 +11,9 @@ TensorGeometry = Float[Tensor, "batch space space"]
 NetworkVertices = Float[Tensor, "num_ifos 3"]
 NetworkDetectorTensors = Float[Tensor, "num_ifos 3 3"]
 TimeSeriesTensor = Float[Tensor, "num_channels time"]
+
+
+TimeSeries1d = Float[Tensor, "time"]
+TimeSeries2d = Float[TimeSeries1d, "channel"]
+TimeSeries3d = Float[TimeSeries2d, "batch"]
+TimeSeries1to3d = Union[TimeSeries1d, TimeSeries2d, TimeSeries3d]

--- a/ml4gw/utils/interferometer.py
+++ b/ml4gw/utils/interferometer.py
@@ -4,7 +4,7 @@ import torch
 # based on values from
 # https://lscsoft.docs.ligo.org/lalsuite/lal/_l_a_l_detectors_8h_source.html
 class InterferometerGeometry:
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         if name == "H1":
             self.x_arm = torch.Tensor(
                 (-0.22389266154, +0.79983062746, +0.55690487831)

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -13,7 +13,7 @@ BatchTimeSeriesTensor = Union[
 
 
 def unfold_windows(
-    x: torch.Tensor,
+    x: Tensor,
     window_size: int,
     stride: int,
     drop_last: bool = True,

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -1,13 +1,14 @@
 from typing import Optional, Union
 
 import torch
-from jaxtyping import Array, Float, Int64
+from jaxtyping import Float, Int64
+from torch import Tensor
 from torch.nn.functional import unfold
 
-TimeSeriesTensor = Union[Float[Array, " time"], Float[Array, "channel time"]]
+TimeSeriesTensor = Union[Float[Tensor, " time"], Float[Tensor, "channel time"]]
 
 BatchTimeSeriesTensor = Union[
-    Float[Array, "batch time"], Float[Array, "batch channel time"]
+    Float[Tensor, "batch time"], Float[Tensor, "batch channel time"]
 ]
 
 
@@ -80,8 +81,8 @@ def unfold_windows(
 
 
 def slice_kernels(
-    x: Union[TimeSeriesTensor, Float[Array, "batch channel time"]],
-    idx: Int64[Array, "..."],
+    x: Union[TimeSeriesTensor, Float[Tensor, "batch channel time"]],
+    idx: Int64[Tensor, "..."],
     kernel_size: int,
 ) -> BatchTimeSeriesTensor:
     """Slice kernels from single or multichannel timeseries

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -1,16 +1,13 @@
 from typing import Optional, Union
 
 import torch
+from jaxtyping import Array, Float, Int64
 from torch.nn.functional import unfold
-from torchtyping import TensorType
 
-# need to define these for flake8 compatibility
-batch = time = channel = None  # noqa
-
-TimeSeriesTensor = Union[TensorType["time"], TensorType["channel", "time"]]
+TimeSeriesTensor = Union[Float[Array, " time"], Float[Array, "channel time"]]
 
 BatchTimeSeriesTensor = Union[
-    TensorType["batch", "time"], TensorType["batch", "channel", "time"]
+    Float[Array, "batch time"], Float[Array, "batch channel time"]
 ]
 
 
@@ -83,8 +80,8 @@ def unfold_windows(
 
 
 def slice_kernels(
-    x: Union[TimeSeriesTensor, TensorType["batch", "channel", "time"]],
-    idx: TensorType[..., torch.int64],
+    x: Union[TimeSeriesTensor, Float[Array, "batch channel time"]],
+    idx: Int64[Array, "..."],
     kernel_size: int,
 ) -> BatchTimeSeriesTensor:
     """Slice kernels from single or multichannel timeseries

--- a/ml4gw/waveforms/generator.py
+++ b/ml4gw/waveforms/generator.py
@@ -1,24 +1,26 @@
-from typing import Callable
+from typing import Callable, Dict, Tuple
 
 import torch
+from jaxtyping import Float
+from torch import Tensor
 
 
 class ParameterSampler(torch.nn.Module):
-    def __init__(self, **parameters: Callable):
+    def __init__(self, **parameters: Callable) -> None:
         super().__init__()
         self.parameters = parameters
 
     def forward(
         self,
         N: int,
-    ):
+    ) -> Dict[str, Float[Tensor, " {N}"]]:
         return {k: v.sample((N,)) for k, v in self.parameters.items()}
 
 
 class WaveformGenerator(torch.nn.Module):
     def __init__(
         self, waveform: Callable, parameter_sampler: ParameterSampler
-    ):
+    ) -> None:
         """
         A torch module that generates waveforms from a given waveform function
         and a parameter sampler.
@@ -34,6 +36,8 @@ class WaveformGenerator(torch.nn.Module):
         self.waveform = waveform
         self.parameter_sampler = parameter_sampler
 
-    def forward(self, N: int):
+    def forward(
+        self, N: int
+    ) -> Tuple[Float[Tensor, "{N} samples"], Dict[str, Float[Tensor, " {N}"]]]:
         parameters = self.parameter_sampler(N)
         return self.waveform(**parameters), parameters

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -16,14 +16,14 @@ class IMRPhenomD(TaylorF2):
 
     def forward(
         self,
-        f: Float[Tensor, ""],
-        chirp_mass: Float[Tensor, ""],
-        mass_ratio: Float[Tensor, ""],
-        chi1: Float[Tensor, ""],
-        chi2: Float[Tensor, ""],
-        distance: Float[Tensor, ""],
-        phic: Float[Tensor, ""],
-        inclination: Float[Tensor, ""],
+        f: Float[Tensor, " signals"],
+        chirp_mass: Float[Tensor, " signals"],
+        mass_ratio: Float[Tensor, " signals"],
+        chi1: Float[Tensor, " signals"],
+        chi2: Float[Tensor, " signals"],
+        distance: Float[Tensor, " signals"],
+        phic: Float[Tensor, " signals"],
+        inclination: Float[Tensor, " signals"],
         f_ref: float,
     ):
         """
@@ -77,13 +77,13 @@ class IMRPhenomD(TaylorF2):
 
     def phenom_d_htilde(
         self,
-        f: Float[Tensor, ""],
-        chirp_mass: Float[Tensor, ""],
-        mass_ratio: Float[Tensor, ""],
-        chi1: Float[Tensor, ""],
-        chi2: Float[Tensor, ""],
-        distance: Float[Tensor, ""],
-        phic: Float[Tensor, ""],
+        f: Float[Tensor, " signals"],
+        chirp_mass: Float[Tensor, " signals"],
+        mass_ratio: Float[Tensor, " signals"],
+        chi1: Float[Tensor, " signals"],
+        chi2: Float[Tensor, " signals"],
+        distance: Float[Tensor, " signals"],
+        phic: Float[Tensor, " signals"],
         f_ref: float,
     ):
         total_mass = chirp_mass * (1 + mass_ratio) ** 1.2 / mass_ratio**0.6

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -1,8 +1,9 @@
 import torch
 from jaxtyping import Float
-from torch import Tensor
 
-from ..constants import MTSUN_SI, PI
+from ml4gw.constants import MTSUN_SI, PI
+from ml4gw.types import FrequencySeries1d, ScalarTensor
+
 from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
 from .taylorf2 import TaylorF2
 
@@ -16,14 +17,14 @@ class IMRPhenomD(TaylorF2):
 
     def forward(
         self,
-        f: Float[Tensor, " signals"],
-        chirp_mass: Float[Tensor, " signals"],
-        mass_ratio: Float[Tensor, " signals"],
-        chi1: Float[Tensor, " signals"],
-        chi2: Float[Tensor, " signals"],
-        distance: Float[Tensor, " signals"],
-        phic: Float[Tensor, " signals"],
-        inclination: Float[Tensor, " signals"],
+        f: FrequencySeries1d,
+        chirp_mass: ScalarTensor,
+        mass_ratio: ScalarTensor,
+        chi1: ScalarTensor,
+        chi2: ScalarTensor,
+        distance: ScalarTensor,
+        phic: ScalarTensor,
+        inclination: ScalarTensor,
         f_ref: float,
     ):
         """
@@ -77,15 +78,15 @@ class IMRPhenomD(TaylorF2):
 
     def phenom_d_htilde(
         self,
-        f: Float[Tensor, " signals"],
-        chirp_mass: Float[Tensor, " signals"],
-        mass_ratio: Float[Tensor, " signals"],
-        chi1: Float[Tensor, " signals"],
-        chi2: Float[Tensor, " signals"],
-        distance: Float[Tensor, " signals"],
-        phic: Float[Tensor, " signals"],
+        f: FrequencySeries1d,
+        chirp_mass: ScalarTensor,
+        mass_ratio: ScalarTensor,
+        chi1: ScalarTensor,
+        chi2: ScalarTensor,
+        distance: ScalarTensor,
+        phic: ScalarTensor,
         f_ref: float,
-    ):
+    ) -> Float[FrequencySeries1d, " batch"]:
         total_mass = chirp_mass * (1 + mass_ratio) ** 1.2 / mass_ratio**0.6
         mass_1 = total_mass / (1 + mass_ratio)
         mass_2 = mass_1 * mass_ratio

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -1,5 +1,6 @@
 import torch
-from jaxtyping import Array, Float
+from jaxtyping import Float
+from torch import Tensor
 
 from ..constants import MTSUN_SI, PI
 from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
@@ -15,14 +16,14 @@ class IMRPhenomD(TaylorF2):
 
     def forward(
         self,
-        f: Float[Array, ""],
-        chirp_mass: Float[Array, ""],
-        mass_ratio: Float[Array, ""],
-        chi1: Float[Array, ""],
-        chi2: Float[Array, ""],
-        distance: Float[Array, ""],
-        phic: Float[Array, ""],
-        inclination: Float[Array, ""],
+        f: Float[Tensor, ""],
+        chirp_mass: Float[Tensor, ""],
+        mass_ratio: Float[Tensor, ""],
+        chi1: Float[Tensor, ""],
+        chi2: Float[Tensor, ""],
+        distance: Float[Tensor, ""],
+        phic: Float[Tensor, ""],
+        inclination: Float[Tensor, ""],
         f_ref: float,
     ):
         """
@@ -76,13 +77,13 @@ class IMRPhenomD(TaylorF2):
 
     def phenom_d_htilde(
         self,
-        f: Float[Array, ""],
-        chirp_mass: Float[Array, ""],
-        mass_ratio: Float[Array, ""],
-        chi1: Float[Array, ""],
-        chi2: Float[Array, ""],
-        distance: Float[Array, ""],
-        phic: Float[Array, ""],
+        f: Float[Tensor, ""],
+        chirp_mass: Float[Tensor, ""],
+        mass_ratio: Float[Tensor, ""],
+        chi1: Float[Tensor, ""],
+        chi2: Float[Tensor, ""],
+        distance: Float[Tensor, ""],
+        phic: Float[Tensor, ""],
         f_ref: float,
     ):
         total_mass = chirp_mass * (1 + mass_ratio) ** 1.2 / mass_ratio**0.6

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -2,7 +2,7 @@ import torch
 from jaxtyping import Float
 
 from ml4gw.constants import MTSUN_SI, PI
-from ml4gw.types import FrequencySeries1d, ScalarTensor
+from ml4gw.types import BatchTensor, FrequencySeries1d
 
 from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
 from .taylorf2 import TaylorF2
@@ -18,13 +18,13 @@ class IMRPhenomD(TaylorF2):
     def forward(
         self,
         f: FrequencySeries1d,
-        chirp_mass: ScalarTensor,
-        mass_ratio: ScalarTensor,
-        chi1: ScalarTensor,
-        chi2: ScalarTensor,
-        distance: ScalarTensor,
-        phic: ScalarTensor,
-        inclination: ScalarTensor,
+        chirp_mass: BatchTensor,
+        mass_ratio: BatchTensor,
+        chi1: BatchTensor,
+        chi2: BatchTensor,
+        distance: BatchTensor,
+        phic: BatchTensor,
+        inclination: BatchTensor,
         f_ref: float,
     ):
         """
@@ -79,12 +79,12 @@ class IMRPhenomD(TaylorF2):
     def phenom_d_htilde(
         self,
         f: FrequencySeries1d,
-        chirp_mass: ScalarTensor,
-        mass_ratio: ScalarTensor,
-        chi1: ScalarTensor,
-        chi2: ScalarTensor,
-        distance: ScalarTensor,
-        phic: ScalarTensor,
+        chirp_mass: BatchTensor,
+        mass_ratio: BatchTensor,
+        chi1: BatchTensor,
+        chi2: BatchTensor,
+        distance: BatchTensor,
+        phic: BatchTensor,
         f_ref: float,
     ) -> Float[FrequencySeries1d, " batch"]:
         total_mass = chirp_mass * (1 + mass_ratio) ** 1.2 / mass_ratio**0.6

--- a/ml4gw/waveforms/phenom_d.py
+++ b/ml4gw/waveforms/phenom_d.py
@@ -1,5 +1,5 @@
 import torch
-from torchtyping import TensorType
+from jaxtyping import Array, Float
 
 from ..constants import MTSUN_SI, PI
 from .phenom_d_data import QNMData_a, QNMData_fdamp, QNMData_fring
@@ -15,14 +15,14 @@ class IMRPhenomD(TaylorF2):
 
     def forward(
         self,
-        f: TensorType,
-        chirp_mass: TensorType,
-        mass_ratio: TensorType,
-        chi1: TensorType,
-        chi2: TensorType,
-        distance: TensorType,
-        phic: TensorType,
-        inclination: TensorType,
+        f: Float[Array, ""],
+        chirp_mass: Float[Array, ""],
+        mass_ratio: Float[Array, ""],
+        chi1: Float[Array, ""],
+        chi2: Float[Array, ""],
+        distance: Float[Array, ""],
+        phic: Float[Array, ""],
+        inclination: Float[Array, ""],
         f_ref: float,
     ):
         """
@@ -76,13 +76,13 @@ class IMRPhenomD(TaylorF2):
 
     def phenom_d_htilde(
         self,
-        f: TensorType,
-        chirp_mass: TensorType,
-        mass_ratio: TensorType,
-        chi1: TensorType,
-        chi2: TensorType,
-        distance: TensorType,
-        phic: TensorType,
+        f: Float[Array, ""],
+        chirp_mass: Float[Array, ""],
+        mass_ratio: Float[Array, ""],
+        chi1: Float[Array, ""],
+        chi2: Float[Array, ""],
+        distance: Float[Array, ""],
+        phic: Float[Array, ""],
         f_ref: float,
     ):
         total_mass = chirp_mass * (1 + mass_ratio) ** 1.2 / mass_ratio**0.6

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -1,7 +1,7 @@
 from typing import Dict, Tuple
 
 import torch
-from torchtyping import TensorType
+from jaxtyping import Array, Float
 
 from ..constants import MPC_SEC, MTSUN_SI, PI
 from .phenom_d import IMRPhenomD
@@ -13,19 +13,19 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def forward(
         self,
-        fs: TensorType,
-        chirp_mass: TensorType,
-        mass_ratio: TensorType,
-        s1x: TensorType,
-        s1y: TensorType,
-        s1z: TensorType,
-        s2x: TensorType,
-        s2y: TensorType,
-        s2z: TensorType,
-        dist_mpc: TensorType,
-        tc: TensorType,
-        phiRef: TensorType,
-        incl: TensorType,
+        fs: Float[Array, ""],
+        chirp_mass: Float[Array, ""],
+        mass_ratio: Float[Array, ""],
+        s1x: Float[Array, ""],
+        s1y: Float[Array, ""],
+        s1z: Float[Array, ""],
+        s2x: Float[Array, ""],
+        s2y: Float[Array, ""],
+        s2z: Float[Array, ""],
+        dist_mpc: Float[Array, ""],
+        tc: Float[Array, ""],
+        phiRef: Float[Array, ""],
+        incl: Float[Array, ""],
         f_ref: float,
     ):
         """
@@ -184,18 +184,18 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def PhenomPCoreTwistUp(
         self,
-        fHz: TensorType,
-        hPhenom: TensorType,
-        eta: TensorType,
-        chi1_l: TensorType,
-        chi2_l: TensorType,
-        chip: TensorType,
-        M: TensorType,
-        angcoeffs: Dict[str, TensorType],
-        Y2m: TensorType,
-        alphaoffset: TensorType,
-        epsilonoffset: TensorType,
-    ) -> Tuple[TensorType, TensorType]:
+        fHz: Float[Array, ""],
+        hPhenom: Float[Array, ""],
+        eta: Float[Array, ""],
+        chi1_l: Float[Array, ""],
+        chi2_l: Float[Array, ""],
+        chip: Float[Array, ""],
+        M: Float[Array, ""],
+        angcoeffs: Dict[str, Float[Array, ""]],
+        Y2m: Float[Array, ""],
+        alphaoffset: Float[Array, ""],
+        epsilonoffset: Float[Array, ""],
+    ) -> Tuple[Float[Array, ""], Float[Array, ""]]:
         assert angcoeffs is not None
         assert Y2m is not None
         f = fHz * MTSUN_SI * M.unsqueeze(1)  # Frequency in geometric units
@@ -354,8 +354,8 @@ class IMRPhenomPv2(IMRPhenomD):
     # Utility functions
 
     def interpolate(
-        self, x: TensorType, xp: TensorType, fp: TensorType
-    ) -> TensorType:
+        self, x: Float[Array, ""], xp: Float[Array, ""], fp: Float[Array, ""]
+    ) -> Float[Array, ""]:
         """One-dimensional linear interpolation for monotonically
         increasing sample points.
 
@@ -385,7 +385,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
         return interpolated.reshape(original_shape)
 
-    def ROTATEZ(self, angle: TensorType, x, y, z):
+    def ROTATEZ(self, angle: Float[Array, ""], x, y, z):
         tmp_x = x * torch.cos(angle) - y * torch.sin(angle)
         tmp_y = x * torch.sin(angle) + y * torch.cos(angle)
         return tmp_x, tmp_y, z
@@ -395,7 +395,9 @@ class IMRPhenomPv2(IMRPhenomD):
         tmp_z = -x * torch.sin(angle) + z * torch.cos(angle)
         return tmp_x, y, tmp_z
 
-    def L2PNR(self, v: TensorType, eta: TensorType) -> TensorType:
+    def L2PNR(
+        self, v: Float[Array, ""], eta: Float[Array, ""]
+    ) -> Float[Array, ""]:
         eta2 = eta**2
         x = v**2
         x2 = x**2
@@ -412,25 +414,25 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def convert_spins(
         self,
-        m1: TensorType,
-        m2: TensorType,
+        m1: Float[Array, ""],
+        m2: Float[Array, ""],
         f_ref: float,
-        phiRef: TensorType,
-        incl: TensorType,
-        s1x: TensorType,
-        s1y: TensorType,
-        s1z: TensorType,
-        s2x: TensorType,
-        s2y: TensorType,
-        s2z: TensorType,
+        phiRef: Float[Array, ""],
+        incl: Float[Array, ""],
+        s1x: Float[Array, ""],
+        s1y: Float[Array, ""],
+        s1z: Float[Array, ""],
+        s2x: Float[Array, ""],
+        s2y: Float[Array, ""],
+        s2z: Float[Array, ""],
     ) -> Tuple[
-        TensorType,
-        TensorType,
-        TensorType,
-        TensorType,
-        TensorType,
-        TensorType,
-        TensorType,
+        Float[Array, ""],
+        Float[Array, ""],
+        Float[Array, ""],
+        Float[Array, ""],
+        Float[Array, ""],
+        Float[Array, ""],
+        Float[Array, ""],
     ]:
         M = m1 + m2
         m1_2 = m1 * m1
@@ -591,8 +593,12 @@ class IMRPhenomPv2(IMRPhenomD):
                 )
 
     def WignerdCoefficients(
-        self, v: TensorType, SL: TensorType, eta: TensorType, Sp: TensorType
-    ) -> Tuple[TensorType, TensorType]:
+        self,
+        v: Float[Array, ""],
+        SL: Float[Array, ""],
+        eta: Float[Array, ""],
+        Sp: Float[Array, ""],
+    ) -> Tuple[Float[Array, ""], Float[Array, ""]]:
         # We define the shorthand s := Sp / (L + SL)
         L = self.L2PNR(v, eta)
         s = (Sp / (L + SL)).mT
@@ -604,8 +610,11 @@ class IMRPhenomPv2(IMRPhenomD):
         return cos_beta_half, sin_beta_half
 
     def ComputeNNLOanglecoeffs(
-        self, q: TensorType, chil: TensorType, chip: TensorType
-    ) -> Dict[str, TensorType]:
+        self,
+        q: Float[Array, ""],
+        chil: Float[Array, ""],
+        chip: Float[Array, ""],
+    ) -> Dict[str, Float[Array, ""]]:
         m2 = q / (1.0 + q)
         m1 = 1.0 / (1.0 + q)
         dm = m1 - m2
@@ -730,12 +739,12 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def FinalSpin_inplane(
         self,
-        m1: TensorType,
-        m2: TensorType,
-        chi1_l: TensorType,
-        chi2_l: TensorType,
-        chip: TensorType,
-    ) -> TensorType:
+        m1: Float[Array, ""],
+        m2: Float[Array, ""],
+        chi1_l: Float[Array, ""],
+        chi2_l: Float[Array, ""],
+        chip: Float[Array, ""],
+    ) -> Float[Array, ""]:
         M = m1 + m2
         eta = m1 * m2 / (M * M)
         eta2 = eta * eta
@@ -751,7 +760,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def phP_get_fRD_fdamp(
         self, m1, m2, chi1_l, chi2_l, chip
-    ) -> Tuple[TensorType, TensorType]:
+    ) -> Tuple[Float[Array, ""], Float[Array, ""]]:
         # m1 > m2 should hold here
         finspin = self.FinalSpin_inplane(m1, m2, chi1_l, chi2_l, chip)
         m1_s = m1 * MTSUN_SI
@@ -770,7 +779,9 @@ class IMRPhenomPv2(IMRPhenomD):
         ) / (1.0 - Erad)
         return fRD / M_s, fdamp / M_s
 
-    def get_Amp0(self, fM_s: TensorType, eta: TensorType) -> TensorType:
+    def get_Amp0(
+        self, fM_s: Float[Array, ""], eta: Float[Array, ""]
+    ) -> Float[Array, ""]:
         Amp0 = (
             (2.0 / 3.0 * eta.unsqueeze(1)) ** (1.0 / 2.0)
             * (fM_s) ** (-7.0 / 6.0)

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -1,7 +1,8 @@
 from typing import Dict, Tuple
 
 import torch
-from jaxtyping import Array, Float
+from jaxtyping import Float
+from torch import Tensor
 
 from ..constants import MPC_SEC, MTSUN_SI, PI
 from .phenom_d import IMRPhenomD
@@ -13,19 +14,19 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def forward(
         self,
-        fs: Float[Array, ""],
-        chirp_mass: Float[Array, ""],
-        mass_ratio: Float[Array, ""],
-        s1x: Float[Array, ""],
-        s1y: Float[Array, ""],
-        s1z: Float[Array, ""],
-        s2x: Float[Array, ""],
-        s2y: Float[Array, ""],
-        s2z: Float[Array, ""],
-        dist_mpc: Float[Array, ""],
-        tc: Float[Array, ""],
-        phiRef: Float[Array, ""],
-        incl: Float[Array, ""],
+        fs: Float[Tensor, ""],
+        chirp_mass: Float[Tensor, ""],
+        mass_ratio: Float[Tensor, ""],
+        s1x: Float[Tensor, ""],
+        s1y: Float[Tensor, ""],
+        s1z: Float[Tensor, ""],
+        s2x: Float[Tensor, ""],
+        s2y: Float[Tensor, ""],
+        s2z: Float[Tensor, ""],
+        dist_mpc: Float[Tensor, ""],
+        tc: Float[Tensor, ""],
+        phiRef: Float[Tensor, ""],
+        incl: Float[Tensor, ""],
         f_ref: float,
     ):
         """
@@ -184,18 +185,18 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def PhenomPCoreTwistUp(
         self,
-        fHz: Float[Array, ""],
-        hPhenom: Float[Array, ""],
-        eta: Float[Array, ""],
-        chi1_l: Float[Array, ""],
-        chi2_l: Float[Array, ""],
-        chip: Float[Array, ""],
-        M: Float[Array, ""],
-        angcoeffs: Dict[str, Float[Array, ""]],
-        Y2m: Float[Array, ""],
-        alphaoffset: Float[Array, ""],
-        epsilonoffset: Float[Array, ""],
-    ) -> Tuple[Float[Array, ""], Float[Array, ""]]:
+        fHz: Float[Tensor, ""],
+        hPhenom: Float[Tensor, ""],
+        eta: Float[Tensor, ""],
+        chi1_l: Float[Tensor, ""],
+        chi2_l: Float[Tensor, ""],
+        chip: Float[Tensor, ""],
+        M: Float[Tensor, ""],
+        angcoeffs: Dict[str, Float[Tensor, ""]],
+        Y2m: Float[Tensor, ""],
+        alphaoffset: Float[Tensor, ""],
+        epsilonoffset: Float[Tensor, ""],
+    ) -> Tuple[Float[Tensor, ""], Float[Tensor, ""]]:
         assert angcoeffs is not None
         assert Y2m is not None
         f = fHz * MTSUN_SI * M.unsqueeze(1)  # Frequency in geometric units
@@ -354,8 +355,11 @@ class IMRPhenomPv2(IMRPhenomD):
     # Utility functions
 
     def interpolate(
-        self, x: Float[Array, ""], xp: Float[Array, ""], fp: Float[Array, ""]
-    ) -> Float[Array, ""]:
+        self,
+        x: Float[Tensor, ""],
+        xp: Float[Tensor, ""],
+        fp: Float[Tensor, ""],
+    ) -> Float[Tensor, ""]:
         """One-dimensional linear interpolation for monotonically
         increasing sample points.
 
@@ -385,7 +389,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
         return interpolated.reshape(original_shape)
 
-    def ROTATEZ(self, angle: Float[Array, ""], x, y, z):
+    def ROTATEZ(self, angle: Float[Tensor, ""], x, y, z):
         tmp_x = x * torch.cos(angle) - y * torch.sin(angle)
         tmp_y = x * torch.sin(angle) + y * torch.cos(angle)
         return tmp_x, tmp_y, z
@@ -396,8 +400,8 @@ class IMRPhenomPv2(IMRPhenomD):
         return tmp_x, y, tmp_z
 
     def L2PNR(
-        self, v: Float[Array, ""], eta: Float[Array, ""]
-    ) -> Float[Array, ""]:
+        self, v: Float[Tensor, ""], eta: Float[Tensor, ""]
+    ) -> Float[Tensor, ""]:
         eta2 = eta**2
         x = v**2
         x2 = x**2
@@ -414,25 +418,25 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def convert_spins(
         self,
-        m1: Float[Array, ""],
-        m2: Float[Array, ""],
+        m1: Float[Tensor, ""],
+        m2: Float[Tensor, ""],
         f_ref: float,
-        phiRef: Float[Array, ""],
-        incl: Float[Array, ""],
-        s1x: Float[Array, ""],
-        s1y: Float[Array, ""],
-        s1z: Float[Array, ""],
-        s2x: Float[Array, ""],
-        s2y: Float[Array, ""],
-        s2z: Float[Array, ""],
+        phiRef: Float[Tensor, ""],
+        incl: Float[Tensor, ""],
+        s1x: Float[Tensor, ""],
+        s1y: Float[Tensor, ""],
+        s1z: Float[Tensor, ""],
+        s2x: Float[Tensor, ""],
+        s2y: Float[Tensor, ""],
+        s2z: Float[Tensor, ""],
     ) -> Tuple[
-        Float[Array, ""],
-        Float[Array, ""],
-        Float[Array, ""],
-        Float[Array, ""],
-        Float[Array, ""],
-        Float[Array, ""],
-        Float[Array, ""],
+        Float[Tensor, ""],
+        Float[Tensor, ""],
+        Float[Tensor, ""],
+        Float[Tensor, ""],
+        Float[Tensor, ""],
+        Float[Tensor, ""],
+        Float[Tensor, ""],
     ]:
         M = m1 + m2
         m1_2 = m1 * m1
@@ -594,11 +598,11 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def WignerdCoefficients(
         self,
-        v: Float[Array, ""],
-        SL: Float[Array, ""],
-        eta: Float[Array, ""],
-        Sp: Float[Array, ""],
-    ) -> Tuple[Float[Array, ""], Float[Array, ""]]:
+        v: Float[Tensor, ""],
+        SL: Float[Tensor, ""],
+        eta: Float[Tensor, ""],
+        Sp: Float[Tensor, ""],
+    ) -> Tuple[Float[Tensor, ""], Float[Tensor, ""]]:
         # We define the shorthand s := Sp / (L + SL)
         L = self.L2PNR(v, eta)
         s = (Sp / (L + SL)).mT
@@ -611,10 +615,10 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def ComputeNNLOanglecoeffs(
         self,
-        q: Float[Array, ""],
-        chil: Float[Array, ""],
-        chip: Float[Array, ""],
-    ) -> Dict[str, Float[Array, ""]]:
+        q: Float[Tensor, ""],
+        chil: Float[Tensor, ""],
+        chip: Float[Tensor, ""],
+    ) -> Dict[str, Float[Tensor, ""]]:
         m2 = q / (1.0 + q)
         m1 = 1.0 / (1.0 + q)
         dm = m1 - m2
@@ -739,12 +743,12 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def FinalSpin_inplane(
         self,
-        m1: Float[Array, ""],
-        m2: Float[Array, ""],
-        chi1_l: Float[Array, ""],
-        chi2_l: Float[Array, ""],
-        chip: Float[Array, ""],
-    ) -> Float[Array, ""]:
+        m1: Float[Tensor, ""],
+        m2: Float[Tensor, ""],
+        chi1_l: Float[Tensor, ""],
+        chi2_l: Float[Tensor, ""],
+        chip: Float[Tensor, ""],
+    ) -> Float[Tensor, ""]:
         M = m1 + m2
         eta = m1 * m2 / (M * M)
         eta2 = eta * eta
@@ -760,7 +764,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def phP_get_fRD_fdamp(
         self, m1, m2, chi1_l, chi2_l, chip
-    ) -> Tuple[Float[Array, ""], Float[Array, ""]]:
+    ) -> Tuple[Float[Tensor, ""], Float[Tensor, ""]]:
         # m1 > m2 should hold here
         finspin = self.FinalSpin_inplane(m1, m2, chi1_l, chi2_l, chip)
         m1_s = m1 * MTSUN_SI
@@ -780,8 +784,8 @@ class IMRPhenomPv2(IMRPhenomD):
         return fRD / M_s, fdamp / M_s
 
     def get_Amp0(
-        self, fM_s: Float[Array, ""], eta: Float[Array, ""]
-    ) -> Float[Array, ""]:
+        self, fM_s: Float[Tensor, ""], eta: Float[Tensor, ""]
+    ) -> Float[Tensor, ""]:
         Amp0 = (
             (2.0 / 3.0 * eta.unsqueeze(1)) ** (1.0 / 2.0)
             * (fM_s) ** (-7.0 / 6.0)

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -4,7 +4,9 @@ import torch
 from jaxtyping import Float
 from torch import Tensor
 
-from ..constants import MPC_SEC, MTSUN_SI, PI
+from ml4gw.constants import MPC_SEC, MTSUN_SI, PI
+from ml4gw.types import FrequencySeries1d, ScalarTensor
+
 from .phenom_d import IMRPhenomD
 
 
@@ -14,19 +16,19 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def forward(
         self,
-        fs: Float[Tensor, ""],
-        chirp_mass: Float[Tensor, ""],
-        mass_ratio: Float[Tensor, ""],
-        s1x: Float[Tensor, ""],
-        s1y: Float[Tensor, ""],
-        s1z: Float[Tensor, ""],
-        s2x: Float[Tensor, ""],
-        s2y: Float[Tensor, ""],
-        s2z: Float[Tensor, ""],
-        dist_mpc: Float[Tensor, ""],
-        tc: Float[Tensor, ""],
-        phiRef: Float[Tensor, ""],
-        incl: Float[Tensor, ""],
+        fs: FrequencySeries1d,
+        chirp_mass: ScalarTensor,
+        mass_ratio: ScalarTensor,
+        s1x: ScalarTensor,
+        s1y: ScalarTensor,
+        s1z: ScalarTensor,
+        s2x: ScalarTensor,
+        s2y: ScalarTensor,
+        s2z: ScalarTensor,
+        dist_mpc: ScalarTensor,
+        tc: ScalarTensor,
+        phiRef: ScalarTensor,
+        incl: ScalarTensor,
         f_ref: float,
     ):
         """
@@ -185,18 +187,18 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def PhenomPCoreTwistUp(
         self,
-        fHz: Float[Tensor, ""],
-        hPhenom: Float[Tensor, ""],
-        eta: Float[Tensor, ""],
-        chi1_l: Float[Tensor, ""],
-        chi2_l: Float[Tensor, ""],
-        chip: Float[Tensor, ""],
-        M: Float[Tensor, ""],
-        angcoeffs: Dict[str, Float[Tensor, ""]],
-        Y2m: Float[Tensor, ""],
-        alphaoffset: Float[Tensor, ""],
-        epsilonoffset: Float[Tensor, ""],
-    ) -> Tuple[Float[Tensor, ""], Float[Tensor, ""]]:
+        fHz: FrequencySeries1d,
+        hPhenom: ScalarTensor,
+        eta: ScalarTensor,
+        chi1_l: ScalarTensor,
+        chi2_l: ScalarTensor,
+        chip: ScalarTensor,
+        M: ScalarTensor,
+        angcoeffs: Dict[str, ScalarTensor],
+        Y2m: ScalarTensor,
+        alphaoffset: ScalarTensor,
+        epsilonoffset: ScalarTensor,
+    ) -> Tuple[ScalarTensor, ScalarTensor]:
         assert angcoeffs is not None
         assert Y2m is not None
         f = fHz * MTSUN_SI * M.unsqueeze(1)  # Frequency in geometric units
@@ -356,10 +358,10 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def interpolate(
         self,
-        x: Float[Tensor, ""],
-        xp: Float[Tensor, ""],
-        fp: Float[Tensor, ""],
-    ) -> Float[Tensor, ""]:
+        x: Float[Tensor, " new_series"],
+        xp: Float[Tensor, " series"],
+        fp: Float[Tensor, " series"],
+    ) -> Float[Tensor, " new_series"]:
         """One-dimensional linear interpolation for monotonically
         increasing sample points.
 
@@ -389,7 +391,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
         return interpolated.reshape(original_shape)
 
-    def ROTATEZ(self, angle: Float[Tensor, ""], x, y, z):
+    def ROTATEZ(self, angle: ScalarTensor, x, y, z):
         tmp_x = x * torch.cos(angle) - y * torch.sin(angle)
         tmp_y = x * torch.sin(angle) + y * torch.cos(angle)
         return tmp_x, tmp_y, z
@@ -400,8 +402,10 @@ class IMRPhenomPv2(IMRPhenomD):
         return tmp_x, y, tmp_z
 
     def L2PNR(
-        self, v: Float[Tensor, ""], eta: Float[Tensor, ""]
-    ) -> Float[Tensor, ""]:
+        self,
+        v: ScalarTensor,
+        eta: ScalarTensor,
+    ) -> ScalarTensor:
         eta2 = eta**2
         x = v**2
         x2 = x**2
@@ -418,25 +422,25 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def convert_spins(
         self,
-        m1: Float[Tensor, ""],
-        m2: Float[Tensor, ""],
+        m1: ScalarTensor,
+        m2: ScalarTensor,
         f_ref: float,
-        phiRef: Float[Tensor, ""],
-        incl: Float[Tensor, ""],
-        s1x: Float[Tensor, ""],
-        s1y: Float[Tensor, ""],
-        s1z: Float[Tensor, ""],
-        s2x: Float[Tensor, ""],
-        s2y: Float[Tensor, ""],
-        s2z: Float[Tensor, ""],
+        phiRef: ScalarTensor,
+        incl: ScalarTensor,
+        s1x: ScalarTensor,
+        s1y: ScalarTensor,
+        s1z: ScalarTensor,
+        s2x: ScalarTensor,
+        s2y: ScalarTensor,
+        s2z: ScalarTensor,
     ) -> Tuple[
-        Float[Tensor, ""],
-        Float[Tensor, ""],
-        Float[Tensor, ""],
-        Float[Tensor, ""],
-        Float[Tensor, ""],
-        Float[Tensor, ""],
-        Float[Tensor, ""],
+        ScalarTensor,
+        ScalarTensor,
+        ScalarTensor,
+        ScalarTensor,
+        ScalarTensor,
+        ScalarTensor,
+        ScalarTensor,
     ]:
         M = m1 + m2
         m1_2 = m1 * m1
@@ -598,11 +602,11 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def WignerdCoefficients(
         self,
-        v: Float[Tensor, ""],
-        SL: Float[Tensor, ""],
-        eta: Float[Tensor, ""],
-        Sp: Float[Tensor, ""],
-    ) -> Tuple[Float[Tensor, ""], Float[Tensor, ""]]:
+        v: ScalarTensor,
+        SL: ScalarTensor,
+        eta: ScalarTensor,
+        Sp: ScalarTensor,
+    ) -> Tuple[ScalarTensor, ScalarTensor]:
         # We define the shorthand s := Sp / (L + SL)
         L = self.L2PNR(v, eta)
         s = (Sp / (L + SL)).mT
@@ -615,10 +619,10 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def ComputeNNLOanglecoeffs(
         self,
-        q: Float[Tensor, ""],
-        chil: Float[Tensor, ""],
-        chip: Float[Tensor, ""],
-    ) -> Dict[str, Float[Tensor, ""]]:
+        q: ScalarTensor,
+        chil: ScalarTensor,
+        chip: ScalarTensor,
+    ) -> Dict[str, ScalarTensor]:
         m2 = q / (1.0 + q)
         m1 = 1.0 / (1.0 + q)
         dm = m1 - m2
@@ -743,12 +747,12 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def FinalSpin_inplane(
         self,
-        m1: Float[Tensor, ""],
-        m2: Float[Tensor, ""],
-        chi1_l: Float[Tensor, ""],
-        chi2_l: Float[Tensor, ""],
-        chip: Float[Tensor, ""],
-    ) -> Float[Tensor, ""]:
+        m1: ScalarTensor,
+        m2: ScalarTensor,
+        chi1_l: ScalarTensor,
+        chi2_l: ScalarTensor,
+        chip: ScalarTensor,
+    ) -> ScalarTensor:
         M = m1 + m2
         eta = m1 * m2 / (M * M)
         eta2 = eta * eta
@@ -764,7 +768,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def phP_get_fRD_fdamp(
         self, m1, m2, chi1_l, chi2_l, chip
-    ) -> Tuple[Float[Tensor, ""], Float[Tensor, ""]]:
+    ) -> Tuple[ScalarTensor, ScalarTensor]:
         # m1 > m2 should hold here
         finspin = self.FinalSpin_inplane(m1, m2, chi1_l, chi2_l, chip)
         m1_s = m1 * MTSUN_SI
@@ -783,9 +787,7 @@ class IMRPhenomPv2(IMRPhenomD):
         ) / (1.0 - Erad)
         return fRD / M_s, fdamp / M_s
 
-    def get_Amp0(
-        self, fM_s: Float[Tensor, ""], eta: Float[Tensor, ""]
-    ) -> Float[Tensor, ""]:
+    def get_Amp0(self, fM_s: ScalarTensor, eta: ScalarTensor) -> ScalarTensor:
         Amp0 = (
             (2.0 / 3.0 * eta.unsqueeze(1)) ** (1.0 / 2.0)
             * (fM_s) ** (-7.0 / 6.0)

--- a/ml4gw/waveforms/phenom_p.py
+++ b/ml4gw/waveforms/phenom_p.py
@@ -5,7 +5,7 @@ from jaxtyping import Float
 from torch import Tensor
 
 from ml4gw.constants import MPC_SEC, MTSUN_SI, PI
-from ml4gw.types import FrequencySeries1d, ScalarTensor
+from ml4gw.types import BatchTensor, FrequencySeries1d
 
 from .phenom_d import IMRPhenomD
 
@@ -17,18 +17,18 @@ class IMRPhenomPv2(IMRPhenomD):
     def forward(
         self,
         fs: FrequencySeries1d,
-        chirp_mass: ScalarTensor,
-        mass_ratio: ScalarTensor,
-        s1x: ScalarTensor,
-        s1y: ScalarTensor,
-        s1z: ScalarTensor,
-        s2x: ScalarTensor,
-        s2y: ScalarTensor,
-        s2z: ScalarTensor,
-        dist_mpc: ScalarTensor,
-        tc: ScalarTensor,
-        phiRef: ScalarTensor,
-        incl: ScalarTensor,
+        chirp_mass: BatchTensor,
+        mass_ratio: BatchTensor,
+        s1x: BatchTensor,
+        s1y: BatchTensor,
+        s1z: BatchTensor,
+        s2x: BatchTensor,
+        s2y: BatchTensor,
+        s2z: BatchTensor,
+        dist_mpc: BatchTensor,
+        tc: BatchTensor,
+        phiRef: BatchTensor,
+        incl: BatchTensor,
         f_ref: float,
     ):
         """
@@ -188,17 +188,17 @@ class IMRPhenomPv2(IMRPhenomD):
     def PhenomPCoreTwistUp(
         self,
         fHz: FrequencySeries1d,
-        hPhenom: ScalarTensor,
-        eta: ScalarTensor,
-        chi1_l: ScalarTensor,
-        chi2_l: ScalarTensor,
-        chip: ScalarTensor,
-        M: ScalarTensor,
-        angcoeffs: Dict[str, ScalarTensor],
-        Y2m: ScalarTensor,
-        alphaoffset: ScalarTensor,
-        epsilonoffset: ScalarTensor,
-    ) -> Tuple[ScalarTensor, ScalarTensor]:
+        hPhenom: BatchTensor,
+        eta: BatchTensor,
+        chi1_l: BatchTensor,
+        chi2_l: BatchTensor,
+        chip: BatchTensor,
+        M: BatchTensor,
+        angcoeffs: Dict[str, BatchTensor],
+        Y2m: BatchTensor,
+        alphaoffset: BatchTensor,
+        epsilonoffset: BatchTensor,
+    ) -> Tuple[BatchTensor, BatchTensor]:
         assert angcoeffs is not None
         assert Y2m is not None
         f = fHz * MTSUN_SI * M.unsqueeze(1)  # Frequency in geometric units
@@ -391,7 +391,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
         return interpolated.reshape(original_shape)
 
-    def ROTATEZ(self, angle: ScalarTensor, x, y, z):
+    def ROTATEZ(self, angle: BatchTensor, x, y, z):
         tmp_x = x * torch.cos(angle) - y * torch.sin(angle)
         tmp_y = x * torch.sin(angle) + y * torch.cos(angle)
         return tmp_x, tmp_y, z
@@ -403,9 +403,9 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def L2PNR(
         self,
-        v: ScalarTensor,
-        eta: ScalarTensor,
-    ) -> ScalarTensor:
+        v: BatchTensor,
+        eta: BatchTensor,
+    ) -> BatchTensor:
         eta2 = eta**2
         x = v**2
         x2 = x**2
@@ -422,25 +422,25 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def convert_spins(
         self,
-        m1: ScalarTensor,
-        m2: ScalarTensor,
+        m1: BatchTensor,
+        m2: BatchTensor,
         f_ref: float,
-        phiRef: ScalarTensor,
-        incl: ScalarTensor,
-        s1x: ScalarTensor,
-        s1y: ScalarTensor,
-        s1z: ScalarTensor,
-        s2x: ScalarTensor,
-        s2y: ScalarTensor,
-        s2z: ScalarTensor,
+        phiRef: BatchTensor,
+        incl: BatchTensor,
+        s1x: BatchTensor,
+        s1y: BatchTensor,
+        s1z: BatchTensor,
+        s2x: BatchTensor,
+        s2y: BatchTensor,
+        s2z: BatchTensor,
     ) -> Tuple[
-        ScalarTensor,
-        ScalarTensor,
-        ScalarTensor,
-        ScalarTensor,
-        ScalarTensor,
-        ScalarTensor,
-        ScalarTensor,
+        BatchTensor,
+        BatchTensor,
+        BatchTensor,
+        BatchTensor,
+        BatchTensor,
+        BatchTensor,
+        BatchTensor,
     ]:
         M = m1 + m2
         m1_2 = m1 * m1
@@ -602,11 +602,11 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def WignerdCoefficients(
         self,
-        v: ScalarTensor,
-        SL: ScalarTensor,
-        eta: ScalarTensor,
-        Sp: ScalarTensor,
-    ) -> Tuple[ScalarTensor, ScalarTensor]:
+        v: BatchTensor,
+        SL: BatchTensor,
+        eta: BatchTensor,
+        Sp: BatchTensor,
+    ) -> Tuple[BatchTensor, BatchTensor]:
         # We define the shorthand s := Sp / (L + SL)
         L = self.L2PNR(v, eta)
         s = (Sp / (L + SL)).mT
@@ -619,10 +619,10 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def ComputeNNLOanglecoeffs(
         self,
-        q: ScalarTensor,
-        chil: ScalarTensor,
-        chip: ScalarTensor,
-    ) -> Dict[str, ScalarTensor]:
+        q: BatchTensor,
+        chil: BatchTensor,
+        chip: BatchTensor,
+    ) -> Dict[str, BatchTensor]:
         m2 = q / (1.0 + q)
         m1 = 1.0 / (1.0 + q)
         dm = m1 - m2
@@ -747,12 +747,12 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def FinalSpin_inplane(
         self,
-        m1: ScalarTensor,
-        m2: ScalarTensor,
-        chi1_l: ScalarTensor,
-        chi2_l: ScalarTensor,
-        chip: ScalarTensor,
-    ) -> ScalarTensor:
+        m1: BatchTensor,
+        m2: BatchTensor,
+        chi1_l: BatchTensor,
+        chi2_l: BatchTensor,
+        chip: BatchTensor,
+    ) -> BatchTensor:
         M = m1 + m2
         eta = m1 * m2 / (M * M)
         eta2 = eta * eta
@@ -768,7 +768,7 @@ class IMRPhenomPv2(IMRPhenomD):
 
     def phP_get_fRD_fdamp(
         self, m1, m2, chi1_l, chi2_l, chip
-    ) -> Tuple[ScalarTensor, ScalarTensor]:
+    ) -> Tuple[BatchTensor, BatchTensor]:
         # m1 > m2 should hold here
         finspin = self.FinalSpin_inplane(m1, m2, chi1_l, chi2_l, chip)
         m1_s = m1 * MTSUN_SI
@@ -787,7 +787,7 @@ class IMRPhenomPv2(IMRPhenomD):
         ) / (1.0 - Erad)
         return fRD / M_s, fdamp / M_s
 
-    def get_Amp0(self, fM_s: ScalarTensor, eta: ScalarTensor) -> ScalarTensor:
+    def get_Amp0(self, fM_s: BatchTensor, eta: BatchTensor) -> BatchTensor:
         Amp0 = (
             (2.0 / 3.0 * eta.unsqueeze(1)) ** (1.0 / 2.0)
             * (fM_s) ** (-7.0 / 6.0)

--- a/ml4gw/waveforms/ringdown.py
+++ b/ml4gw/waveforms/ringdown.py
@@ -1,9 +1,8 @@
 import numpy as np
 import torch
 
+from ml4gw.constants import PI, C, G, m_per_Mpc
 from ml4gw.types import ScalarTensor
-
-from ..constants import PI, C, G, m_per_Mpc
 
 
 class Ringdown(torch.nn.Module):

--- a/ml4gw/waveforms/ringdown.py
+++ b/ml4gw/waveforms/ringdown.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 
 from ml4gw.constants import PI, C, G, m_per_Mpc
-from ml4gw.types import ScalarTensor
+from ml4gw.types import BatchTensor
 
 
 class Ringdown(torch.nn.Module):
@@ -26,12 +26,12 @@ class Ringdown(torch.nn.Module):
 
     def forward(
         self,
-        frequency: ScalarTensor,
-        quality: ScalarTensor,
-        epsilon: ScalarTensor,
-        phase: ScalarTensor,
-        inclination: ScalarTensor,
-        distance: ScalarTensor,
+        frequency: BatchTensor,
+        quality: BatchTensor,
+        epsilon: BatchTensor,
+        phase: BatchTensor,
+        inclination: BatchTensor,
+        distance: BatchTensor,
     ):
         """
         Generate ringdown waveform based on the damped sinusoid equation.

--- a/ml4gw/waveforms/sine_gaussian.py
+++ b/ml4gw/waveforms/sine_gaussian.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor
 
-from ml4gw.types import ScalarTensor
+from ml4gw.types import BatchTensor
 
 
 def semi_major_minor_from_e(e: Tensor):
@@ -32,11 +32,11 @@ class SineGaussian(torch.nn.Module):
 
     def forward(
         self,
-        quality: ScalarTensor,
-        frequency: ScalarTensor,
-        hrss: ScalarTensor,
-        phase: ScalarTensor,
-        eccentricity: ScalarTensor,
+        quality: BatchTensor,
+        frequency: BatchTensor,
+        hrss: BatchTensor,
+        phase: BatchTensor,
+        eccentricity: BatchTensor,
     ):
         """
         Generate lalinference implementation of a sine-Gaussian waveform.

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -1,5 +1,6 @@
 import torch
-from jaxtyping import Array, Float
+from jaxtyping import Float
+from torch import Tensor
 
 from ..constants import MPC_SEC, MTSUN_SI, PI
 from ..constants import EulerGamma as GAMMA
@@ -11,14 +12,14 @@ class TaylorF2(torch.nn.Module):
 
     def forward(
         self,
-        f: Float[Array, ""],
-        chirp_mass: Float[Array, ""],
-        mass_ratio: Float[Array, ""],
-        chi1: Float[Array, ""],
-        chi2: Float[Array, ""],
-        distance: Float[Array, ""],
-        phic: Float[Array, ""],
-        inclination: Float[Array, ""],
+        f: Float[Tensor, ""],
+        chirp_mass: Float[Tensor, ""],
+        mass_ratio: Float[Tensor, ""],
+        chi1: Float[Tensor, ""],
+        chi2: Float[Tensor, ""],
+        distance: Float[Tensor, ""],
+        phic: Float[Tensor, ""],
+        inclination: Float[Tensor, ""],
         f_ref: float,
     ):
         """
@@ -75,13 +76,13 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_htilde(
         self,
-        f: Float[Array, ""],
-        mass1: Float[Array, ""],
-        mass2: Float[Array, ""],
-        chi1: Float[Array, ""],
-        chi2: Float[Array, ""],
-        distance: Float[Array, ""],
-        phic: Float[Array, ""],
+        f: Float[Tensor, ""],
+        mass1: Float[Tensor, ""],
+        mass2: Float[Tensor, ""],
+        chi1: Float[Tensor, ""],
+        chi2: Float[Tensor, ""],
+        distance: Float[Tensor, ""],
+        phic: Float[Tensor, ""],
         f_ref: float,
     ):
         mass1_s = mass1 * MTSUN_SI
@@ -103,8 +104,8 @@ class TaylorF2(torch.nn.Module):
         return h0
 
     def taylorf2_amplitude(
-        self, Mf: Float[Array, ""], mass1, mass2, eta, distance
-    ) -> Float[Array, ""]:
+        self, Mf: Float[Tensor, ""], mass1, mass2, eta, distance
+    ) -> Float[Tensor, ""]:
         mass1_s = mass1 * MTSUN_SI
         mass2_s = mass2 * MTSUN_SI
         v = (PI * Mf) ** (1.0 / 3.0)
@@ -126,12 +127,12 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_phase(
         self,
-        Mf: Float[Array, ""],
-        mass1: Float[Array, ""],
-        mass2: Float[Array, ""],
-        chi1: Float[Array, ""],
-        chi2: Float[Array, ""],
-    ) -> Float[Array, ""]:
+        Mf: Float[Tensor, ""],
+        mass1: Float[Tensor, ""],
+        mass2: Float[Tensor, ""],
+        chi1: Float[Tensor, ""],
+        chi2: Float[Tensor, ""],
+    ) -> Float[Tensor, ""]:
         """
         Calculate the inspiral phase for the TaylorF2.
         """

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -1,9 +1,9 @@
 import torch
 from jaxtyping import Float
-from torch import Tensor
 
-from ..constants import MPC_SEC, MTSUN_SI, PI
-from ..constants import EulerGamma as GAMMA
+from ml4gw.constants import MPC_SEC, MTSUN_SI, PI
+from ml4gw.constants import EulerGamma as GAMMA
+from ml4gw.types import FrequencySeries1d, ScalarTensor
 
 
 class TaylorF2(torch.nn.Module):
@@ -12,14 +12,14 @@ class TaylorF2(torch.nn.Module):
 
     def forward(
         self,
-        f: Float[Tensor, ""],
-        chirp_mass: Float[Tensor, ""],
-        mass_ratio: Float[Tensor, ""],
-        chi1: Float[Tensor, ""],
-        chi2: Float[Tensor, ""],
-        distance: Float[Tensor, ""],
-        phic: Float[Tensor, ""],
-        inclination: Float[Tensor, ""],
+        f: FrequencySeries1d,
+        chirp_mass: ScalarTensor,
+        mass_ratio: ScalarTensor,
+        chi1: ScalarTensor,
+        chi2: ScalarTensor,
+        distance: ScalarTensor,
+        phic: ScalarTensor,
+        inclination: ScalarTensor,
         f_ref: float,
     ):
         """
@@ -76,15 +76,15 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_htilde(
         self,
-        f: Float[Tensor, ""],
-        mass1: Float[Tensor, ""],
-        mass2: Float[Tensor, ""],
-        chi1: Float[Tensor, ""],
-        chi2: Float[Tensor, ""],
-        distance: Float[Tensor, ""],
-        phic: Float[Tensor, ""],
+        f: FrequencySeries1d,
+        mass1: ScalarTensor,
+        mass2: ScalarTensor,
+        chi1: ScalarTensor,
+        chi2: ScalarTensor,
+        distance: ScalarTensor,
+        phic: ScalarTensor,
         f_ref: float,
-    ):
+    ) -> Float[FrequencySeries1d, " batch"]:
         mass1_s = mass1 * MTSUN_SI
         mass2_s = mass2 * MTSUN_SI
         M_s = mass1_s + mass2_s
@@ -104,8 +104,13 @@ class TaylorF2(torch.nn.Module):
         return h0
 
     def taylorf2_amplitude(
-        self, Mf: Float[Tensor, ""], mass1, mass2, eta, distance
-    ) -> Float[Tensor, ""]:
+        self,
+        Mf: ScalarTensor,
+        mass1: ScalarTensor,
+        mass2: ScalarTensor,
+        eta: ScalarTensor,
+        distance: ScalarTensor,
+    ) -> Float[FrequencySeries1d, " batch"]:
         mass1_s = mass1 * MTSUN_SI
         mass2_s = mass2 * MTSUN_SI
         v = (PI * Mf) ** (1.0 / 3.0)
@@ -127,12 +132,12 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_phase(
         self,
-        Mf: Float[Tensor, ""],
-        mass1: Float[Tensor, ""],
-        mass2: Float[Tensor, ""],
-        chi1: Float[Tensor, ""],
-        chi2: Float[Tensor, ""],
-    ) -> Float[Tensor, ""]:
+        Mf: ScalarTensor,
+        mass1: ScalarTensor,
+        mass2: ScalarTensor,
+        chi1: ScalarTensor,
+        chi2: ScalarTensor,
+    ) -> Float[FrequencySeries1d, " batch"]:
         """
         Calculate the inspiral phase for the TaylorF2.
         """

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -1,5 +1,5 @@
 import torch
-from torchtyping import TensorType
+from jaxtyping import Array, Float
 
 from ..constants import MPC_SEC, MTSUN_SI, PI
 from ..constants import EulerGamma as GAMMA
@@ -11,14 +11,14 @@ class TaylorF2(torch.nn.Module):
 
     def forward(
         self,
-        f: TensorType,
-        chirp_mass: TensorType,
-        mass_ratio: TensorType,
-        chi1: TensorType,
-        chi2: TensorType,
-        distance: TensorType,
-        phic: TensorType,
-        inclination: TensorType,
+        f: Float[Array, ""],
+        chirp_mass: Float[Array, ""],
+        mass_ratio: Float[Array, ""],
+        chi1: Float[Array, ""],
+        chi2: Float[Array, ""],
+        distance: Float[Array, ""],
+        phic: Float[Array, ""],
+        inclination: Float[Array, ""],
         f_ref: float,
     ):
         """
@@ -75,13 +75,13 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_htilde(
         self,
-        f: TensorType,
-        mass1: TensorType,
-        mass2: TensorType,
-        chi1: TensorType,
-        chi2: TensorType,
-        distance: TensorType,
-        phic: TensorType,
+        f: Float[Array, ""],
+        mass1: Float[Array, ""],
+        mass2: Float[Array, ""],
+        chi1: Float[Array, ""],
+        chi2: Float[Array, ""],
+        distance: Float[Array, ""],
+        phic: Float[Array, ""],
         f_ref: float,
     ):
         mass1_s = mass1 * MTSUN_SI
@@ -103,8 +103,8 @@ class TaylorF2(torch.nn.Module):
         return h0
 
     def taylorf2_amplitude(
-        self, Mf: TensorType, mass1, mass2, eta, distance
-    ) -> TensorType:
+        self, Mf: Float[Array, ""], mass1, mass2, eta, distance
+    ) -> Float[Array, ""]:
         mass1_s = mass1 * MTSUN_SI
         mass2_s = mass2 * MTSUN_SI
         v = (PI * Mf) ** (1.0 / 3.0)
@@ -126,12 +126,12 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_phase(
         self,
-        Mf: TensorType,
-        mass1: TensorType,
-        mass2: TensorType,
-        chi1: TensorType,
-        chi2: TensorType,
-    ) -> TensorType:
+        Mf: Float[Array, ""],
+        mass1: Float[Array, ""],
+        mass2: Float[Array, ""],
+        chi1: Float[Array, ""],
+        chi2: Float[Array, ""],
+    ) -> Float[Array, ""]:
         """
         Calculate the inspiral phase for the TaylorF2.
         """

--- a/ml4gw/waveforms/taylorf2.py
+++ b/ml4gw/waveforms/taylorf2.py
@@ -3,7 +3,7 @@ from jaxtyping import Float
 
 from ml4gw.constants import MPC_SEC, MTSUN_SI, PI
 from ml4gw.constants import EulerGamma as GAMMA
-from ml4gw.types import FrequencySeries1d, ScalarTensor
+from ml4gw.types import BatchTensor, FrequencySeries1d
 
 
 class TaylorF2(torch.nn.Module):
@@ -13,13 +13,13 @@ class TaylorF2(torch.nn.Module):
     def forward(
         self,
         f: FrequencySeries1d,
-        chirp_mass: ScalarTensor,
-        mass_ratio: ScalarTensor,
-        chi1: ScalarTensor,
-        chi2: ScalarTensor,
-        distance: ScalarTensor,
-        phic: ScalarTensor,
-        inclination: ScalarTensor,
+        chirp_mass: BatchTensor,
+        mass_ratio: BatchTensor,
+        chi1: BatchTensor,
+        chi2: BatchTensor,
+        distance: BatchTensor,
+        phic: BatchTensor,
+        inclination: BatchTensor,
         f_ref: float,
     ):
         """
@@ -77,12 +77,12 @@ class TaylorF2(torch.nn.Module):
     def taylorf2_htilde(
         self,
         f: FrequencySeries1d,
-        mass1: ScalarTensor,
-        mass2: ScalarTensor,
-        chi1: ScalarTensor,
-        chi2: ScalarTensor,
-        distance: ScalarTensor,
-        phic: ScalarTensor,
+        mass1: BatchTensor,
+        mass2: BatchTensor,
+        chi1: BatchTensor,
+        chi2: BatchTensor,
+        distance: BatchTensor,
+        phic: BatchTensor,
         f_ref: float,
     ) -> Float[FrequencySeries1d, " batch"]:
         mass1_s = mass1 * MTSUN_SI
@@ -105,11 +105,11 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_amplitude(
         self,
-        Mf: ScalarTensor,
-        mass1: ScalarTensor,
-        mass2: ScalarTensor,
-        eta: ScalarTensor,
-        distance: ScalarTensor,
+        Mf: BatchTensor,
+        mass1: BatchTensor,
+        mass2: BatchTensor,
+        eta: BatchTensor,
+        distance: BatchTensor,
     ) -> Float[FrequencySeries1d, " batch"]:
         mass1_s = mass1 * MTSUN_SI
         mass2_s = mass2 * MTSUN_SI
@@ -132,11 +132,11 @@ class TaylorF2(torch.nn.Module):
 
     def taylorf2_phase(
         self,
-        Mf: ScalarTensor,
-        mass1: ScalarTensor,
-        mass2: ScalarTensor,
-        chi1: ScalarTensor,
-        chi2: ScalarTensor,
+        Mf: BatchTensor,
+        mass1: BatchTensor,
+        mass2: BatchTensor,
+        chi1: BatchTensor,
+        chi2: BatchTensor,
     ) -> Float[FrequencySeries1d, " batch"]:
         """
         Calculate the inspiral phase for the TaylorF2.

--- a/poetry.lock
+++ b/poetry.lock
@@ -654,43 +654,38 @@ test = ["black", "isort", "pytest (>=3.6)", "pytest-cov (>=2.6.1)", "toml"]
 
 [[package]]
 name = "cryptography"
-version = "42.0.8"
+version = "43.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:81d8a521705787afe7a18d5bfb47ea9d9cc068206270aad0b96a725022e18d2e"},
-    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:961e61cefdcb06e0c6d7e3a1b22ebe8b996eb2bf50614e89384be54c48c6b63d"},
-    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3ec3672626e1b9e55afd0df6d774ff0e953452886e06e0f1eb7eb0c832e8902"},
-    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e599b53fd95357d92304510fb7bda8523ed1f79ca98dce2f43c115950aa78801"},
-    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5226d5d21ab681f432a9c1cf8b658c0cb02533eece706b155e5fbd8a0cdd3949"},
-    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6b7c4f03ce01afd3b76cf69a5455caa9cfa3de8c8f493e0d3ab7d20611c8dae9"},
-    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:2346b911eb349ab547076f47f2e035fc8ff2c02380a7cbbf8d87114fa0f1c583"},
-    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad803773e9df0b92e0a817d22fd8a3675493f690b96130a5e24f1b8fabbea9c7"},
-    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2f66d9cd9147ee495a8374a45ca445819f8929a3efcd2e3df6428e46c3cbb10b"},
-    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d45b940883a03e19e944456a558b67a41160e367a719833c53de6911cabba2b7"},
-    {file = "cryptography-42.0.8-cp37-abi3-win32.whl", hash = "sha256:a0c5b2b0585b6af82d7e385f55a8bc568abff8923af147ee3c07bd8b42cda8b2"},
-    {file = "cryptography-42.0.8-cp37-abi3-win_amd64.whl", hash = "sha256:57080dee41209e556a9a4ce60d229244f7a66ef52750f813bfbe18959770cfba"},
-    {file = "cryptography-42.0.8-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:dea567d1b0e8bc5764b9443858b673b734100c2871dc93163f58c46a97a83d28"},
-    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4783183f7cb757b73b2ae9aed6599b96338eb957233c58ca8f49a49cc32fd5e"},
-    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0608251135d0e03111152e41f0cc2392d1e74e35703960d4190b2e0f4ca9c70"},
-    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dc0fdf6787f37b1c6b08e6dfc892d9d068b5bdb671198c72072828b80bd5fe4c"},
-    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9c0c1716c8447ee7dbf08d6db2e5c41c688544c61074b54fc4564196f55c25a7"},
-    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"},
-    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cafb92b2bc622cd1aa6a1dce4b93307792633f4c5fe1f46c6b97cf67073ec961"},
-    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:31f721658a29331f895a5a54e7e82075554ccfb8b163a18719d342f5ffe5ecb1"},
-    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b297f90c5723d04bcc8265fc2a0f86d4ea2e0f7ab4b6994459548d3a6b992a14"},
-    {file = "cryptography-42.0.8-cp39-abi3-win32.whl", hash = "sha256:2f88d197e66c65be5e42cd72e5c18afbfae3f741742070e3019ac8f4ac57262c"},
-    {file = "cryptography-42.0.8-cp39-abi3-win_amd64.whl", hash = "sha256:fa76fbb7596cc5839320000cdd5d0955313696d9511debab7ee7278fc8b5c84a"},
-    {file = "cryptography-42.0.8-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ba4f0a211697362e89ad822e667d8d340b4d8d55fae72cdd619389fb5912eefe"},
-    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:81884c4d096c272f00aeb1f11cf62ccd39763581645b0812e99a91505fa48e0c"},
-    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c9bb2ae11bfbab395bdd072985abde58ea9860ed84e59dbc0463a5d0159f5b71"},
-    {file = "cryptography-42.0.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7016f837e15b0a1c119d27ecd89b3515f01f90a8615ed5e9427e30d9cdbfed3d"},
-    {file = "cryptography-42.0.8-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5a94eccb2a81a309806027e1670a358b99b8fe8bfe9f8d329f27d72c094dde8c"},
-    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dec9b018df185f08483f294cae6ccac29e7a6e0678996587363dc352dc65c842"},
-    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:343728aac38decfdeecf55ecab3264b015be68fc2816ca800db649607aeee648"},
-    {file = "cryptography-42.0.8-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:013629ae70b40af70c9a7a5db40abe5d9054e6f4380e50ce769947b73bf3caad"},
-    {file = "cryptography-42.0.8.tar.gz", hash = "sha256:8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2"},
+    {file = "cryptography-43.0.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:64c3f16e2a4fc51c0d06af28441881f98c5d91009b8caaff40cf3548089e9c74"},
+    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3dcdedae5c7710b9f97ac6bba7e1052b95c7083c9d0e9df96e02a1932e777895"},
+    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d9a1eca329405219b605fac09ecfc09ac09e595d6def650a437523fcd08dd22"},
+    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ea9e57f8ea880eeea38ab5abf9fbe39f923544d7884228ec67d666abd60f5a47"},
+    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9a8d6802e0825767476f62aafed40532bd435e8a5f7d23bd8b4f5fd04cc80ecf"},
+    {file = "cryptography-43.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cc70b4b581f28d0a254d006f26949245e3657d40d8857066c2ae22a61222ef55"},
+    {file = "cryptography-43.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4a997df8c1c2aae1e1e5ac49c2e4f610ad037fc5a3aadc7b64e39dea42249431"},
+    {file = "cryptography-43.0.0-cp37-abi3-win32.whl", hash = "sha256:6e2b11c55d260d03a8cf29ac9b5e0608d35f08077d8c087be96287f43af3ccdc"},
+    {file = "cryptography-43.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:31e44a986ceccec3d0498e16f3d27b2ee5fdf69ce2ab89b52eaad1d2f33d8778"},
+    {file = "cryptography-43.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:7b3f5fe74a5ca32d4d0f302ffe6680fcc5c28f8ef0dc0ae8f40c0f3a1b4fca66"},
+    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac1955ce000cb29ab40def14fd1bbfa7af2017cca696ee696925615cafd0dce5"},
+    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:299d3da8e00b7e2b54bb02ef58d73cd5f55fb31f33ebbf33bd00d9aa6807df7e"},
+    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ee0c405832ade84d4de74b9029bedb7b31200600fa524d218fc29bfa371e97f5"},
+    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cb013933d4c127349b3948aa8aaf2f12c0353ad0eccd715ca789c8a0f671646f"},
+    {file = "cryptography-43.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fdcb265de28585de5b859ae13e3846a8e805268a823a12a4da2597f1f5afc9f0"},
+    {file = "cryptography-43.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2905ccf93a8a2a416f3ec01b1a7911c3fe4073ef35640e7ee5296754e30b762b"},
+    {file = "cryptography-43.0.0-cp39-abi3-win32.whl", hash = "sha256:47ca71115e545954e6c1d207dd13461ab81f4eccfcb1345eac874828b5e3eaaf"},
+    {file = "cryptography-43.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:0663585d02f76929792470451a5ba64424acc3cd5227b03921dab0e2f27b1709"},
+    {file = "cryptography-43.0.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2c6d112bf61c5ef44042c253e4859b3cbbb50df2f78fa8fae6747a7814484a70"},
+    {file = "cryptography-43.0.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:844b6d608374e7d08f4f6e6f9f7b951f9256db41421917dfb2d003dde4cd6b66"},
+    {file = "cryptography-43.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:51956cf8730665e2bdf8ddb8da0056f699c1a5715648c1b0144670c1ba00b48f"},
+    {file = "cryptography-43.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:aae4d918f6b180a8ab8bf6511a419473d107df4dbb4225c7b48c5c9602c38c7f"},
+    {file = "cryptography-43.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:232ce02943a579095a339ac4b390fbbe97f5b5d5d107f8a08260ea2768be8cc2"},
+    {file = "cryptography-43.0.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5bcb8a5620008a8034d39bce21dc3e23735dfdb6a33a06974739bfa04f853947"},
+    {file = "cryptography-43.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:08a24a7070b2b6804c1940ff0f910ff728932a9d0e80e7814234269f9d46d069"},
+    {file = "cryptography-43.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e9c5266c432a1e23738d178e51c2c7a5e2ddf790f248be939448c0ba2021f9d1"},
+    {file = "cryptography-43.0.0.tar.gz", hash = "sha256:b88075ada2d51aa9f18283532c9f60e72170041bba88d7f37e49cbb10275299e"},
 ]
 
 [package.dependencies]
@@ -703,7 +698,7 @@ nox = ["nox"]
 pep8test = ["check-sdist", "click", "mypy", "ruff"]
 sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test = ["certifi", "cryptography-vectors (==43.0.0)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -1252,13 +1247,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "8.0.0"
+version = "8.2.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-8.0.0-py3-none-any.whl", hash = "sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f"},
-    {file = "importlib_metadata-8.0.0.tar.gz", hash = "sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812"},
+    {file = "importlib_metadata-8.2.0-py3-none-any.whl", hash = "sha256:11901fa0c2f97919b288679932bb64febaeacf289d18ac84dd68cb2e74213369"},
+    {file = "importlib_metadata-8.2.0.tar.gz", hash = "sha256:72e8d4399996132204f9a16dcc751af254a48f8d1b20b9ff0f98d4a8f901e73d"},
 ]
 
 [package.dependencies]
@@ -1296,20 +1291,6 @@ python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
-]
-
-[[package]]
-name = "intel-openmp"
-version = "2021.4.0"
-description = "Intel OpenMP* Runtime Library"
-optional = false
-python-versions = "*"
-files = [
-    {file = "intel_openmp-2021.4.0-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:41c01e266a7fdb631a7609191709322da2bbf24b252ba763f125dd651bcc7675"},
-    {file = "intel_openmp-2021.4.0-py2.py3-none-manylinux1_i686.whl", hash = "sha256:3b921236a38384e2016f0f3d65af6732cf2c12918087128a9163225451e776f2"},
-    {file = "intel_openmp-2021.4.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:e2240ab8d01472fed04f3544a878cda5da16c26232b7ea1b59132dbfb48b186e"},
-    {file = "intel_openmp-2021.4.0-py2.py3-none-win32.whl", hash = "sha256:6e863d8fd3d7e8ef389d52cf97a50fe2afe1a19247e8c0d168ce021546f96fc9"},
-    {file = "intel_openmp-2021.4.0-py2.py3-none-win_amd64.whl", hash = "sha256:eef4c8bcc8acefd7f5cd3b9384dbf73d59e2c99fc56545712ded913f43c4a94f"},
 ]
 
 [[package]]
@@ -1418,6 +1399,22 @@ files = [
 
 [package.dependencies]
 arrow = ">=0.15.0"
+
+[[package]]
+name = "jaxtyping"
+version = "0.2.19"
+description = "Type annotations and runtime checking for shape and dtype of JAX arrays, and PyTrees."
+optional = false
+python-versions = "~=3.8"
+files = [
+    {file = "jaxtyping-0.2.19-py3-none-any.whl", hash = "sha256:651352032799d422987e783fd1b77699b53c3bb28ffa644bbca5f75ec4fbb843"},
+    {file = "jaxtyping-0.2.19.tar.gz", hash = "sha256:21ff4c3caec6781cadfe980b019dde856c1011e17d11dfe8589298040056325a"},
+]
+
+[package.dependencies]
+numpy = ">=1.20.0"
+typeguard = ">=2.13.3"
+typing-extensions = ">=3.7.4.1"
 
 [[package]]
 name = "jedi"
@@ -1707,13 +1704,13 @@ test = ["jupyter-server (>=2.0.0)", "pytest (>=7.0)", "pytest-jupyter[server] (>
 
 [[package]]
 name = "jupyterlab"
-version = "4.2.3"
+version = "4.2.4"
 description = "JupyterLab computational environment"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyterlab-4.2.3-py3-none-any.whl", hash = "sha256:0b59d11808e84bb84105c73364edfa867dd475492429ab34ea388a52f2e2e596"},
-    {file = "jupyterlab-4.2.3.tar.gz", hash = "sha256:df6e46969ea51d66815167f23d92f105423b7f1f06fa604d4f44aeb018c82c7b"},
+    {file = "jupyterlab-4.2.4-py3-none-any.whl", hash = "sha256:807a7ec73637744f879e112060d4b9d9ebe028033b7a429b2d1f4fc523d00245"},
+    {file = "jupyterlab-4.2.4.tar.gz", hash = "sha256:343a979fb9582fd08c8511823e320703281cd072a0049bcdafdc7afeda7f2537"},
 ]
 
 [package.dependencies]
@@ -1739,7 +1736,7 @@ dev = ["build", "bump2version", "coverage", "hatch", "pre-commit", "pytest-cov",
 docs = ["jsx-lexer", "myst-parser", "pydata-sphinx-theme (>=0.13.0)", "pytest", "pytest-check-links", "pytest-jupyter", "sphinx (>=1.8,<7.3.0)", "sphinx-copybutton"]
 docs-screenshots = ["altair (==5.3.0)", "ipython (==8.16.1)", "ipywidgets (==8.1.2)", "jupyterlab-geojson (==3.4.0)", "jupyterlab-language-pack-zh-cn (==4.1.post2)", "matplotlib (==3.8.3)", "nbconvert (>=7.0.0)", "pandas (==2.2.1)", "scipy (==1.12.0)", "vega-datasets (==0.9.0)"]
 test = ["coverage", "pytest (>=7.0)", "pytest-check-links (>=0.7)", "pytest-console-scripts", "pytest-cov", "pytest-jupyter (>=0.5.3)", "pytest-timeout", "pytest-tornasync", "requests", "requests-cache", "virtualenv"]
-upgrade-extension = ["copier (>=8,<10)", "jinja2-time (<0.3)", "pydantic (<2.0)", "pyyaml-include (<2.0)", "tomli-w (<2.0)"]
+upgrade-extension = ["copier (>=9,<10)", "jinja2-time (<0.3)", "pydantic (<3.0)", "pyyaml-include (<3.0)", "tomli-w (<2.0)"]
 
 [[package]]
 name = "jupyterlab-pygments"
@@ -1754,13 +1751,13 @@ files = [
 
 [[package]]
 name = "jupyterlab-server"
-version = "2.27.2"
+version = "2.27.3"
 description = "A set of server components for JupyterLab and JupyterLab like applications."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyterlab_server-2.27.2-py3-none-any.whl", hash = "sha256:54aa2d64fd86383b5438d9f0c032f043c4d8c0264b8af9f60bd061157466ea43"},
-    {file = "jupyterlab_server-2.27.2.tar.gz", hash = "sha256:15cbb349dc45e954e09bacf81b9f9bcb10815ff660fb2034ecd7417db3a7ea27"},
+    {file = "jupyterlab_server-2.27.3-py3-none-any.whl", hash = "sha256:e697488f66c3db49df675158a77b3b017520d772c6e1548c7d9bcc5df7944ee4"},
+    {file = "jupyterlab_server-2.27.3.tar.gz", hash = "sha256:eb36caca59e74471988f0ae25c77945610b887f777255aa21f8065def9e51ed4"},
 ]
 
 [package.dependencies]
@@ -2215,24 +2212,6 @@ files = [
 ]
 
 [[package]]
-name = "mkl"
-version = "2021.4.0"
-description = "Intel® oneAPI Math Kernel Library"
-optional = false
-python-versions = "*"
-files = [
-    {file = "mkl-2021.4.0-py2.py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.whl", hash = "sha256:67460f5cd7e30e405b54d70d1ed3ca78118370b65f7327d495e9c8847705e2fb"},
-    {file = "mkl-2021.4.0-py2.py3-none-manylinux1_i686.whl", hash = "sha256:636d07d90e68ccc9630c654d47ce9fdeb036bb46e2b193b3a9ac8cfea683cce5"},
-    {file = "mkl-2021.4.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:398dbf2b0d12acaf54117a5210e8f191827f373d362d796091d161f610c1ebfb"},
-    {file = "mkl-2021.4.0-py2.py3-none-win32.whl", hash = "sha256:439c640b269a5668134e3dcbcea4350459c4a8bc46469669b2d67e07e3d330e8"},
-    {file = "mkl-2021.4.0-py2.py3-none-win_amd64.whl", hash = "sha256:ceef3cafce4c009dd25f65d7ad0d833a0fbadc3d8903991ec92351fe5de1e718"},
-]
-
-[package.dependencies]
-intel-openmp = "==2021.*"
-tbb = "==2021.*"
-
-[[package]]
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
@@ -2519,12 +2498,13 @@ files = [
 
 [[package]]
 name = "nvidia-cudnn-cu12"
-version = "8.9.2.26"
+version = "9.1.0.70"
 description = "cuDNN runtime libraries"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl", hash = "sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9"},
+    {file = "nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f"},
+    {file = "nvidia_cudnn_cu12-9.1.0.70-py3-none-win_amd64.whl", hash = "sha256:6278562929433d68365a07a4a1546c237ba2849852c0d4b2262a486e805b977a"},
 ]
 
 [package.dependencies]
@@ -2982,13 +2962,13 @@ files = [
 
 [[package]]
 name = "pure-eval"
-version = "0.2.2"
+version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
-    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
+    {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
+    {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
 ]
 
 [package.extras]
@@ -3094,17 +3074,17 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pyopenssl"
-version = "24.1.0"
+version = "24.2.1"
 description = "Python wrapper module around the OpenSSL library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyOpenSSL-24.1.0-py3-none-any.whl", hash = "sha256:17ed5be5936449c5418d1cd269a1a9e9081bc54c17aed272b45856a3d3dc86ad"},
-    {file = "pyOpenSSL-24.1.0.tar.gz", hash = "sha256:cabed4bfaa5df9f1a16c0ef64a0cb65318b5cd077a7eda7d6970131ca2f41a6f"},
+    {file = "pyOpenSSL-24.2.1-py3-none-any.whl", hash = "sha256:967d5719b12b243588573f39b0c677637145c7a1ffedcd495a487e58177fbb8d"},
+    {file = "pyopenssl-24.2.1.tar.gz", hash = "sha256:4247f0dbe3748d560dcbb2ff3ea01af0f9a1a001ef5f7c4c647956ed8cbf0e95"},
 ]
 
 [package.dependencies]
-cryptography = ">=41.0.5,<43"
+cryptography = ">=41.0.5,<44"
 
 [package.extras]
 docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx-rtd-theme"]
@@ -3485,110 +3465,114 @@ files = [
 
 [[package]]
 name = "rpds-py"
-version = "0.19.0"
+version = "0.19.1"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "rpds_py-0.19.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:fb37bd599f031f1a6fb9e58ec62864ccf3ad549cf14bac527dbfa97123edcca4"},
-    {file = "rpds_py-0.19.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3384d278df99ec2c6acf701d067147320b864ef6727405d6470838476e44d9e8"},
-    {file = "rpds_py-0.19.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e54548e0be3ac117595408fd4ca0ac9278fde89829b0b518be92863b17ff67a2"},
-    {file = "rpds_py-0.19.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8eb488ef928cdbc05a27245e52de73c0d7c72a34240ef4d9893fdf65a8c1a955"},
-    {file = "rpds_py-0.19.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5da93debdfe27b2bfc69eefb592e1831d957b9535e0943a0ee8b97996de21b5"},
-    {file = "rpds_py-0.19.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:79e205c70afddd41f6ee79a8656aec738492a550247a7af697d5bd1aee14f766"},
-    {file = "rpds_py-0.19.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:959179efb3e4a27610e8d54d667c02a9feaa86bbabaf63efa7faa4dfa780d4f1"},
-    {file = "rpds_py-0.19.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a6e605bb9edcf010f54f8b6a590dd23a4b40a8cb141255eec2a03db249bc915b"},
-    {file = "rpds_py-0.19.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9133d75dc119a61d1a0ded38fb9ba40a00ef41697cc07adb6ae098c875195a3f"},
-    {file = "rpds_py-0.19.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dd36b712d35e757e28bf2f40a71e8f8a2d43c8b026d881aa0c617b450d6865c9"},
-    {file = "rpds_py-0.19.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:354f3a91718489912f2e0fc331c24eaaf6a4565c080e00fbedb6015857c00582"},
-    {file = "rpds_py-0.19.0-cp310-none-win32.whl", hash = "sha256:ebcbf356bf5c51afc3290e491d3722b26aaf5b6af3c1c7f6a1b757828a46e336"},
-    {file = "rpds_py-0.19.0-cp310-none-win_amd64.whl", hash = "sha256:75a6076289b2df6c8ecb9d13ff79ae0cad1d5fb40af377a5021016d58cd691ec"},
-    {file = "rpds_py-0.19.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6d45080095e585f8c5097897313def60caa2046da202cdb17a01f147fb263b81"},
-    {file = "rpds_py-0.19.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5c9581019c96f865483d031691a5ff1cc455feb4d84fc6920a5ffc48a794d8a"},
-    {file = "rpds_py-0.19.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1540d807364c84516417115c38f0119dfec5ea5c0dd9a25332dea60b1d26fc4d"},
-    {file = "rpds_py-0.19.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e65489222b410f79711dc3d2d5003d2757e30874096b2008d50329ea4d0f88c"},
-    {file = "rpds_py-0.19.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9da6f400eeb8c36f72ef6646ea530d6d175a4f77ff2ed8dfd6352842274c1d8b"},
-    {file = "rpds_py-0.19.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:37f46bb11858717e0efa7893c0f7055c43b44c103e40e69442db5061cb26ed34"},
-    {file = "rpds_py-0.19.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:071d4adc734de562bd11d43bd134330fb6249769b2f66b9310dab7460f4bf714"},
-    {file = "rpds_py-0.19.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9625367c8955e4319049113ea4f8fee0c6c1145192d57946c6ffcd8fe8bf48dd"},
-    {file = "rpds_py-0.19.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e19509145275d46bc4d1e16af0b57a12d227c8253655a46bbd5ec317e941279d"},
-    {file = "rpds_py-0.19.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d438e4c020d8c39961deaf58f6913b1bf8832d9b6f62ec35bd93e97807e9cbc"},
-    {file = "rpds_py-0.19.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90bf55d9d139e5d127193170f38c584ed3c79e16638890d2e36f23aa1630b952"},
-    {file = "rpds_py-0.19.0-cp311-none-win32.whl", hash = "sha256:8d6ad132b1bc13d05ffe5b85e7a01a3998bf3a6302ba594b28d61b8c2cf13aaf"},
-    {file = "rpds_py-0.19.0-cp311-none-win_amd64.whl", hash = "sha256:7ec72df7354e6b7f6eb2a17fa6901350018c3a9ad78e48d7b2b54d0412539a67"},
-    {file = "rpds_py-0.19.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:5095a7c838a8647c32aa37c3a460d2c48debff7fc26e1136aee60100a8cd8f68"},
-    {file = "rpds_py-0.19.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f2f78ef14077e08856e788fa482107aa602636c16c25bdf59c22ea525a785e9"},
-    {file = "rpds_py-0.19.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7cc6cb44f8636fbf4a934ca72f3e786ba3c9f9ba4f4d74611e7da80684e48d2"},
-    {file = "rpds_py-0.19.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf902878b4af334a09de7a45badbff0389e7cf8dc2e4dcf5f07125d0b7c2656d"},
-    {file = "rpds_py-0.19.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:688aa6b8aa724db1596514751ffb767766e02e5c4a87486ab36b8e1ebc1aedac"},
-    {file = "rpds_py-0.19.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57dbc9167d48e355e2569346b5aa4077f29bf86389c924df25c0a8b9124461fb"},
-    {file = "rpds_py-0.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b4cf5a9497874822341c2ebe0d5850fed392034caadc0bad134ab6822c0925b"},
-    {file = "rpds_py-0.19.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8a790d235b9d39c70a466200d506bb33a98e2ee374a9b4eec7a8ac64c2c261fa"},
-    {file = "rpds_py-0.19.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d16089dfa58719c98a1c06f2daceba6d8e3fb9b5d7931af4a990a3c486241cb"},
-    {file = "rpds_py-0.19.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:bc9128e74fe94650367fe23f37074f121b9f796cabbd2f928f13e9661837296d"},
-    {file = "rpds_py-0.19.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8f77e661ffd96ff104bebf7d0f3255b02aa5d5b28326f5408d6284c4a8b3248"},
-    {file = "rpds_py-0.19.0-cp312-none-win32.whl", hash = "sha256:5f83689a38e76969327e9b682be5521d87a0c9e5a2e187d2bc6be4765f0d4600"},
-    {file = "rpds_py-0.19.0-cp312-none-win_amd64.whl", hash = "sha256:06925c50f86da0596b9c3c64c3837b2481337b83ef3519e5db2701df695453a4"},
-    {file = "rpds_py-0.19.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:52e466bea6f8f3a44b1234570244b1cff45150f59a4acae3fcc5fd700c2993ca"},
-    {file = "rpds_py-0.19.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e21cc693045fda7f745c790cb687958161ce172ffe3c5719ca1764e752237d16"},
-    {file = "rpds_py-0.19.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b31f059878eb1f5da8b2fd82480cc18bed8dcd7fb8fe68370e2e6285fa86da6"},
-    {file = "rpds_py-0.19.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1dd46f309e953927dd018567d6a9e2fb84783963650171f6c5fe7e5c41fd5666"},
-    {file = "rpds_py-0.19.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:34a01a4490e170376cd79258b7f755fa13b1a6c3667e872c8e35051ae857a92b"},
-    {file = "rpds_py-0.19.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bcf426a8c38eb57f7bf28932e68425ba86def6e756a5b8cb4731d8e62e4e0223"},
-    {file = "rpds_py-0.19.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f68eea5df6347d3f1378ce992d86b2af16ad7ff4dcb4a19ccdc23dea901b87fb"},
-    {file = "rpds_py-0.19.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dab8d921b55a28287733263c0e4c7db11b3ee22aee158a4de09f13c93283c62d"},
-    {file = "rpds_py-0.19.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:6fe87efd7f47266dfc42fe76dae89060038f1d9cb911f89ae7e5084148d1cc08"},
-    {file = "rpds_py-0.19.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:535d4b52524a961d220875688159277f0e9eeeda0ac45e766092bfb54437543f"},
-    {file = "rpds_py-0.19.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:8b1a94b8afc154fbe36978a511a1f155f9bd97664e4f1f7a374d72e180ceb0ae"},
-    {file = "rpds_py-0.19.0-cp38-none-win32.whl", hash = "sha256:7c98298a15d6b90c8f6e3caa6457f4f022423caa5fa1a1ca7a5e9e512bdb77a4"},
-    {file = "rpds_py-0.19.0-cp38-none-win_amd64.whl", hash = "sha256:b0da31853ab6e58a11db3205729133ce0df26e6804e93079dee095be3d681dc1"},
-    {file = "rpds_py-0.19.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:5039e3cef7b3e7a060de468a4a60a60a1f31786da94c6cb054e7a3c75906111c"},
-    {file = "rpds_py-0.19.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ab1932ca6cb8c7499a4d87cb21ccc0d3326f172cfb6a64021a889b591bb3045c"},
-    {file = "rpds_py-0.19.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2afd2164a1e85226fcb6a1da77a5c8896c18bfe08e82e8ceced5181c42d2179"},
-    {file = "rpds_py-0.19.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1c30841f5040de47a0046c243fc1b44ddc87d1b12435a43b8edff7e7cb1e0d0"},
-    {file = "rpds_py-0.19.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f757f359f30ec7dcebca662a6bd46d1098f8b9fb1fcd661a9e13f2e8ce343ba1"},
-    {file = "rpds_py-0.19.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15e65395a59d2e0e96caf8ee5389ffb4604e980479c32742936ddd7ade914b22"},
-    {file = "rpds_py-0.19.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb0f6eb3a320f24b94d177e62f4074ff438f2ad9d27e75a46221904ef21a7b05"},
-    {file = "rpds_py-0.19.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b228e693a2559888790936e20f5f88b6e9f8162c681830eda303bad7517b4d5a"},
-    {file = "rpds_py-0.19.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2575efaa5d949c9f4e2cdbe7d805d02122c16065bfb8d95c129372d65a291a0b"},
-    {file = "rpds_py-0.19.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:5c872814b77a4e84afa293a1bee08c14daed1068b2bb1cc312edbf020bbbca2b"},
-    {file = "rpds_py-0.19.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:850720e1b383df199b8433a20e02b25b72f0fded28bc03c5bd79e2ce7ef050be"},
-    {file = "rpds_py-0.19.0-cp39-none-win32.whl", hash = "sha256:ce84a7efa5af9f54c0aa7692c45861c1667080814286cacb9958c07fc50294fb"},
-    {file = "rpds_py-0.19.0-cp39-none-win_amd64.whl", hash = "sha256:1c26da90b8d06227d7769f34915913911222d24ce08c0ab2d60b354e2d9c7aff"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:75969cf900d7be665ccb1622a9aba225cf386bbc9c3bcfeeab9f62b5048f4a07"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8445f23f13339da640d1be8e44e5baf4af97e396882ebbf1692aecd67f67c479"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5a7c1062ef8aea3eda149f08120f10795835fc1c8bc6ad948fb9652a113ca55"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:462b0c18fbb48fdbf980914a02ee38c423a25fcc4cf40f66bacc95a2d2d73bc8"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3208f9aea18991ac7f2b39721e947bbd752a1abbe79ad90d9b6a84a74d44409b"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c3444fe52b82f122d8a99bf66777aed6b858d392b12f4c317da19f8234db4533"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88cb4bac7185a9f0168d38c01d7a00addece9822a52870eee26b8d5b61409213"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6b130bd4163c93798a6b9bb96be64a7c43e1cec81126ffa7ffaa106e1fc5cef5"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:a707b158b4410aefb6b054715545bbb21aaa5d5d0080217290131c49c2124a6e"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:dc9ac4659456bde7c567107556ab065801622396b435a3ff213daef27b495388"},
-    {file = "rpds_py-0.19.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:81ea573aa46d3b6b3d890cd3c0ad82105985e6058a4baed03cf92518081eec8c"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3f148c3f47f7f29a79c38cc5d020edcb5ca780020fab94dbc21f9af95c463581"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0906357f90784a66e89ae3eadc2654f36c580a7d65cf63e6a616e4aec3a81be"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f629ecc2db6a4736b5ba95a8347b0089240d69ad14ac364f557d52ad68cf94b0"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6feacd1d178c30e5bc37184526e56740342fd2aa6371a28367bad7908d454fc"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae8b6068ee374fdfab63689be0963333aa83b0815ead5d8648389a8ded593378"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78d57546bad81e0da13263e4c9ce30e96dcbe720dbff5ada08d2600a3502e526"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8b6683a37338818646af718c9ca2a07f89787551057fae57c4ec0446dc6224b"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e8481b946792415adc07410420d6fc65a352b45d347b78fec45d8f8f0d7496f0"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:bec35eb20792ea64c3c57891bc3ca0bedb2884fbac2c8249d9b731447ecde4fa"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl", hash = "sha256:aa5476c3e3a402c37779e95f7b4048db2cb5b0ed0b9d006983965e93f40fe05a"},
-    {file = "rpds_py-0.19.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:19d02c45f2507b489fd4df7b827940f1420480b3e2e471e952af4d44a1ea8e34"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a3e2fd14c5d49ee1da322672375963f19f32b3d5953f0615b175ff7b9d38daed"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:93a91c2640645303e874eada51f4f33351b84b351a689d470f8108d0e0694210"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5b9fc03bf76a94065299d4a2ecd8dfbae4ae8e2e8098bbfa6ab6413ca267709"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a4b07cdf3f84310c08c1de2c12ddadbb7a77568bcb16e95489f9c81074322ed"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba0ed0dc6763d8bd6e5de5cf0d746d28e706a10b615ea382ac0ab17bb7388633"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:474bc83233abdcf2124ed3f66230a1c8435896046caa4b0b5ab6013c640803cc"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329c719d31362355a96b435f4653e3b4b061fcc9eba9f91dd40804ca637d914e"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ef9101f3f7b59043a34f1dccbb385ca760467590951952d6701df0da9893ca0c"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:0121803b0f424ee2109d6e1f27db45b166ebaa4b32ff47d6aa225642636cd834"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:8344127403dea42f5970adccf6c5957a71a47f522171fafaf4c6ddb41b61703a"},
-    {file = "rpds_py-0.19.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:443cec402ddd650bb2b885113e1dcedb22b1175c6be223b14246a714b61cd521"},
-    {file = "rpds_py-0.19.0.tar.gz", hash = "sha256:4fdc9afadbeb393b4bbbad75481e0ea78e4469f2e1d713a90811700830b553a9"},
+    {file = "rpds_py-0.19.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:aaf71f95b21f9dc708123335df22e5a2fef6307e3e6f9ed773b2e0938cc4d491"},
+    {file = "rpds_py-0.19.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca0dda0c5715efe2ab35bb83f813f681ebcd2840d8b1b92bfc6fe3ab382fae4a"},
+    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81db2e7282cc0487f500d4db203edc57da81acde9e35f061d69ed983228ffe3b"},
+    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1a8dfa125b60ec00c7c9baef945bb04abf8ac772d8ebefd79dae2a5f316d7850"},
+    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:271accf41b02687cef26367c775ab220372ee0f4925591c6796e7c148c50cab5"},
+    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9bc4161bd3b970cd6a6fcda70583ad4afd10f2750609fb1f3ca9505050d4ef3"},
+    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0cf2a0dbb5987da4bd92a7ca727eadb225581dd9681365beba9accbe5308f7d"},
+    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b5e28e56143750808c1c79c70a16519e9bc0a68b623197b96292b21b62d6055c"},
+    {file = "rpds_py-0.19.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c7af6f7b80f687b33a4cdb0a785a5d4de1fb027a44c9a049d8eb67d5bfe8a687"},
+    {file = "rpds_py-0.19.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e429fc517a1c5e2a70d576077231538a98d59a45dfc552d1ac45a132844e6dfb"},
+    {file = "rpds_py-0.19.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d2dbd8f4990d4788cb122f63bf000357533f34860d269c1a8e90ae362090ff3a"},
+    {file = "rpds_py-0.19.1-cp310-none-win32.whl", hash = "sha256:e0f9d268b19e8f61bf42a1da48276bcd05f7ab5560311f541d22557f8227b866"},
+    {file = "rpds_py-0.19.1-cp310-none-win_amd64.whl", hash = "sha256:df7c841813f6265e636fe548a49664c77af31ddfa0085515326342a751a6ba51"},
+    {file = "rpds_py-0.19.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:902cf4739458852fe917104365ec0efbea7d29a15e4276c96a8d33e6ed8ec137"},
+    {file = "rpds_py-0.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f3d73022990ab0c8b172cce57c69fd9a89c24fd473a5e79cbce92df87e3d9c48"},
+    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3837c63dd6918a24de6c526277910e3766d8c2b1627c500b155f3eecad8fad65"},
+    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cdb7eb3cf3deb3dd9e7b8749323b5d970052711f9e1e9f36364163627f96da58"},
+    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26ab43b6d65d25b1a333c8d1b1c2f8399385ff683a35ab5e274ba7b8bb7dc61c"},
+    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75130df05aae7a7ac171b3b5b24714cffeabd054ad2ebc18870b3aa4526eba23"},
+    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34f751bf67cab69638564eee34023909380ba3e0d8ee7f6fe473079bf93f09b"},
+    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f2671cb47e50a97f419a02cd1e0c339b31de017b033186358db92f4d8e2e17d8"},
+    {file = "rpds_py-0.19.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c73254c256081704dba0a333457e2fb815364018788f9b501efe7c5e0ada401"},
+    {file = "rpds_py-0.19.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4383beb4a29935b8fa28aca8fa84c956bf545cb0c46307b091b8d312a9150e6a"},
+    {file = "rpds_py-0.19.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dbceedcf4a9329cc665452db1aaf0845b85c666e4885b92ee0cddb1dbf7e052a"},
+    {file = "rpds_py-0.19.1-cp311-none-win32.whl", hash = "sha256:f0a6d4a93d2a05daec7cb885157c97bbb0be4da739d6f9dfb02e101eb40921cd"},
+    {file = "rpds_py-0.19.1-cp311-none-win_amd64.whl", hash = "sha256:c149a652aeac4902ecff2dd93c3b2681c608bd5208c793c4a99404b3e1afc87c"},
+    {file = "rpds_py-0.19.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:56313be667a837ff1ea3508cebb1ef6681d418fa2913a0635386cf29cff35165"},
+    {file = "rpds_py-0.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d1d7539043b2b31307f2c6c72957a97c839a88b2629a348ebabe5aa8b626d6b"},
+    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e1dc59a5e7bc7f44bd0c048681f5e05356e479c50be4f2c1a7089103f1621d5"},
+    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8f78398e67a7227aefa95f876481485403eb974b29e9dc38b307bb6eb2315ea"},
+    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ef07a0a1d254eeb16455d839cef6e8c2ed127f47f014bbda64a58b5482b6c836"},
+    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8124101e92c56827bebef084ff106e8ea11c743256149a95b9fd860d3a4f331f"},
+    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08ce9c95a0b093b7aec75676b356a27879901488abc27e9d029273d280438505"},
+    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0b02dd77a2de6e49078c8937aadabe933ceac04b41c5dde5eca13a69f3cf144e"},
+    {file = "rpds_py-0.19.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4dd02e29c8cbed21a1875330b07246b71121a1c08e29f0ee3db5b4cfe16980c4"},
+    {file = "rpds_py-0.19.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9c7042488165f7251dc7894cd533a875d2875af6d3b0e09eda9c4b334627ad1c"},
+    {file = "rpds_py-0.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f809a17cc78bd331e137caa25262b507225854073fd319e987bd216bed911b7c"},
+    {file = "rpds_py-0.19.1-cp312-none-win32.whl", hash = "sha256:3ddab996807c6b4227967fe1587febade4e48ac47bb0e2d3e7858bc621b1cace"},
+    {file = "rpds_py-0.19.1-cp312-none-win_amd64.whl", hash = "sha256:32e0db3d6e4f45601b58e4ac75c6f24afbf99818c647cc2066f3e4b192dabb1f"},
+    {file = "rpds_py-0.19.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:747251e428406b05fc86fee3904ee19550c4d2d19258cef274e2151f31ae9d38"},
+    {file = "rpds_py-0.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dc733d35f861f8d78abfaf54035461e10423422999b360966bf1c443cbc42705"},
+    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbda75f245caecff8faa7e32ee94dfaa8312a3367397975527f29654cd17a6ed"},
+    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd04d8cab16cab5b0a9ffc7d10f0779cf1120ab16c3925404428f74a0a43205a"},
+    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2d66eb41ffca6cc3c91d8387509d27ba73ad28371ef90255c50cb51f8953301"},
+    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fdf4890cda3b59170009d012fca3294c00140e7f2abe1910e6a730809d0f3f9b"},
+    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1fa67ef839bad3815124f5f57e48cd50ff392f4911a9f3cf449d66fa3df62a5"},
+    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b82c9514c6d74b89a370c4060bdb80d2299bc6857e462e4a215b4ef7aa7b090e"},
+    {file = "rpds_py-0.19.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c7b07959866a6afb019abb9564d8a55046feb7a84506c74a6f197cbcdf8a208e"},
+    {file = "rpds_py-0.19.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4f580ae79d0b861dfd912494ab9d477bea535bfb4756a2269130b6607a21802e"},
+    {file = "rpds_py-0.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c6d20c8896c00775e6f62d8373aba32956aa0b850d02b5ec493f486c88e12859"},
+    {file = "rpds_py-0.19.1-cp313-none-win32.whl", hash = "sha256:afedc35fe4b9e30ab240b208bb9dc8938cb4afe9187589e8d8d085e1aacb8309"},
+    {file = "rpds_py-0.19.1-cp313-none-win_amd64.whl", hash = "sha256:1d4af2eb520d759f48f1073ad3caef997d1bfd910dc34e41261a595d3f038a94"},
+    {file = "rpds_py-0.19.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:34bca66e2e3eabc8a19e9afe0d3e77789733c702c7c43cd008e953d5d1463fde"},
+    {file = "rpds_py-0.19.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:24f8ae92c7fae7c28d0fae9b52829235df83f34847aa8160a47eb229d9666c7b"},
+    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71157f9db7f6bc6599a852852f3389343bea34315b4e6f109e5cbc97c1fb2963"},
+    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d494887d40dc4dd0d5a71e9d07324e5c09c4383d93942d391727e7a40ff810b"},
+    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b3661e6d4ba63a094138032c1356d557de5b3ea6fd3cca62a195f623e381c76"},
+    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97fbb77eaeb97591efdc654b8b5f3ccc066406ccfb3175b41382f221ecc216e8"},
+    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4cc4bc73e53af8e7a42c8fd7923bbe35babacfa7394ae9240b3430b5dcf16b2a"},
+    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:35af5e4d5448fa179fd7fff0bba0fba51f876cd55212f96c8bbcecc5c684ae5c"},
+    {file = "rpds_py-0.19.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3511f6baf8438326e351097cecd137eb45c5f019944fe0fd0ae2fea2fd26be39"},
+    {file = "rpds_py-0.19.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:57863d16187995c10fe9cf911b897ed443ac68189179541734502353af33e693"},
+    {file = "rpds_py-0.19.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:9e318e6786b1e750a62f90c6f7fa8b542102bdcf97c7c4de2a48b50b61bd36ec"},
+    {file = "rpds_py-0.19.1-cp38-none-win32.whl", hash = "sha256:53dbc35808c6faa2ce3e48571f8f74ef70802218554884787b86a30947842a14"},
+    {file = "rpds_py-0.19.1-cp38-none-win_amd64.whl", hash = "sha256:8df1c283e57c9cb4d271fdc1875f4a58a143a2d1698eb0d6b7c0d7d5f49c53a1"},
+    {file = "rpds_py-0.19.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:e76c902d229a3aa9d5ceb813e1cbcc69bf5bda44c80d574ff1ac1fa3136dea71"},
+    {file = "rpds_py-0.19.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de1f7cd5b6b351e1afd7568bdab94934d656abe273d66cda0ceea43bbc02a0c2"},
+    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24fc5a84777cb61692d17988989690d6f34f7f95968ac81398d67c0d0994a897"},
+    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:74129d5ffc4cde992d89d345f7f7d6758320e5d44a369d74d83493429dad2de5"},
+    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5e360188b72f8080fefa3adfdcf3618604cc8173651c9754f189fece068d2a45"},
+    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13e6d4840897d4e4e6b2aa1443e3a8eca92b0402182aafc5f4ca1f5e24f9270a"},
+    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f09529d2332264a902688031a83c19de8fda5eb5881e44233286b9c9ec91856d"},
+    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0d4b52811dcbc1aba08fd88d475f75b4f6db0984ba12275d9bed1a04b2cae9b5"},
+    {file = "rpds_py-0.19.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dd635c2c4043222d80d80ca1ac4530a633102a9f2ad12252183bcf338c1b9474"},
+    {file = "rpds_py-0.19.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f35b34a5184d5e0cc360b61664c1c06e866aab077b5a7c538a3e20c8fcdbf90b"},
+    {file = "rpds_py-0.19.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d4ec0046facab83012d821b33cead742a35b54575c4edfb7ed7445f63441835f"},
+    {file = "rpds_py-0.19.1-cp39-none-win32.whl", hash = "sha256:f5b8353ea1a4d7dfb59a7f45c04df66ecfd363bb5b35f33b11ea579111d4655f"},
+    {file = "rpds_py-0.19.1-cp39-none-win_amd64.whl", hash = "sha256:1fb93d3486f793d54a094e2bfd9cd97031f63fcb5bc18faeb3dd4b49a1c06523"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7d5c7e32f3ee42f77d8ff1a10384b5cdcc2d37035e2e3320ded909aa192d32c3"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:89cc8921a4a5028d6dd388c399fcd2eef232e7040345af3d5b16c04b91cf3c7e"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bca34e913d27401bda2a6f390d0614049f5a95b3b11cd8eff80fe4ec340a1208"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5953391af1405f968eb5701ebbb577ebc5ced8d0041406f9052638bafe52209d"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:840e18c38098221ea6201f091fc5d4de6128961d2930fbbc96806fb43f69aec1"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d8b735c4d162dc7d86a9cf3d717f14b6c73637a1f9cd57fe7e61002d9cb1972"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce757c7c90d35719b38fa3d4ca55654a76a40716ee299b0865f2de21c146801c"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a9421b23c85f361a133aa7c5e8ec757668f70343f4ed8fdb5a4a14abd5437244"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:3b823be829407393d84ee56dc849dbe3b31b6a326f388e171555b262e8456cc1"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:5e58b61dcbb483a442c6239c3836696b79f2cd8e7eec11e12155d3f6f2d886d1"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:39d67896f7235b2c886fb1ee77b1491b77049dcef6fbf0f401e7b4cbed86bbd4"},
+    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8b32cd4ab6db50c875001ba4f5a6b30c0f42151aa1fbf9c2e7e3674893fb1dc4"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1c32e41de995f39b6b315d66c27dea3ef7f7c937c06caab4c6a79a5e09e2c415"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:1a129c02b42d46758c87faeea21a9f574e1c858b9f358b6dd0bbd71d17713175"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:346557f5b1d8fd9966059b7a748fd79ac59f5752cd0e9498d6a40e3ac1c1875f"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31e450840f2f27699d014cfc8865cc747184286b26d945bcea6042bb6aa4d26e"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01227f8b3e6c8961490d869aa65c99653df80d2f0a7fde8c64ebddab2b9b02fd"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69084fd29bfeff14816666c93a466e85414fe6b7d236cfc108a9c11afa6f7301"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d2b88efe65544a7d5121b0c3b003ebba92bfede2ea3577ce548b69c5235185"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6ea961a674172ed2235d990d7edf85d15d8dfa23ab8575e48306371c070cda67"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:5beffdbe766cfe4fb04f30644d822a1080b5359df7db3a63d30fa928375b2720"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:720f3108fb1bfa32e51db58b832898372eb5891e8472a8093008010911e324c5"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:c2087dbb76a87ec2c619253e021e4fb20d1a72580feeaa6892b0b3d955175a71"},
+    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2ddd50f18ebc05ec29a0d9271e9dbe93997536da3546677f8ca00b76d477680c"},
+    {file = "rpds_py-0.19.1.tar.gz", hash = "sha256:31dd5794837f00b46f4096aa8ccaa5972f73a938982e32ed817bb520c465e520"},
 ]
 
 [[package]]
@@ -3680,18 +3664,19 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "70.3.0"
+version = "72.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
-    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
+    {file = "setuptools-72.1.0-py3-none-any.whl", hash = "sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"},
+    {file = "setuptools-72.1.0.tar.gz", hash = "sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec"},
 ]
 
 [package.extras]
+core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.text (>=3.7)", "more-itertools (>=8.8)", "ordered-set (>=3.1.1)", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.11.*)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (<0.4)", "pytest-ruff (>=0.2.1)", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -3934,13 +3919,13 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "sympy"
-version = "1.13.0"
+version = "1.13.1"
 description = "Computer algebra system (CAS) in Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sympy-1.13.0-py3-none-any.whl", hash = "sha256:6b0b32a4673fb91bd3cac3b55406c8e01d53ae22780be467301cc452f6680c92"},
-    {file = "sympy-1.13.0.tar.gz", hash = "sha256:3b6af8f4d008b9a1a6a4268b335b984b23835f26d1d60b0526ebc71d48a25f57"},
+    {file = "sympy-1.13.1-py3-none-any.whl", hash = "sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8"},
+    {file = "sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f"},
 ]
 
 [package.dependencies]
@@ -3948,19 +3933,6 @@ mpmath = ">=1.1.0,<1.4"
 
 [package.extras]
 dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
-
-[[package]]
-name = "tbb"
-version = "2021.13.0"
-description = "Intel® oneAPI Threading Building Blocks (oneTBB)"
-optional = false
-python-versions = "*"
-files = [
-    {file = "tbb-2021.13.0-py2.py3-none-manylinux1_i686.whl", hash = "sha256:a2567725329639519d46d92a2634cf61e76601dac2f777a05686fea546c4fe4f"},
-    {file = "tbb-2021.13.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:aaf667e92849adb012b8874d6393282afc318aca4407fc62f912ee30a22da46a"},
-    {file = "tbb-2021.13.0-py3-none-win32.whl", hash = "sha256:6669d26703e9943f6164c6407bd4a237a45007e79b8d3832fe6999576eaaa9ef"},
-    {file = "tbb-2021.13.0-py3-none-win_amd64.whl", hash = "sha256:3528a53e4bbe64b07a6112b4c5a00ff3c61924ee46c9c68e004a1ac7ad1f09c3"},
-]
 
 [[package]]
 name = "terminado"
@@ -4014,44 +3986,43 @@ files = [
 
 [[package]]
 name = "torch"
-version = "2.3.1"
+version = "2.4.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "torch-2.3.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:605a25b23944be5ab7c3467e843580e1d888b8066e5aaf17ff7bf9cc30001cc3"},
-    {file = "torch-2.3.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:f2357eb0965583a0954d6f9ad005bba0091f956aef879822274b1bcdb11bd308"},
-    {file = "torch-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:32b05fe0d1ada7f69c9f86c14ff69b0ef1957a5a54199bacba63d22d8fab720b"},
-    {file = "torch-2.3.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:7c09a94362778428484bcf995f6004b04952106aee0ef45ff0b4bab484f5498d"},
-    {file = "torch-2.3.1-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:b2ec81b61bb094ea4a9dee1cd3f7b76a44555375719ad29f05c0ca8ef596ad39"},
-    {file = "torch-2.3.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:490cc3d917d1fe0bd027057dfe9941dc1d6d8e3cae76140f5dd9a7e5bc7130ab"},
-    {file = "torch-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5802530783bd465fe66c2df99123c9a54be06da118fbd785a25ab0a88123758a"},
-    {file = "torch-2.3.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:a7dd4ed388ad1f3d502bf09453d5fe596c7b121de7e0cfaca1e2017782e9bbac"},
-    {file = "torch-2.3.1-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:a486c0b1976a118805fc7c9641d02df7afbb0c21e6b555d3bb985c9f9601b61a"},
-    {file = "torch-2.3.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:224259821fe3e4c6f7edf1528e4fe4ac779c77addaa74215eb0b63a5c474d66c"},
-    {file = "torch-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:e5fdccbf6f1334b2203a61a0e03821d5845f1421defe311dabeae2fc8fbeac2d"},
-    {file = "torch-2.3.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:3c333dc2ebc189561514eda06e81df22bf8fb64e2384746b2cb9f04f96d1d4c8"},
-    {file = "torch-2.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:07e9ba746832b8d069cacb45f312cadd8ad02b81ea527ec9766c0e7404bb3feb"},
-    {file = "torch-2.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:462d1c07dbf6bb5d9d2f3316fee73a24f3d12cd8dacf681ad46ef6418f7f6626"},
-    {file = "torch-2.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff60bf7ce3de1d43ad3f6969983f321a31f0a45df3690921720bcad6a8596cc4"},
-    {file = "torch-2.3.1-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:bee0bd33dc58aa8fc8a7527876e9b9a0e812ad08122054a5bff2ce5abf005b10"},
-    {file = "torch-2.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:aaa872abde9a3d4f91580f6396d54888620f4a0b92e3976a6034759df4b961ad"},
-    {file = "torch-2.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3d7a7f7ef21a7520510553dc3938b0c57c116a7daee20736a9e25cbc0e832bdc"},
-    {file = "torch-2.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:4777f6cefa0c2b5fa87223c213e7b6f417cf254a45e5829be4ccd1b2a4ee1011"},
-    {file = "torch-2.3.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:2bb5af780c55be68fe100feb0528d2edebace1d55cb2e351de735809ba7391eb"},
+    {file = "torch-2.4.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:4ed94583e244af51d6a8d28701ca5a9e02d1219e782f5a01dd401f90af17d8ac"},
+    {file = "torch-2.4.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:c4ca297b7bd58b506bfd6e78ffd14eb97c0e7797dcd7965df62f50bb575d8954"},
+    {file = "torch-2.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:2497cbc7b3c951d69b276ca51fe01c2865db67040ac67f5fc20b03e41d16ea4a"},
+    {file = "torch-2.4.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:685418ab93730efbee71528821ff54005596970dd497bf03c89204fb7e3f71de"},
+    {file = "torch-2.4.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:e743adadd8c8152bb8373543964551a7cb7cc20ba898dc8f9c0cdbe47c283de0"},
+    {file = "torch-2.4.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:7334325c0292cbd5c2eac085f449bf57d3690932eac37027e193ba775703c9e6"},
+    {file = "torch-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:97730014da4c57ffacb3c09298c6ce05400606e890bd7a05008d13dd086e46b1"},
+    {file = "torch-2.4.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:f169b4ea6dc93b3a33319611fcc47dc1406e4dd539844dcbd2dec4c1b96e166d"},
+    {file = "torch-2.4.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:997084a0f9784d2a89095a6dc67c7925e21bf25dea0b3d069b41195016ccfcbb"},
+    {file = "torch-2.4.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:bc3988e8b36d1e8b998d143255d9408d8c75da4ab6dd0dcfd23b623dfb0f0f57"},
+    {file = "torch-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:3374128bbf7e62cdaed6c237bfd39809fbcfaa576bee91e904706840c3f2195c"},
+    {file = "torch-2.4.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:91aaf00bfe1ffa44dc5b52809d9a95129fca10212eca3ac26420eb11727c6288"},
+    {file = "torch-2.4.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cc30457ea5489c62747d3306438af00c606b509d78822a88f804202ba63111ed"},
+    {file = "torch-2.4.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a046491aaf96d1215e65e1fa85911ef2ded6d49ea34c8df4d0638879f2402eef"},
+    {file = "torch-2.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:688eec9240f3ce775f22e1e1a5ab9894f3d5fe60f3f586deb7dbd23a46a83916"},
+    {file = "torch-2.4.0-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:3af4de2a618fb065e78404c4ba27a818a7b7957eaeff28c6c66ce7fb504b68b8"},
+    {file = "torch-2.4.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:618808d3f610d5f180e47a697d4ec90b810953bb1e020f424b2ac7fb0884b545"},
+    {file = "torch-2.4.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:ed765d232d23566052ba83632ec73a4fccde00b4c94ad45d63b471b09d63b7a7"},
+    {file = "torch-2.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:a2feb98ac470109472fb10dfef38622a7ee08482a16c357863ebc7bc7db7c8f7"},
+    {file = "torch-2.4.0-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:8940fc8b97a4c61fdb5d46a368f21f4a3a562a17879e932eb51a5ec62310cb31"},
 ]
 
 [package.dependencies]
 filelock = "*"
 fsspec = "*"
 jinja2 = "*"
-mkl = {version = ">=2021.1.1,<=2021.4.0", markers = "platform_system == \"Windows\""}
 networkx = "*"
 nvidia-cublas-cu12 = {version = "12.1.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-cuda-cupti-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-cuda-nvrtc-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-cuda-runtime-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cudnn-cu12 = {version = "8.9.2.26", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
+nvidia-cudnn-cu12 = {version = "9.1.0.70", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-cufft-cu12 = {version = "11.0.2.54", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-curand-cu12 = {version = "10.3.2.106", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-cusolver-cu12 = {version = "11.4.5.107", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
@@ -4059,59 +4030,44 @@ nvidia-cusparse-cu12 = {version = "12.1.0.106", markers = "platform_system == \"
 nvidia-nccl-cu12 = {version = "2.20.5", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-nvtx-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 sympy = "*"
-triton = {version = "2.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.12\""}
+triton = {version = "3.0.0", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""}
 typing-extensions = ">=4.8.0"
 
 [package.extras]
 opt-einsum = ["opt-einsum (>=3.3)"]
-optree = ["optree (>=0.9.1)"]
+optree = ["optree (>=0.11.0)"]
 
 [[package]]
 name = "torchaudio"
-version = "2.3.1"
+version = "2.4.0"
 description = "An audio package for PyTorch"
 optional = false
 python-versions = "*"
 files = [
-    {file = "torchaudio-2.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1f9134b27e5a7f0c1e33382fc0fe278e53695768cb0af02e8d22b5006c74a2ad"},
-    {file = "torchaudio-2.3.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:88796183c12631dbc3dca58a74625e2fb6c5c7e50a54649df14239439d874ba6"},
-    {file = "torchaudio-2.3.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:6b57e773aad72743d50a64a7402a06cb8bdfcc709efc6d8c26429d940e6788e2"},
-    {file = "torchaudio-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:5b1224f944d1a3fc9755bd2876df6824a42c60cf4f32a05426dfdcd9668466da"},
-    {file = "torchaudio-2.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:01984f38398ca5e98ecfbfeafb72ae5b2131d0bb8aa464b5777addb3e4826877"},
-    {file = "torchaudio-2.3.1-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:68815815e09105fe1171f0541681a7ebaf6d5d52b8e095ccde94b8064b107002"},
-    {file = "torchaudio-2.3.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:c8c727c8341825bd18d91017c4c00f36b53b08f2176cdb9bdcb0def1c450b21d"},
-    {file = "torchaudio-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:341e33450831146bc4c4cc8191d94484f1acc8bb566c2463a57c4133f792464e"},
-    {file = "torchaudio-2.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5e36685420a07a176146e9d6e0fa8225198f126e167a00785538f853807e2d43"},
-    {file = "torchaudio-2.3.1-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:07b72d76fa108ac0f3400a759456ba96bdaa2b8649fd9588cc93295a532b01d9"},
-    {file = "torchaudio-2.3.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:42af6c7a430e6268f2c028e06078d413912b5ec6efa28a097ebdd3c3c79659df"},
-    {file = "torchaudio-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:25bd1137e47de96b48ef0dc4865bc620a0b759e44c009c7e78e92d7bfdf257ba"},
-    {file = "torchaudio-2.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ce45e05acd544696c6a6f023d4fe8614ade57515799a1103b2418e854838d4a5"},
-    {file = "torchaudio-2.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6f8bc958ce1f24346dabe00d42e816f9b51698c00afe52492914761103e617a9"},
-    {file = "torchaudio-2.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:9fd0f4bbc3fd585fbd7d976a988fe6e783fcb2e0db9d70dac60f40be072c6504"},
-    {file = "torchaudio-2.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:d4982f4c520e49628507e968fb29c5db707108a8580b11593f049a932c8f2b98"},
-    {file = "torchaudio-2.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:36e8c0b6532571c27a08a40dae428cd34af225007f15bcd77272643b6266b81d"},
-    {file = "torchaudio-2.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:ae22a402fa862f7c3c177916f1b17482641d96b8bec56937e7df10739f3e3947"},
-    {file = "torchaudio-2.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:4e3bca232f820c6a0fa5394424076cc519fae32288e7ff6f6d68bd71794dc354"},
-    {file = "torchaudio-2.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7e0758b217e397bf2addfdc2df7c21f7dc34641968597a2a7e279c16e7c6d0b"},
+    {file = "torchaudio-2.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:733e9d859b88dabefeaf008e3ab2b8c7885b29466068b4b79a42766be4619e46"},
+    {file = "torchaudio-2.4.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:c48bab82a9ee0c67b9323c2ebbe0890a34c5815d1ff1ace77b1c9df4e6fdbbff"},
+    {file = "torchaudio-2.4.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:17cb73d4336771d455cd8dda8b4891307a5346b890a4e6b1d4b73d565258fee1"},
+    {file = "torchaudio-2.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:af19edc1c3c0ac626f594fc67f087db401016d9216af8d62b6c6ff731efbae43"},
+    {file = "torchaudio-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:acbcf9129ffcfce808254e2cbff103363c505ce06ed4c4231b3f436a10679d4d"},
+    {file = "torchaudio-2.4.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:393ee8c24110ccc8030482c10cd9d5d0b5e528f6a9dd3d60557e1151aa951b13"},
+    {file = "torchaudio-2.4.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:be969c09466db35e0d79b8b09dff66caedbb9569b42c903a2d5e0db2af760e3c"},
+    {file = "torchaudio-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:2993a3288b2b451bf90c7c4d65991b5769e2614d923e295f08a10066ce79d3c0"},
+    {file = "torchaudio-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ae13a95ef6fabcadb0eff36d85f5048d70474a2e9704fa9c86e9903cbcec0d4a"},
+    {file = "torchaudio-2.4.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:4782a49171d94431bb815a55aa72733f5fe38034bdf6adeced28c226e2cc791b"},
+    {file = "torchaudio-2.4.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:534d1907bb252ecd2ba9e1d61cff7220fd66090e63df7b3c109cea77a19d4cb8"},
+    {file = "torchaudio-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:473c149c1c5288f4ce7b609c5ecb7b2528e7958ea701147a20413d65e5a8a59c"},
+    {file = "torchaudio-2.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fc3f8ecd6f0bbfc654d3bc52756a7ca359f1d88b4fa0290e1cdb763a3131b7b9"},
+    {file = "torchaudio-2.4.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2bcd9700f8ec70804cc9c48d4f6f3fa7372f52421eebb64d02c04bf805ad284d"},
+    {file = "torchaudio-2.4.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d7fe9e7f2fe8250fde07b20356c44d770d5faa3ca277abdcda3af7d484048fba"},
+    {file = "torchaudio-2.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:6a10d3c29097a4d81533ab79e351c93d6d91eb1584671d5eee59ba3c259be796"},
+    {file = "torchaudio-2.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1fd670c808e322c101957a07651e29935f86ec389243c0c43a24edd7a1854841"},
+    {file = "torchaudio-2.4.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1eecb83c123577779a45381de3a38e4add132a80104cff4afd816913f51ca17b"},
+    {file = "torchaudio-2.4.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c840894de12a6dd3ea57cbb0d0086123aaa48001ba3ad99ef714fe009eae8eb9"},
+    {file = "torchaudio-2.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:608fd609cdd8323ef4a50c1e984a0be7282a6c630fad22e040e957f8e376950e"},
 ]
 
 [package.dependencies]
-torch = "2.3.1"
-
-[[package]]
-name = "torchtyping"
-version = "0.1.4"
-description = "Runtime type annotations for the shape, dtype etc. of PyTorch Tensors."
-optional = false
-python-versions = ">=3.7.0"
-files = [
-    {file = "torchtyping-0.1.4-py3-none-any.whl", hash = "sha256:485fb6ef3965c39b0de15f00d6f49373e0a3a6993e9733942a63c5e207d35390"},
-    {file = "torchtyping-0.1.4.tar.gz", hash = "sha256:4763375d17752641bd1bff0faaddade29be3c125fca6355e3cee7700e975fdb5"},
-]
-
-[package.dependencies]
-torch = ">=1.7.0"
-typeguard = ">=2.11.1"
+torch = "2.4.0"
 
 [[package]]
 name = "tornado"
@@ -4170,17 +4126,21 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "triton"
-version = "2.3.1"
+version = "3.0.0"
 description = "A language and compiler for custom Deep Learning operations"
 optional = false
 python-versions = "*"
 files = [
-    {file = "triton-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c84595cbe5e546b1b290d2a58b1494df5a2ef066dd890655e5b8a8a92205c33"},
-    {file = "triton-2.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9d64ae33bcb3a7a18081e3a746e8cf87ca8623ca13d2c362413ce7a486f893e"},
-    {file = "triton-2.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaf80e8761a9e3498aa92e7bf83a085b31959c61f5e8ac14eedd018df6fccd10"},
-    {file = "triton-2.3.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b13bf35a2b659af7159bf78e92798dc62d877aa991de723937329e2d382f1991"},
-    {file = "triton-2.3.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63381e35ded3304704ea867ffde3b7cfc42c16a55b3062d41e017ef510433d66"},
-    {file = "triton-2.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d968264523c7a07911c8fb51b4e0d1b920204dae71491b1fe7b01b62a31e124"},
+    {file = "triton-3.0.0-1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e1efef76935b2febc365bfadf74bcb65a6f959a9872e5bddf44cc9e0adce1e1a"},
+    {file = "triton-3.0.0-1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ce8520437c602fb633f1324cc3871c47bee3b67acf9756c1a66309b60e3216c"},
+    {file = "triton-3.0.0-1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e509deb77f1c067d8640725ef00c5cbfcb2052a1a3cb6a6d343841f92624eb"},
+    {file = "triton-3.0.0-1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bcbf3b1c48af6a28011a5c40a5b3b9b5330530c3827716b5fbf6d7adcc1e53e9"},
+    {file = "triton-3.0.0-1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6e5727202f7078c56f91ff13ad0c1abab14a0e7f2c87e91b12b6f64f3e8ae609"},
+    {file = "triton-3.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39b052da883351fdf6be3d93cedae6db3b8e3988d3b09ed221bccecfa9612230"},
+    {file = "triton-3.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd34f19a8582af96e6291d4afce25dac08cb2a5d218c599163761e8e0827208e"},
+    {file = "triton-3.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d5e10de8c011adeb7c878c6ce0dd6073b14367749e34467f1cff2bde1b78253"},
+    {file = "triton-3.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8903767951bf86ec960b4fe4e21bc970055afc65e9d57e916d79ae3c93665e3"},
+    {file = "triton-3.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41004fb1ae9a53fcb3e970745feb87f0e3c94c6ce1ba86e95fa3b8537894bef7"},
 ]
 
 [package.dependencies]
@@ -4188,8 +4148,8 @@ filelock = "*"
 
 [package.extras]
 build = ["cmake (>=3.20)", "lit"]
-tests = ["autopep8", "flake8", "isort", "numpy", "pytest", "scipy (>=1.7.1)", "torch"]
-tutorials = ["matplotlib", "pandas", "tabulate", "torch"]
+tests = ["autopep8", "flake8", "isort", "llnl-hatchet", "numpy", "pytest", "scipy (>=1.7.1)"]
+tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
 name = "typeguard"
@@ -4376,4 +4336,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.12"
-content-hash = "44baf0163b2fdc6e8430eb747fa95e66efa945a88a0eead398238c67f1652850"
+content-hash = "518cbdea4fc0963b84f2b63d1bb310505ede90e7e68751ec562e8d088b4e1a64"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4336,4 +4336,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.12"
-content-hash = "518cbdea4fc0963b84f2b63d1bb310505ede90e7e68751ec562e8d088b4e1a64"
+content-hash = "de0e1a1d753d619162dc1a1d3cd68fc9e95736b4fd81123d310b1165a1086d5d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,11 @@ authors = [
 [tool.poetry.dependencies]
 python = "^3.8,<3.12"
 
+jaxtyping = "^0.2"
+
 # torch deps
 torch = "^2.0"
 torchaudio = "^2.0"
-torchtyping = "^0.1"
 numpy = "<2.0.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Switching over from `torchtyping` to `jaxtyping`. Closes #83.

- [x] Replace all current instances of `torchtyping` to `jaxtyping`
- [x] Do better type-hinting throughout