### PR TITLE
Specify output size for irfft

### DIFF
--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -441,7 +441,7 @@ def normalize_by_psd(
 
     # convert back to the time domain and normalize
     # TODO: what's this normalization factor?
-    X = torch.fft.irfft(X_tilde, norm="forward", dim=-1)
+    X = torch.fft.irfft(X_tilde, n=X.shape[-1], norm="forward", dim=-1)
     X = X.float() / sample_rate**0.5
 
     # slice off corrupted data at edges of kernel


### PR DESCRIPTION
When the last dimension of `X` was odd, computing the rfft and irfft would result in losing a sample, which lead to unexpected behaviors downstream. Explicitly setting the output shape of the irfft fixes this.