### PR TITLE
Small improvements

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2674,8 +2674,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -4376,4 +4376,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.12"
-content-hash = "44baf0163b2fdc6e8430eb747fa95e66efa945a88a0eead398238c67f1652850"
+content-hash = "80c4ef747fe087938bc9ec07d34187013a31294e6436956d101b1fcb93d86aff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ bilby = "^2.1"
 jupyter = "^1.0.0"
 gwpy = "^2.1"
 
+# versions >= 1.9. fix issue with median calculation 
+# https://github.com/scipy/scipy/issues/15601
+scipy = ">=1.9.0"
+
 Sphinx = ">5.0"
 sphinx-rtd-theme = "^2.0.0"
 myst-parser = "^2.0.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def compare_against_numpy():
     def compare(value, expected):
         sigma = 0.01
         prob = 0.9999
-        N = np.product(expected.shape)
+        N = np.prod(expected.shape)
         tol = sigma * erfinv(prob ** (1 / N)) * 2**0.5
         np.testing.assert_allclose(value, expected, rtol=tol)
 

--- a/tests/dataloading/test_hdf5_dataset.py
+++ b/tests/dataloading/test_hdf5_dataset.py
@@ -32,6 +32,8 @@ class TestHdf5TimeSeriesDataset:
         data_dir.mkdir(exist_ok=True)
 
         fnames = {"a.h5": 10, "b.h5": 4, "c.h5": 6}
+        fnames = {data_dir / fname: length for fname, length in fnames.items()}
+
         idx = 0
         keys = sorted(fnames)
         for fname in keys:
@@ -98,11 +100,11 @@ class TestHdf5TimeSeriesDataset:
         # really weak check: let's at least confirm
         # that we sample the 10s segment  more than
         # we sample the 4s segment.
-        counts = {fname: 0 for fname in dataset.fnames}
+        counts = {fname.name: 0 for fname in dataset.fnames}
         for _ in range(10):
             fnames = dataset.sample_fnames((10,))
             for fname in fnames:
-                counts[fname] += 1
+                counts[fname.name] += 1
         assert counts["a.h5"] > counts["b.h5"]
 
     def test_sample_batch(self, dataset, kernel_size, coincident):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -67,7 +67,7 @@ def test_power_law():
     bins = ebins[1:] + ebins[:-1]
     bins *= 0.5
 
-    popt, _ = optimize.curve_fit(foo, bins, counts, (20, 3))
+    popt, _ = optimize.curve_fit(foo, bins, counts)
     # popt[1] is the index
     assert popt[1] == pytest.approx(2, rel=1e-1)
 
@@ -77,7 +77,7 @@ def test_power_law():
     counts, ebins = np.histogram(samples, bins=100)
     bins = ebins[1:] + ebins[:-1]
     bins *= 0.5
-    popt, _ = optimize.curve_fit(foo, bins, counts, (20, 3))
+    popt, _ = optimize.curve_fit(foo, bins, counts)
     # popt[1] is the index
     assert popt[1] == pytest.approx(-1, rel=1e-1)
 

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -2,9 +2,7 @@ from functools import partial
 
 import numpy as np
 import pytest
-import scipy
 import torch
-from packaging import version
 from scipy import signal
 
 from ml4gw.spectral import fast_spectral_density, spectral_density, whiten
@@ -259,21 +257,6 @@ def test_fast_spectral_density_with_y(
             average=average,
         )
     assert scipy_result.shape == torch_result.shape
-
-    scipy_version = version.parse(scipy.__version__)
-    num_windows = (x.shape[-1] - nperseg) // nstride + 1
-    if (
-        average == "median"
-        and scipy_version < version.parse("1.9")
-        and num_windows > 1
-    ):
-        # scipy actually had a bug in the median calc for
-        # csd, see this issue:
-        # https://github.com/scipy/scipy/issues/15601
-        from scipy.signal.spectral import _median_bias
-
-        scipy_result *= _median_bias(num_freq_bins)
-        scipy_result /= _median_bias(num_windows)
 
     torch_result = torch_result[..., 2:]
     scipy_result = scipy_result[..., 2:]

--- a/tests/transforms/test_spectral_transform.py
+++ b/tests/transforms/test_spectral_transform.py
@@ -2,9 +2,7 @@ from io import BytesIO
 
 import numpy as np
 import pytest
-import scipy
 import torch
-from packaging import version
 from scipy import signal
 
 from ml4gw.transforms.spectral import SpectralDensity
@@ -281,24 +279,6 @@ def test_transform_with_csd(
             average=average,
         )
     assert scipy_result.shape == torch_result.shape
-
-    scipy_version = version.parse(scipy.__version__)
-    num_windows = (x.shape[-1] - transform.nperseg) // transform.nstride + 1
-    if (
-        average == "median"
-        and scipy_version < version.parse("1.9")
-        and num_windows > 1
-    ):
-        # scipy actually had a bug in the median calc for
-        # csd, see this issue:
-        # https://github.com/scipy/scipy/issues/15601
-        try:
-            from scipy.signal.spectral import _median_bias
-        except ImportError:
-            from scipy.signal._spectral_py import _median_bias
-
-        scipy_result *= _median_bias(num_freq_bins)
-        scipy_result /= _median_bias(num_windows)
 
     if fast:
         torch_result = torch_result[..., 2:]


### PR DESCRIPTION
1. closes #121 
2. Removes initial guess on power law tests - should complete more regularly
3. Fixes issue in hdf5 dataloading test with writing temp files
4. Constrains `scipy` version to >1.9.0 so we don't have to do weird check for version in spectral tests.