### PR TITLE
Increased waveform tolerance

### DIFF
--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -452,17 +452,18 @@ def test_phenom_p(
         hp_lal_data = hp_lal.data.data[lal_mask]
         hc_lal_data = hc_lal.data.data[lal_mask]
 
+        # Only 4 of 50,000 samples failed this tolerance
         assert np.allclose(
-            1e21 * hp_lal_data.real, 1e21 * hp_ml4gw.real.numpy(), atol=1e-3
+            1e21 * hp_lal_data.real, 1e21 * hp_ml4gw.real.numpy(), atol=2e-3
         )
         assert np.allclose(
-            1e21 * hp_lal_data.imag, 1e21 * hp_ml4gw.imag.numpy(), atol=1e-3
+            1e21 * hp_lal_data.imag, 1e21 * hp_ml4gw.imag.numpy(), atol=2e-3
         )
         assert np.allclose(
-            1e21 * hc_lal_data.real, 1e21 * hc_ml4gw.real.numpy(), atol=1e-3
+            1e21 * hc_lal_data.real, 1e21 * hc_ml4gw.real.numpy(), atol=2e-3
         )
         assert np.allclose(
-            1e21 * hc_lal_data.imag, 1e21 * hc_ml4gw.imag.numpy(), atol=1e-3
+            1e21 * hc_lal_data.imag, 1e21 * hc_ml4gw.imag.numpy(), atol=2e-3
         )
 
         # test close (< 400 Mpc) waveforms  (O(1e-2) agreement)


### PR DESCRIPTION
Did some testing because our tests here were failing too often. I was seeing a failure about 1 / 2,500 waveform samples, and we do 2,400 waveforms in our CI, so it's not too surprising that we have so many failures. Doubling the tolerance reduces the rate to about 1 / 10,000, which is more reasonable.

I'd increase more, but some of the differences were greater than 1e-2, which I think would be too large of a tolerance. Here's a histogram of the maximum differences of 25,000 samples.

![diff_hist](https://github.com/user-attachments/assets/e365dcf0-9521-455e-b100-943f677328a8)