### PR TITLE
Add multi-rate resampling

### DIFF
--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -4,6 +4,6 @@ from .scaler import ChannelWiseScaler
 from .snr_rescaler import SnrRescaler
 from .spectral import SpectralDensity
 from .spectrogram import MultiResolutionSpectrogram
-from .spline_interpolation import SplineInterpolation
+from .spline_interpolation import SplineInterpolate
 from .waveforms import WaveformProjector, WaveformSampler
 from .whitening import FixedWhiten, Whiten

--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -4,5 +4,6 @@ from .scaler import ChannelWiseScaler
 from .snr_rescaler import SnrRescaler
 from .spectral import SpectralDensity
 from .spectrogram import MultiResolutionSpectrogram
+from .spline_interpolation import SplineInterpolation
 from .waveforms import WaveformProjector, WaveformSampler
 from .whitening import FixedWhiten, Whiten

--- a/ml4gw/transforms/multi_rate_resample.py
+++ b/ml4gw/transforms/multi_rate_resample.py
@@ -1,0 +1,76 @@
+from typing import List
+
+import torch
+from torch import Tensor
+from torchaudio.transforms import Resample
+
+
+class MultiRateResample(torch.nn.Module):
+    """
+    Resample a time series to multiple different sample rates
+
+    Args:
+        original_sample_rate:
+            The sample rate of the original time series in Hz
+        duration:
+            The duration of the original time series in seconds
+        new_sample_rates:
+            A list of new sample rates that different portions
+            of the time series will be resampled to
+        breakpoints:
+            The time at which there is a transition from one
+            sample rate to another
+
+    Returns:
+        A time series Tensor with each of the resampled segments
+        concatenated together
+    """
+
+    def __init__(
+        self,
+        original_sample_rate: int,
+        duration: float,
+        new_sample_rates: List[int],
+        breakpoints: List[float],
+    ):
+        super().__init__()
+        self.original_sample_rate = original_sample_rate
+        self.duration = duration
+        self.new_sample_rates = new_sample_rates
+        self.breakpoints = breakpoints
+        self._validate_inputs()
+
+        # Add endpoints to breakpoint list
+        self.breakpoints.append(duration)
+        self.breakpoints.insert(0, 0)
+
+        self.resamplers = torch.nn.ModuleList(
+            [Resample(original_sample_rate, new) for new in new_sample_rates]
+        )
+        idxs = [
+            [int(breakpoints[i] * new), int(breakpoints[i + 1] * new)]
+            for i, new in enumerate(self.new_sample_rates)
+        ]
+        self.register_buffer("idxs", torch.Tensor(idxs).int())
+
+    def _validate_inputs(self):
+        if len(self.new_sample_rates) != len(self.breakpoints) + 1:
+            raise ValueError(
+                "There are too many/few breakpoints given "
+                "for the number of frequencies"
+            )
+        if max(self.breakpoints) >= self.duration:
+            raise ValueError(
+                "At least one breakpoint was greater than the given duration"
+            )
+        if not self.breakpoints[1:] > self.breakpoints[:-1]:
+            raise ValueError("Breakpoints must be sorted in ascending order")
+
+    def forward(self, X: Tensor):
+        return torch.cat(
+            [
+                resample(X)[..., idx[0] : idx[1]]
+                for resample, idx in zip(self.resamplers, self.idxs)
+            ],
+            dim=-1,
+        )

--- a/ml4gw/transforms/qtransform.py
+++ b/ml4gw/transforms/qtransform.py
@@ -349,10 +349,6 @@ class SingleQTransform(torch.nn.Module):
         X = torch.fft.rfft(X, norm="forward")
         X[..., 1:] *= 2
         self.qtiles = [qtile(X, norm) for qtile in self.qtile_transforms]
-        self.qtiles = [
-            torch.stack([self.qtiles[i] for i in idx], dim=-2)
-            for idx in self.stack_idx
-        ]
 
     def interpolate(self) -> TimeSeries3d:
         if self.qtiles is None:
@@ -360,11 +356,15 @@ class SingleQTransform(torch.nn.Module):
                 "Q-tiles must first be computed with .compute_qtiles()"
             )
         if self.interpolation_method == "spline":
+            qtiles = [
+                torch.stack([self.qtiles[i] for i in idx], dim=-2)
+                for idx in self.stack_idx
+            ]
             time_interped = torch.cat(
                 [
                     interpolator(qtile)
                     for qtile, interpolator in zip(
-                        self.qtiles, self.qtile_interpolators
+                        qtiles, self.qtile_interpolators
                     )
                 ],
                 dim=-2,

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -86,7 +86,7 @@ class SplineInterpolate(torch.nn.Module):
         Returns:
             Tensor of knot positions.
         """
-        return F.pad(x[None], (k, k), mode="replicate").squeeze(0)
+        return F.pad(x[None], (k, k), mode="replicate")[0]
 
     def compute_L_R(
         self,

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -1,0 +1,405 @@
+"""
+Adaption of code from https://github.com/dottormale/Qtransform
+"""
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+class SplineInterpolateBase(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def _compute_knots_and_basis_matrices(self, x, k, s):
+        knots = self.generate_natural_knots(x, k)
+        basis_matrix = self.bspline_basis_natural(x, k, knots)
+        identity = torch.eye(basis_matrix.shape[-1])
+        B_T_B = basis_matrix.T @ basis_matrix + s * identity
+        return knots, basis_matrix, B_T_B
+
+    def generate_natural_knots(self, x: Tensor, k: int) -> Tensor:
+        """
+        Generates a natural knot sequence for B-spline interpolation.
+        Natural knot sequence means that 2*k knots are added to the beginning
+        and end of datapoints as replicas of first and last datapoint
+        respectively in order to enforce natural boundary conditions,
+        i.e. second derivative = 0.
+        The other n nodes are placed in correspondece of the data points.
+
+        Args:
+            x: Tensor of data point positions.
+            k: Degree of the spline.
+
+        Returns:
+            Tensor of knot positions.
+        """
+        return F.pad(x[None], (k, k), mode="replicate").squeeze(0)
+
+    def compute_L_R(
+        self,
+        x: Tensor,
+        t: Tensor,
+        d: int,
+        m: int,
+    ) -> Tuple[Tensor, Tensor]:
+
+        """
+        Compute the L and R values for B-spline basis functions.
+        L and R are respectively the first and second coefficient multiplying
+        B_{i,p-1}(x) and B_{i+1,p-1}(x) in De Boor's recursive formula for
+        Bspline basis funciton computation
+        See https://en.wikipedia.org/wiki/De_Boor%27s_algorithm for details
+
+        Args:
+            x:
+                Tensor of data point positions.
+            t:
+                Tensor of knot positions.
+            d:
+                Current degree of the basis function.
+            m:
+                Number of intervals (n - k - 1, where n is the number of knots
+                and k is the degree).
+
+        Returns:
+            L: Tensor containing left values for the B-spline basis functions.
+            R: Tensor containing right values for the B-spline basis functions.
+        """
+        left_num = x.unsqueeze(1) - t[:m].unsqueeze(0)
+        left_den = t[d : m + d] - t[:m]
+        L = left_num / left_den.unsqueeze(0)
+        L = torch.nan_to_num_(L, nan=0.0, posinf=0.0, neginf=0.0)
+
+        right_num = t[d + 1 : m + d + 1] - x.unsqueeze(1)
+        right_den = t[d + 1 : m + d + 1] - t[1 : m + 1]
+        R = right_num / right_den.unsqueeze(0)
+        R = torch.nan_to_num_(R, nan=0.0, posinf=0.0, neginf=0.0)
+
+        return L, R
+
+    def zeroth_order(
+        self,
+        x: Tensor,
+        k: int,
+        t: Tensor,
+        n: int,
+        m: int,
+    ) -> Tensor:
+
+        """
+        Compute the zeroth-order B-spline basis functions
+        according to de Boors recursive formula.
+        See https://en.wikipedia.org/wiki/De_Boor%27s_algorithm for reference
+
+        Args:
+            x:
+                Tensor of data point positions.
+            k:
+                Degree of the spline.
+            t:
+                Tensor of knot positions.
+            n:
+                Number of data points.
+            m:
+                Number of intervals (n - k - 1, where n is the number of knots
+                and k is the degree).
+
+        Returns:
+            b: Tensor containing the zeroth-order B-spline basis functions.
+        """
+        b = torch.zeros((n, m, k + 1))
+
+        mask_lower = t[: m + 1].unsqueeze(0)[:, :-1] <= x.unsqueeze(1)
+        mask_upper = x.unsqueeze(1) < t[: m + 1].unsqueeze(0)[:, 1:]
+
+        b[:, :, 0] = mask_lower & mask_upper
+        b[:, 0, 0] = torch.where(x < t[1], torch.ones_like(x), b[:, 0, 0])
+        b[:, -1, 0] = torch.where(x >= t[-2], torch.ones_like(x), b[:, -1, 0])
+        return b
+
+    def bspline_basis_natural(
+        self,
+        x: Tensor,
+        k: int,
+        t: Tensor,
+    ) -> Tensor:
+        """
+        Compute bspline basis function using de Boor's recursive formula
+        (See https://en.wikipedia.org/wiki/De_Boor%27s_algorithm for reference)
+        Args:
+            x: Tensor of data point positions.
+            k: Degree of the spline.
+            t: Tensor of knot positions.
+
+        Returns:
+            Tensor containing the kth-order B-spline basis functions
+        """
+
+        n = x.shape[0]
+        m = t.shape[0] - k - 1
+
+        # calculate zeroth order basis funciton
+        b = self.zeroth_order(x, k, t, n, m)
+
+        zeros_tensor = torch.zeros(b.shape[0], 1)
+        # recursive de Boors formula for bspline basis functions
+        for d in range(1, k + 1):
+            L, R = self.compute_L_R(x, t, d, m)
+            left = L * b[:, :, d - 1]
+
+            temp_b = torch.cat([b[:, 1:, d - 1], zeros_tensor], dim=1)
+
+            right = R * temp_b
+            b[:, :, d] = left + right
+
+        return b[:, :, -1]
+
+
+class SplineInterpolate1D(SplineInterpolateBase):
+    def __init__(
+        self,
+        k=3,
+        s=0.001,
+        x_in: Optional[Tensor] = None,
+        x_out: Optional[Tensor] = None,
+    ):
+        super().__init__()
+        self.k = k
+        self.s = s
+        self.register_buffer("x_in", x_in)
+        self.register_buffer("x_out", x_out)
+
+        if self.x_in is not None:
+            tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, k, s)
+            self.register_buffer("t", tx)
+            self.register_buffer("B", Bx)
+            self.register_buffer("B_T_B", BxT_Bx)
+
+        if self.x_out is not None:
+            if self.x_in is None:
+                raise ValueError(
+                    "If x_out is specified, x_in must also be given"
+                )
+            Bx_out = self.bspline_basis_natural(x_out, k, self.tx)
+            self.register_buffer("Bx_out", Bx_out)
+
+    def univariate_spline_fit_natural(self, Z):
+        B_T_z = self.Bx.transpose(-2, -1) @ Z.unsqueeze(
+            -1
+        )  # (batch_size, m, 1)
+        # Solve the linear system for each batch
+        coef = torch.linalg.solve(
+            self.BxT_Bx.expand(Z.size(0), -1, -1), B_T_z
+        ).squeeze(-1)
+        return coef
+
+    def evaluate_univariate_spline(self, C: Tensor):
+        """
+        Evaluate a bivariate spline on a grid of x and y points.
+
+        Args:
+            C: Coefficient tensor of shape (batch_size, mx, my).
+
+        Returns:
+            Z_interp: Interpolated values at the grid points.
+        """
+        # Perform batched matrix multiplication:
+        # (batch_size, n, m) @ (batch_size, m, 1) -> (batch_size, n)
+        return (self.Bx_out.unsqueeze(0) @ C.unsqueeze(-1)).squeeze(-1)
+
+    def forward(
+        self,
+        Z: Tensor,
+        x_in: Optional[Tensor] = None,
+        x_out: Optional[Tensor] = None,
+    ) -> Tensor:
+        if x_out is None and self.x_out is None:
+            raise ValueError(
+                "Output x-coordinates were not specified in either object "
+                "creation or in forward call"
+            )
+
+        if len(Z.shape) > 3:
+            raise ValueError("Input data has more than 3 dimensions")
+
+        while len(Z.shape) < 3:
+            Z = Z.unsqueeze(0)
+
+        nx_points = Z.shape[-1:]
+
+        if self.x_in is None and x_in is None:
+            x_in = torch.linspace(-1, 1, nx_points)
+
+        if x_in is not None:
+            self.x_in = x_in if x_in is not None else self.x_in
+            (
+                self.tx,
+                self.Bx,
+                self.BxT_Bx,
+            ) = self._compute_knots_and_basis_matrices(
+                self.x_in, self.kx, self.sx
+            )
+        if x_out is not None:
+            self.x_out = x_out if x_out is not None else self.x_out
+            self.Bx_out = self.bspline_basis_natural(
+                self.x_out, self.kx, self.tx
+            )
+
+        coef = self.univariate_spline_fit_natural(Z)
+        Z_interp = self.evaluateunivariate_spline(coef)
+        return Z_interp
+
+
+class SplineInterpolate2D(SplineInterpolateBase):
+    def __init__(
+        self,
+        kx=3,
+        ky=3,
+        sx=0.001,
+        sy=0.001,
+        x_in: Optional[Tensor] = None,
+        y_in: Optional[Tensor] = None,
+        x_out: Optional[Tensor] = None,
+        y_out: Optional[Tensor] = None,
+        logf: Optional[bool] = False,
+    ):
+        super().__init__()
+        self.kx = kx
+        self.ky = ky
+        self.sx = sx
+        self.sy = sy
+        self.logf = logf
+        self.register_buffer("x_in", x_in)
+        self.register_buffer("y_in", y_in)
+        self.register_buffer("x_out", x_out)
+        self.register_buffer("y_out", y_out)
+
+        if self.x_in is not None:
+            tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(
+                x_in, kx, sx
+            )
+            self.register_buffer("tx", tx)
+            self.register_buffer("Bx", Bx)
+            self.register_buffer("BxT_Bx", BxT_Bx)
+        if self.y_in is not None:
+            ty, By, ByT_By = self._compute_knots_and_basis_matrices(
+                y_in, ky, sy
+            )
+            self.register_buffer("ty", ty)
+            self.register_buffer("By", By)
+            self.register_buffer("ByT_By", ByT_By)
+
+        if self.x_out is not None:
+            if self.x_in is None:
+                raise ValueError(
+                    "If x_out is specified, x_in must also be given"
+                )
+            Bx_out = self.bspline_basis_natural(x_out, kx, self.tx)
+            self.register_buffer("Bx_out", Bx_out)
+        if self.y_out is not None:
+            if self.y_in is None:
+                raise ValueError(
+                    "If y_out is specified, y_in must also be given"
+                )
+            By_out = self.bspline_basis_natural(y_out, ky, self.ty)
+            self.register_buffer("By_out", By_out)
+
+    def bivariate_spline_fit_natural(self, Z):
+
+        # Adding batch dimension handling
+        ByT_Z_Bx = (
+            torch.einsum("ij,bcjk->bcik", self.By.T, Z.transpose(-2, -1))
+            @ self.Bx
+        )  # (batch, channel, my, mx)
+        E = torch.linalg.solve(self.ByT_By, ByT_Z_Bx)  # (batch_size, my, mx)
+        C = torch.linalg.solve(self.BxT_Bx, E.transpose(-2, -1)).transpose(
+            -2, -1
+        )  # (batch_size, channel, mx, my)
+
+        return C
+
+    def evaluate_bivariate_spline(self, C: Tensor):
+        """
+        Evaluate a bivariate spline on a grid of x and y points.
+
+        Args:
+            C: Coefficient tensor of shape (batch_size, mx, my).
+
+        Returns:
+            Z_interp: Interpolated values at the grid points.
+        """
+        # Perform matrix multiplication using einsum to get Z_interp
+        return torch.einsum(
+            "ik,bckm,mj->bcij", self.By_out, C, self.Bx_out.transpose(-2, -1)
+        )
+
+    def forward(
+        self,
+        Z: Tensor,
+        x_in: Optional[Tensor] = None,
+        y_in: Optional[Tensor] = None,
+        x_out: Optional[Tensor] = None,
+        y_out: Optional[Tensor] = None,
+    ) -> Tensor:
+        if x_out is None and self.x_out is None:
+            raise ValueError(
+                "Output x-coordinates were not specified in either object "
+                "creation or in forward call"
+            )
+
+        if y_out is None and self.y_out is None:
+            raise ValueError(
+                "Output x-coordinates were not specified in either object "
+                "creation or in forward call"
+            )
+
+        if len(Z.shape) > 4:
+            raise ValueError("Input data has more than 4 dimensions")
+
+        while len(Z.shape) < 4:
+            Z = Z.unsqueeze(0)
+
+        ny_points, nx_points = Z.shape[-2:]
+
+        if self.x_in is None and x_in is None:
+            x_in = torch.linspace(-1, 1, nx_points)
+        if self.y_in is None and y_in is None:
+            if self.logf:
+                y_in = torch.logspace(-1, 1, ny_points)
+            else:
+                y_in = torch.linspace(-1, 1, ny_points)
+
+        if x_in is not None:
+            self.x_in = x_in if x_in is not None else self.x_in
+            (
+                self.tx,
+                self.Bx,
+                self.BxT_Bx,
+            ) = self._compute_knots_and_basis_matrices(
+                self.x_in, self.kx, self.sx
+            )
+        if y_in is not None:
+            self.y_in = y_in if y_in is not None else self.y_in
+            (
+                self.ty,
+                self.By,
+                self.ByT_By,
+            ) = self._compute_knots_and_basis_matrices(
+                self.y_in, self.ky, self.sy
+            )
+        if x_out is not None:
+            self.x_out = x_out if x_out is not None else self.x_out
+            self.Bx_out = self.bspline_basis_natural(
+                self.x_out, self.kx, self.tx
+            )
+        if y_out is not None:
+            self.y_out = y_out if y_out is not None else self.y_out
+            self.By_out = self.bspline_basis_natural(
+                self.y_out, self.ky, self.ty
+            )
+
+        coef = self.bivariate_spline_fit_natural(Z)
+        Z_interp = self.evaluate_bivariate_spline(coef)
+        return Z_interp

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -35,8 +35,9 @@ class SplineInterpolate(torch.nn.Module):
     produces edge artifacts when the output coordinates are near
     the boundaries of the input coordinates. Therefore, it is
     recommended to interpolate only to coordinates that are well
-    within the input coordinate range (around 25 data points on
-    all sides).
+    within the input coordinate range. Unfortunately, the specific
+    definition of "well within" changes based on the size of the
+    data, so some testing may be required to get good results.
 
     Args:
         x_in:
@@ -102,17 +103,9 @@ class SplineInterpolate(torch.nn.Module):
         self.register_buffer("ByT_By", ByT_By)
 
         if self.x_out is not None:
-            if self.x_in is None:
-                raise ValueError(
-                    "If x_out is specified, x_in must also be given"
-                )
             Bx_out = self.bspline_basis_natural(x_out, kx, self.tx)
             self.register_buffer("Bx_out", Bx_out)
         if self.y_out is not None:
-            if self.y_in is None:
-                raise ValueError(
-                    "If y_out is specified, y_in must also be given"
-                )
             By_out = self.bspline_basis_natural(y_out, ky, self.ty)
             self.register_buffer("By_out", By_out)
 

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -103,7 +103,7 @@ def test_singleqtransform(
         qtransform.get_max_energy()
 
     with pytest.raises(RuntimeError):
-        qtransform.interpolate(*spectrogram_shape)
+        qtransform.interpolate()
 
     qplane = QPlane(
         q,

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -14,7 +14,7 @@ def duration(request):
     return request.param
 
 
-@pytest.fixture(params=[2048, 4096])
+@pytest.fixture(params=[1024, 2048])
 def sample_rate(request):
     return request.param
 
@@ -29,7 +29,7 @@ def spectrogram_shape(request):
     return request.param
 
 
-@pytest.fixture(params=[12, 100])
+@pytest.fixture(params=[12, 50])
 def q(request):
     return request.param
 
@@ -39,8 +39,13 @@ def mismatch(request):
     return request.param
 
 
-@pytest.fixture(params=[128, 512])
+@pytest.fixture(params=[128, 256])
 def frequency(request):
+    return request.param
+
+
+@pytest.fixture(params=["bilinear", "bicubic", "spline"])
+def interpolation_method(request):
     return request.param
 
 
@@ -85,10 +90,33 @@ def test_singleqtransform(
     mismatch,
     norm,
     spectrogram_shape,
+    interpolation_method,
 ):
     X = torch.randn(int(duration * sample_rate))
     fseries = torch.fft.rfft(X, norm="forward")
     fseries[..., 1:] *= 2
+
+    with pytest.raises(ValueError):
+        qtransform = SingleQTransform(
+            duration,
+            sample_rate,
+            spectrogram_shape,
+            q,
+            frange=[0, torch.inf],
+            mismatch=mismatch,
+            interpolation_method="nonsense",
+        )
+
+    with pytest.raises(ValueError):
+        qtransform = SingleQTransform(
+            duration,
+            sample_rate,
+            spectrogram_shape,
+            q=1000,
+            frange=[0, torch.inf],
+            mismatch=mismatch,
+            interpolation_method="nonsense",
+        )
 
     qtransform = SingleQTransform(
         duration,
@@ -97,6 +125,7 @@ def test_singleqtransform(
         q,
         frange=[0, torch.inf],
         mismatch=mismatch,
+        interpolation_method=interpolation_method,
     )
 
     with pytest.raises(RuntimeError):

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -174,3 +174,7 @@ def test_get_qs(
     )
 
     assert np.allclose(qscan.get_qs(), qtiling.qs)
+
+    # Just check that the QScan runs
+    data = torch.randn(int(sample_rate * duration))
+    _ = qscan(data)

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -167,7 +167,12 @@ def test_get_qs(
     qrange = [1, 1000]
 
     qscan = QScan(
-        duration, sample_rate, spectrogram_shape, qrange, frange, mismatch
+        duration,
+        sample_rate,
+        spectrogram_shape,
+        qrange,
+        frange,
+        mismatch=mismatch,
     )
     qtiling = QTiling(
         duration, sample_rate, qrange, frange=[0, np.inf], mismatch=mismatch

--- a/tests/transforms/test_spline_interpolation.py
+++ b/tests/transforms/test_spline_interpolation.py
@@ -1,0 +1,62 @@
+import numpy as np
+from scipy.interpolate import RectBivariateSpline, UnivariateSpline
+from torch import Tensor
+
+from ml4gw.transforms import SplineInterpolate
+
+
+class TestSplineInterpolate:
+    def test_1d_interpolation(self):
+        x_in = np.linspace(0, 10, 100)
+        data = np.sin(x_in)
+        # There are edge effects in the torch transform that
+        # aren't present in scipy. Would be great to solve that,
+        # but a workaround is to interpolate well within the
+        # boundaries of the input coordinates
+        x_out = np.linspace(1, 9, 200)
+
+        scipy_spline = UnivariateSpline(x_in, data, k=3, s=0)
+        expected = scipy_spline(x_out)
+
+        torch_spline = SplineInterpolate(
+            x_in=Tensor(x_in),
+            x_out=Tensor(x_out),
+            kx=3,
+            sx=0,
+        )
+        actual = torch_spline(Tensor(data)).squeeze().numpy()
+
+        # The "steady-state" ratio between the torch and scipy
+        # interpolations is about 0.999, with some minor fluctuations.
+        # Would be nice to know why the torch interpolation is
+        # consistently smaller
+        assert np.allclose(actual, expected, rtol=5e-3)
+
+    def test_2d_interpolation(self):
+        x_in = np.linspace(0, 10, 100)
+        y_in = np.linspace(0, 5, 200)
+        x_grid, y_grid = np.meshgrid(x_in, y_in)
+        data = np.sin(x_grid) * np.cos(y_grid)
+        x_out = np.linspace(1, 9, 200)
+        y_out = np.linspace(1, 4, 50)
+
+        scipy_spline = RectBivariateSpline(x_in, y_in, data.T, kx=3, ky=3, s=0)
+        expected = scipy_spline(x_out, y_out).T
+
+        torch_spline = SplineInterpolate(
+            x_in=Tensor(x_in),
+            x_out=Tensor(x_out),
+            y_in=Tensor(y_in),
+            y_out=Tensor(y_out),
+            kx=3,
+            ky=3,
+            sx=0,
+            sy=0,
+        )
+        actual = torch_spline(Tensor(data)).squeeze().numpy()
+
+        # The "steady-state" ratio between the torch and scipy
+        # interpolations is about 0.999, with some minor fluctuations.
+        # Would be nice to know why the torch interpolation is
+        # consistently smaller
+        assert np.allclose(actual, expected, rtol=5e-3)

--- a/tests/transforms/test_spline_interpolation.py
+++ b/tests/transforms/test_spline_interpolation.py
@@ -42,7 +42,7 @@ class TestSplineInterpolate:
         # interpolations is about 0.9990, with some minor fluctuations.
         # Would be nice to know why the torch interpolation is
         # consistently smaller
-        assert np.allclose(actual, expected, rtol=1e-2)
+        assert np.allclose(actual, expected, rtol=5e-3)
 
     def test_2d_interpolation(self, x_out_len, y_out_len):
         x_in = np.linspace(0, 10, 100)

--- a/tests/transforms/test_spline_interpolation.py
+++ b/tests/transforms/test_spline_interpolation.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+import torch
 from scipy.interpolate import RectBivariateSpline, UnivariateSpline
 from torch import Tensor
 
@@ -6,14 +8,25 @@ from ml4gw.transforms import SplineInterpolate
 
 
 class TestSplineInterpolate:
-    def test_1d_interpolation(self):
+    @pytest.fixture(params=[50, 100, 200])
+    def x_out_len(self, request):
+        return request.param
+
+    @pytest.fixture(params=[25, 200, 1000])
+    def y_out_len(self, request):
+        return request.param
+
+    def test_1d_interpolation(self, x_out_len):
         x_in = np.linspace(0, 10, 100)
         data = np.sin(x_in)
         # There are edge effects in the torch transform that
         # aren't present in scipy. Would be great to solve that,
         # but a workaround is to interpolate well within the
-        # boundaries of the input coordinates
-        x_out = np.linspace(1, 9, 200)
+        # boundaries of the input coordinates. Unfortunately,
+        # what specifically that means depends on the size of
+        # the input array.
+        pad = len(x_in) // 10
+        x_out = np.linspace(x_in[pad], x_in[-pad], x_out_len)
 
         scipy_spline = UnivariateSpline(x_in, data, k=3, s=0)
         expected = scipy_spline(x_out)
@@ -22,23 +35,25 @@ class TestSplineInterpolate:
             x_in=Tensor(x_in),
             x_out=Tensor(x_out),
             kx=3,
-            sx=0,
         )
         actual = torch_spline(Tensor(data)).squeeze().numpy()
 
         # The "steady-state" ratio between the torch and scipy
-        # interpolations is about 0.999, with some minor fluctuations.
+        # interpolations is about 0.9990, with some minor fluctuations.
         # Would be nice to know why the torch interpolation is
         # consistently smaller
-        assert np.allclose(actual, expected, rtol=5e-3)
+        assert np.allclose(actual, expected, rtol=1e-2)
 
-    def test_2d_interpolation(self):
+    def test_2d_interpolation(self, x_out_len, y_out_len):
         x_in = np.linspace(0, 10, 100)
         y_in = np.linspace(0, 5, 200)
         x_grid, y_grid = np.meshgrid(x_in, y_in)
         data = np.sin(x_grid) * np.cos(y_grid)
-        x_out = np.linspace(1, 9, 200)
-        y_out = np.linspace(1, 4, 50)
+
+        pad = len(x_in) // 10
+        x_out = np.linspace(x_in[pad], x_in[-pad], x_out_len)
+        pad = len(y_in) // 10
+        y_out = np.linspace(y_in[pad], y_in[-pad], y_out_len)
 
         scipy_spline = RectBivariateSpline(x_in, y_in, data.T, kx=3, ky=3, s=0)
         expected = scipy_spline(x_out, y_out).T
@@ -50,8 +65,6 @@ class TestSplineInterpolate:
             y_out=Tensor(y_out),
             kx=3,
             ky=3,
-            # sx=0,
-            # sy=0,
         )
         actual = torch_spline(Tensor(data)).squeeze().numpy()
 
@@ -60,3 +73,29 @@ class TestSplineInterpolate:
         # Would be nice to know why the torch interpolation is
         # consistently smaller
         assert np.allclose(actual, expected, rtol=5e-3)
+
+    def test_errors(self):
+        x_in = torch.arange(10)
+        x_out = x_in
+        torch_spline = SplineInterpolate(x_in)
+        data = torch.randn(len(x_in))
+        with pytest.raises(ValueError) as exc:
+            torch_spline(data)
+        assert str(exc.value).startswith("Output x-coordinates were not")
+
+        data = torch.randn((1, 2, 3, 4, 5))
+        with pytest.raises(ValueError) as exc:
+            torch_spline(data, x_out=x_out)
+        assert str(exc.value).startswith("Input data has more than 4")
+
+        y_in = torch.arange(10)
+        torch_spline = SplineInterpolate(x_in=x_in, y_in=y_in)
+        data = torch.randn(len(x_in))
+        with pytest.raises(ValueError) as exc:
+            torch_spline(data, x_out=x_out)
+        assert str(exc.value).startswith("An input y-coordinate array")
+
+        data = torch.randn((len(y_in) - 1, len(x_in) - 1))
+        with pytest.raises(ValueError) as exc:
+            torch_spline(data, x_out=x_out)
+        assert str(exc.value).startswith("The spatial dimensions of the data")

--- a/tests/transforms/test_spline_interpolation.py
+++ b/tests/transforms/test_spline_interpolation.py
@@ -50,8 +50,8 @@ class TestSplineInterpolate:
             y_out=Tensor(y_out),
             kx=3,
             ky=3,
-            sx=0,
-            sy=0,
+            # sx=0,
+            # sy=0,
         )
         actual = torch_spline(Tensor(data)).squeeze().numpy()
 


### PR DESCRIPTION
Adds a transform that takes a timeseries at a given sample rate and returns a timeseries with different segments at different sample rates.

Rather than splitting the timeseries into component segments and resampling each individually, this resamples the entire timeseries multiple times, splitting and concatenating to get the final result. This is less computationally efficient, but avoids having multiple resampled edges in the final product. Some kind of in-between solution is probably better, splitting the original timeseries into overlapping segments that get resampled and cropped.

Need to add testing as well.