### PR TITLE
Add `fnames_per_batch` argument to `HDF5Dataset`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,7 @@ repos:
   - id: poetry-check
   - id: poetry-lock
     args: [--check, --no-update]
+- repo: https://github.com/dhruvmanila/remove-print-statements
+  rev: v0.5.2  
+  hooks:
+  - id: remove-print-statements

--- a/ml4gw/dataloading/hdf5_dataset.py
+++ b/ml4gw/dataloading/hdf5_dataset.py
@@ -119,19 +119,16 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
         # first, randomly select `self.num_files_per_batch`
         # file indices based on their probabilities
         fname_indices = np.arange(len(self.fnames))
-        print(fname_indices)
         fname_indices = np.random.choice(
             fname_indices,
             p=self.probs,
             size=(self.num_files_per_batch),
             replace=False,
         )
-        print(fname_indices)
         # now renormalize the probabilities, and sample
         # the requested size from this subset of files
         probs = self.probs[fname_indices]
         probs /= probs.sum()
-        print(self.fnames)
         return np.random.choice(
             self.fnames[fname_indices],
             p=probs,

--- a/ml4gw/dataloading/hdf5_dataset.py
+++ b/ml4gw/dataloading/hdf5_dataset.py
@@ -50,7 +50,7 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
             channel. The latter setting limits the amount of
             entropy in the effective dataset, but can provide
             over 2x improvement in total throughput.
-        files_per_batch:
+        fnames_per_batch:
             The number of unique files from which to sample
             batch elements each epoch. If left as `None`,
             will use all available files. Useful when reading
@@ -67,7 +67,7 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
         batch_size: int,
         batches_per_epoch: int,
         coincident: Union[bool, str],
-        files_per_batch: Optional[int] = None,
+        fnames_per_batch: Optional[int] = None,
     ) -> None:
         if not isinstance(coincident, bool) and coincident != "files":
             raise ValueError(
@@ -75,7 +75,7 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
                 "got unrecognized value {}".format(coincident)
             )
 
-        self.fnames = fnames
+        self.fnames = np.array(fnames)
         self.channels = channels
         self.num_channels = len(channels)
         self.kernel_size = kernel_size
@@ -83,7 +83,7 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
         self.batches_per_epoch = batches_per_epoch
         self.coincident = coincident
         self.fnames_per_batch = (
-            len(fnames) if files_per_batch is None else files_per_batch
+            len(fnames) if fnames_per_batch is None else fnames_per_batch
         )
 
         self.sizes = {}
@@ -96,7 +96,7 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
                         "without using chunked storage. This can have "
                         "severe performance impacts at data loading time. "
                         "If you need faster loading, try re-generating "
-                        "your datset with chunked storage turned on.".format(
+                        "your dataset with chunked storage turned on.".format(
                             fname
                         ),
                         category=ContiguousHdf5Warning,
@@ -111,15 +111,24 @@ class Hdf5TimeSeriesDataset(torch.utils.data.IterableDataset):
         return self.batches_per_epoch
 
     def sample_fnames(self, size) -> np.ndarray:
-        # randomly select `self.fnames_per_batch`
-        # files from which to sample elements for this batch
-        fname_indices = torch.randperm(len(self.fnames))[
-            : self.fnames_per_batch
-        ]
-        fnames = self.fnames[fname_indices]
-        return np.random.choice(
-            fnames,
+        # first, randomly select `self.fnames_per_batch`
+        # file indices based on their probabilities
+        fname_indices = np.arange(len(self.fnames))
+        fname_indices = np.random.choice(
+            fname_indices,
             p=self.probs,
+            size=(self.fnames_per_batch),
+            replace=False,
+        )
+
+        # now renormalize the probabilities, and sample
+        # the requested size from this subset of files
+        probs = self.probs[fname_indices]
+        probs /= probs.sum()
+
+        return np.random.choice(
+            self.fnames[fname_indices],
+            p=probs,
             size=size,
             replace=True,
         )

--- a/tests/dataloading/test_hdf5_dataset.py
+++ b/tests/dataloading/test_hdf5_dataset.py
@@ -107,6 +107,15 @@ class TestHdf5TimeSeriesDataset:
                 counts[fname.name] += 1
         assert counts["a.h5"] > counts["b.h5"]
 
+        # override fnames per batch for testing
+        dataset.fnames_per_batch = 1
+        fnames = dataset.sample_fnames(size=(10,))
+        assert len(np.unique(fnames)) == 1
+
+        dataset.fnames_per_batch = 2
+        fnames = dataset.sample_fnames(size=(10,))
+        assert len(np.unique(fnames)) == 2
+
     def test_sample_batch(self, dataset, kernel_size, coincident):
         x = dataset.sample_batch()
         assert x.shape == (128, 2, kernel_size)

--- a/tests/dataloading/test_hdf5_dataset.py
+++ b/tests/dataloading/test_hdf5_dataset.py
@@ -107,13 +107,21 @@ class TestHdf5TimeSeriesDataset:
                 counts[fname.name] += 1
         assert counts["a.h5"] > counts["b.h5"]
 
+        # when not specifying fnames per batch,
+        # ensure all 3 files are sampled
+        fnames = dataset.sample_fnames((10000,))
+        assert len(np.unique(fnames)) == 3
+
         # override fnames per batch for testing
         dataset.num_files_per_batch = 1
         fnames = dataset.sample_fnames(size=(10,))
         assert len(np.unique(fnames)) == 1
 
+        # use large enough size (1000)
+        # such that extremely likely
+        # each file sampled at least once
         dataset.num_files_per_batch = 2
-        fnames = dataset.sample_fnames(size=(10,))
+        fnames = dataset.sample_fnames(size=(1000,))
         assert len(np.unique(fnames)) == 2
 
     def test_sample_batch(self, dataset, kernel_size, coincident):

--- a/tests/dataloading/test_hdf5_dataset.py
+++ b/tests/dataloading/test_hdf5_dataset.py
@@ -108,11 +108,11 @@ class TestHdf5TimeSeriesDataset:
         assert counts["a.h5"] > counts["b.h5"]
 
         # override fnames per batch for testing
-        dataset.fnames_per_batch = 1
+        dataset.num_files_per_batch = 1
         fnames = dataset.sample_fnames(size=(10,))
         assert len(np.unique(fnames)) == 1
 
-        dataset.fnames_per_batch = 2
+        dataset.num_files_per_batch = 2
         fnames = dataset.sample_fnames(size=(10,))
         assert len(np.unique(fnames)) == 2
 


### PR DESCRIPTION
Adds argument for specifying number of files to sample per batch. If left as `None` will default to all available fnames