### PR TITLE
Add lowpass option to whitening

### DIFF
--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -394,13 +394,12 @@ def truncate_inverse_power_spectrum(
     inv_asd = 1 / psd**0.5
 
     # zero out frequencies if we want the filter
-    # filter to perform highpass/lowpass filtering
+    # to perform highpass/lowpass filtering
+    df = sample_rate / N
     if highpass is not None:
-        df = sample_rate / N
         idx = int(highpass / df)
         inv_asd[:, :, :idx] = 0
     if lowpass is not None:
-        df = sample_rate / N
         idx = int(lowpass / df)
         inv_asd[:, :, idx:] = 0
 

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -343,6 +343,7 @@ def truncate_inverse_power_spectrum(
     fduration: Union[Float[Tensor, " time"], float],
     sample_rate: float,
     highpass: Optional[float] = None,
+    lowpass: Optional[float] = None,
 ) -> PSDTensor:
     """
     Truncate the length of the time domain response
@@ -375,6 +376,10 @@ def truncate_inverse_power_spectrum(
             If specified, will zero out the frequency response
             of all frequencies below this value in Hz. If left
             as `None`, no highpass filtering will be applied.
+        lowpass:
+            If specified, will zero out the frequency response
+            of all frequencies above this value in Hz. If left
+            as `None`, no lowpass filtering will be applied.
     Returns:
         The PSD with its time domain response truncated
             to `fduration` and any highpassed frequencies
@@ -388,12 +393,16 @@ def truncate_inverse_power_spectrum(
     # impulse response function
     inv_asd = 1 / psd**0.5
 
-    # zero our leading frequencies if we want the
-    # filter to perform highpass filtering
+    # zero out frequencies if we want the filter
+    # filter to perform highpass/lowpass filtering
     if highpass is not None:
         df = sample_rate / N
         idx = int(highpass / df)
         inv_asd[:, :, :idx] = 0
+    if lowpass is not None:
+        df = sample_rate / N
+        idx = int(lowpass / df)
+        inv_asd[:, :, idx:] = 0
 
     if inv_asd.size(-1) % 2:
         inv_asd[:, :, -1] = 0
@@ -455,12 +464,13 @@ def whiten(
     fduration: Union[Float[Tensor, " time"], float],
     sample_rate: float,
     highpass: Optional[float] = None,
+    lowpass: Optional[float] = None,
 ) -> WaveformTensor:
     """
     Whiten a batch of timeseries using the specified
     background one-sided power spectral densities (PSDs),
     modified to have the desired time domain response length
-    `fduration` and possibly to highpass filter.
+    `fduration` and possibly to highpass/lowpass filter.
 
     Args:
         X:
@@ -493,6 +503,11 @@ def whiten(
             the data, setting the frequency response in the
             whitening filter to 0. If left as `None`, no
             highpass filtering will be applied.
+        lowpass:
+            The frequency in Hz at which to lowpass filter
+            the data, setting the frequency response in the
+            whitening filter to 0. If left as `None`, no
+            lowpass filtering will be applied.
     Returns:
         Batch of whitened multichannel timeseries with
             `fduration / 2` seconds trimmed from each side.
@@ -529,7 +544,11 @@ def whiten(
     # truncate it to have the desired
     # time domain response length
     psd = truncate_inverse_power_spectrum(
-        psd, fduration, sample_rate, highpass
+        psd,
+        fduration,
+        sample_rate,
+        highpass,
+        lowpass,
     )
 
     return normalize_by_psd(X, psd, sample_rate, pad)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def compare_against_numpy():
 
 @pytest.fixture
 def validate_whitened():
-    def validate(whitened, highpass, sample_rate, df):
+    def validate(whitened, highpass, lowpass, sample_rate, df):
         # make sure we have 0 mean unit variance
         means = whitened.mean(axis=-1)
         target = torch.zeros_like(means)
@@ -35,14 +35,17 @@ def validate_whitened():
         stds = whitened.std(axis=-1)
         target = torch.ones_like(stds)
 
-        # if we're highpassing, then we shouldn't expect
-        # the standard deviation to be one because we're
-        # subtracting some power, so remove roughly the
-        # expected power contributed by the highpassed
-        # frequencies from the target.
+        # if we're highpassingi or lowpassing, then we
+        # shouldn't expect the standard deviation to be
+        # one because we're subtracting some power, so
+        # remove roughly the expected power contributed
+        # by the highpassed frequencies from the target.
         if highpass is not None:
             nyquist = sample_rate / 2
             target *= (1 - highpass / nyquist) ** 0.5
+        if lowpass is not None:
+            nyquist = sample_rate / 2
+            target *= (lowpass / nyquist) ** 0.5
 
         # TODO: most statistically accurate test would be
         # to ensure that variances of the whitened data
@@ -54,10 +57,10 @@ def validate_whitened():
         # a way to account for all of these sources of noise
         # in the tolerance, but for now we'll just adopt the
         # tolerance that gwpy uses in its tests
-        torch.testing.assert_close(stds, target, rtol=0.02, atol=0.0)
+        torch.testing.assert_close(stds, target, rtol=0.04, atol=0.0)
 
-        # check that frequencies up to close to the highpass
-        # frequency have near 0 power.
+        # check that frequencies up to close to the highpass/lowpass
+        # frequencies have near 0 power.
         # TODO: the tolerance will need to increase
         # the closer to the cutoff frequency we get,
         # so what's a better way to check this
@@ -65,6 +68,12 @@ def validate_whitened():
             fft = torch.fft.rfft(whitened, norm="ortho").abs()
             idx = int(0.8 * highpass / df)
             passed = fft[:, :, :idx]
+            target = torch.zeros_like(passed)
+            torch.testing.assert_close(passed, target, rtol=0, atol=0.07)
+        if lowpass is not None:
+            fft = torch.fft.rfft(whitened, norm="ortho").abs()
+            idx = int(1.2 * lowpass / df)
+            passed = fft[:, :, idx:]
             target = torch.zeros_like(passed)
             torch.testing.assert_close(passed, target, rtol=0, atol=0.07)
 

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -341,6 +341,11 @@ def highpass(request):
     return request.param
 
 
+@pytest.fixture(params=[None, 512])
+def lowpass(request):
+    return request.param
+
+
 @pytest.fixture(params=[64, 128])
 def whiten_length(request):
     return request.param
@@ -354,6 +359,7 @@ def background_length(request):
 def test_whiten(
     fduration,
     highpass,
+    lowpass,
     ndim,
     whiten_length,
     validate_whitened,
@@ -404,21 +410,23 @@ def test_whiten(
 
     size = int(whiten_length * sample_rate)
     X = mean + std * torch.randn(batch_size, num_channels, size)
-    whitened = whiten(X, psd, fduration, sample_rate, highpass)
+    whitened = whiten(X, psd, fduration, sample_rate, highpass, lowpass)
     expected_size = int((whiten_length - fduration) * sample_rate)
     assert whitened.shape == (batch_size, num_channels, expected_size)
 
-    validate_whitened(whitened, highpass, sample_rate, 1 / whiten_length)
+    validate_whitened(
+        whitened, highpass, lowpass, sample_rate, 1 / whiten_length
+    )
 
     # inject a gaussian pulse into the timeseries and
     # ensure that its max value comes out to the same place
     # adapted from gwpy's tests
     # https://github.com/gwpy/gwpy/blob/e9f687e8d34720d9d386a6bd7f95e3b759264739/gwpy/timeseries/tests/test_timeseries.py#L1285  # noqa
     t = np.arange(size) / sample_rate - whiten_length / 2
-    glitch = torch.Tensor(signal.gausspulse(t, bw=100))
+    glitch = torch.Tensor(signal.gausspulse(t, fc=128, bw=2))
     glitch = 10 * std * glitch
     inj = X + glitch
-    whitened = whiten(inj, psd, fduration, sample_rate, highpass)
+    whitened = whiten(inj, psd, fduration, sample_rate, highpass, lowpass)
     maxs = whitened.argmax(-1) / sample_rate + fduration / 2
     target = torch.ones_like(maxs) * whiten_length / 2
     torch.testing.assert_close(maxs, target, rtol=0, atol=0.01)


### PR DESCRIPTION
Allows users to specify a lowpass frequency, analogous to the highpass option that already exists. Updates the tests to include the lowpass argument, and modifies a couple of the tests to accommodate this.