### PR TITLE
add option to regularize scaler std

### DIFF
--- a/ml4gw/transforms/scaler.py
+++ b/ml4gw/transforms/scaler.py
@@ -36,7 +36,9 @@ class ChannelWiseScaler(FittableTransform):
         self.register_buffer("mean", mean)
         self.register_buffer("std", std)
 
-    def fit(self, X: Float[Tensor, "... time"]) -> None:
+    def fit(
+        self, X: Float[Tensor, "... time"], std_reg: Optional[float] = 0.0
+    ) -> None:
         """Fit the scaling parameters to a timeseries
 
         Computes the channel-wise mean and standard deviation
@@ -59,7 +61,7 @@ class ChannelWiseScaler(FittableTransform):
                 "Can't fit channel wise mean and standard deviation "
                 "from tensor of shape {}".format(X.shape)
             )
-
+        std += std_reg * torch.ones_like(std)
         super().build(mean=mean, std=std)
 
     def forward(

--- a/tests/transforms/test_scaler.py
+++ b/tests/transforms/test_scaler.py
@@ -37,6 +37,16 @@ def test_scaler_1d():
     assert torch.isclose(x, y, rtol=1e-6).all().item()
 
 
+def test_scaler_regularization():
+    scaler_non_reg = ChannelWiseScaler(num_channels=2)
+    scaler_reg = ChannelWiseScaler(num_channels=2)
+    X = torch.ones(2, 100).type(torch.float32)
+    scaler_non_reg.fit(X)
+    scaler_reg.fit(X, std_reg=1e-8)
+    assert torch.all(scaler_non_reg.std == 0)
+    assert torch.all(scaler_reg.std > 0)
+
+
 def test_scaler_2d():
     num_channels = 4
     scaler = ChannelWiseScaler(num_channels)


### PR DESCRIPTION
This is handy when scaling priors which have some parameters fixed, i.e. delta functions