### PR TITLE
Set random seed for unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from scipy.special import erfinv
 from torch.distributions import Uniform
 
 
+# If a fixture is doing anything random,
+# it should take this function as an argument
 @pytest.fixture(autouse=True)
 def seed_everything():
     seed = 101589

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,9 +93,8 @@ def validate_whitened():
     return validate
 
 
-# number of samples to draw from
-# the distributions for testing
-N_SAMPLES = 1000
+# A num_samples fixture should be defined for any
+# test that wants to use these fixtures
 
 
 @pytest.fixture(params=[256, 1024, 2048])
@@ -104,90 +103,90 @@ def sample_rate(request):
 
 
 @pytest.fixture()
-def chirp_mass(request):
+def chirp_mass(num_samples, seed_everything):
     dist = Uniform(5, 100)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def mass_ratio():
+def mass_ratio(num_samples, seed_everything):
     dist = Uniform(0.125, 0.99)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def a_1(request):
+def a_1(num_samples, seed_everything):
     dist = Uniform(0, 0.90)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def a_2(request):
+def a_2(num_samples, seed_everything):
     dist = Uniform(0, 0.90)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def tilt_1(request):
+def tilt_1(num_samples, seed_everything):
     dist = Uniform(0, torch.pi)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def tilt_2(request):
+def tilt_2(num_samples, seed_everything):
     dist = Uniform(0, torch.pi)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def phi_12(request):
+def phi_12(num_samples, seed_everything):
     dist = Uniform(0, 2 * torch.pi)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def phi_jl(request):
+def phi_jl(num_samples, seed_everything):
     dist = Uniform(0, 2 * torch.pi)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def distance(request):
+def distance(num_samples, seed_everything):
     dist = Uniform(100, 3000)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def distance_far(request):
+def distance_far(num_samples, seed_everything):
     dist = Uniform(500, 3000)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def distance_close(request):
+def distance_close(num_samples, seed_everything):
     dist = Uniform(100, 500)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def theta_jn(request):
+def theta_jn(num_samples, seed_everything):
     dist = Uniform(0, torch.pi)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def phase(request):
+def phase(num_samples, seed_everything):
     dist = Uniform(0, 2 * torch.pi)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def chi1(request):
+def chi1(num_samples, seed_everything):
     dist = Uniform(-0.999, 0.999)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))
 
 
 @pytest.fixture()
-def chi2(request):
+def chi2(num_samples, seed_everything):
     dist = Uniform(-0.999, 0.999)
-    return dist.sample((N_SAMPLES,))
+    return dist.sample((num_samples,))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,18 @@
+import random
+
 import numpy as np
 import pytest
 import torch
 from scipy.special import erfinv
 from torch.distributions import Uniform
+
+
+@pytest.fixture(autouse=True)
+def seed_everything():
+    seed = 101589
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    random.seed(seed)
 
 
 @pytest.fixture

--- a/tests/transforms/test_iirfilter.py
+++ b/tests/transforms/test_iirfilter.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 from astropy import units as u
 from scipy.signal import filtfilt, iirfilter
-from torch.distributions import Uniform
 
 from ml4gw.constants import MSUN
 from ml4gw.transforms.iirfilter import IIRFilter
@@ -124,73 +123,9 @@ def test_filters_synthetic_signal(sample_rate, order):
         )
 
 
-N_SAMPLES = 1
-
-
 @pytest.fixture()
-def chirp_mass(seed_everything, request):
-    dist = Uniform(5, 100)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def mass_ratio(seed_everything):
-    dist = Uniform(0.125, 0.99)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def a_1(seed_everything, request):
-    dist = Uniform(0, 0.90)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def a_2(seed_everything, request):
-    dist = Uniform(0, 0.90)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def tilt_1(seed_everything, request):
-    dist = Uniform(0, torch.pi)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def tilt_2(seed_everything, request):
-    dist = Uniform(0, torch.pi)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def phi_12(seed_everything, request):
-    dist = Uniform(0, 2 * torch.pi)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def phi_jl(seed_everything, request):
-    dist = Uniform(0, 2 * torch.pi)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def distance(seed_everything, request):
-    dist = Uniform(100, 3000)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def theta_jn(seed_everything, request):
-    dist = Uniform(0, torch.pi)
-    return dist.sample(torch.Size((N_SAMPLES,)))
-
-
-@pytest.fixture()
-def phase(seed_everything, request):
-    dist = Uniform(0, 2 * torch.pi)
-    return dist.sample(torch.Size((N_SAMPLES,)))
+def num_samples():
+    return 1
 
 
 @pytest.fixture(params=[20, 40])

--- a/tests/transforms/test_iirfilter.py
+++ b/tests/transforms/test_iirfilter.py
@@ -128,67 +128,67 @@ N_SAMPLES = 1
 
 
 @pytest.fixture()
-def chirp_mass(request):
+def chirp_mass(seed_everything, request):
     dist = Uniform(5, 100)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def mass_ratio():
+def mass_ratio(seed_everything):
     dist = Uniform(0.125, 0.99)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def a_1(request):
+def a_1(seed_everything, request):
     dist = Uniform(0, 0.90)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def a_2(request):
+def a_2(seed_everything, request):
     dist = Uniform(0, 0.90)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def tilt_1(request):
+def tilt_1(seed_everything, request):
     dist = Uniform(0, torch.pi)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def tilt_2(request):
+def tilt_2(seed_everything, request):
     dist = Uniform(0, torch.pi)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def phi_12(request):
+def phi_12(seed_everything, request):
     dist = Uniform(0, 2 * torch.pi)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def phi_jl(request):
+def phi_jl(seed_everything, request):
     dist = Uniform(0, 2 * torch.pi)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def distance(request):
+def distance(seed_everything, request):
     dist = Uniform(100, 3000)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def theta_jn(request):
+def theta_jn(seed_everything, request):
     dist = Uniform(0, torch.pi)
     return dist.sample(torch.Size((N_SAMPLES,)))
 
 
 @pytest.fixture()
-def phase(request):
+def phase(seed_everything, request):
     dist = Uniform(0, 2 * torch.pi)
     return dist.sample(torch.Size((N_SAMPLES,)))
 

--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 import torch
 from astropy import units as u
-from torch.distributions import Uniform
 
 import ml4gw.waveforms as waveforms
 from ml4gw.waveforms.conversion import (
@@ -12,104 +11,10 @@ from ml4gw.waveforms.conversion import (
     chirp_mass_and_mass_ratio_to_components,
 )
 
-# number of samples to draw from
-# the distributions for testing
-N_SAMPLES = 100
-
-
-@pytest.fixture(params=[256, 1024, 2048])
-def sample_rate(request):
-    return request.param
-
 
 @pytest.fixture()
-def chirp_mass(seed_everything, request):
-    dist = Uniform(5, 100)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def mass_ratio(seed_everything):
-    dist = Uniform(0.125, 0.99)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def a_1(seed_everything, request):
-    dist = Uniform(0, 0.90)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def a_2(seed_everything, request):
-    dist = Uniform(0, 0.90)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def tilt_1(seed_everything, request):
-    dist = Uniform(0, torch.pi)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def tilt_2(seed_everything, request):
-    dist = Uniform(0, torch.pi)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def phi_12(seed_everything, request):
-    dist = Uniform(0, 2 * torch.pi)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def phi_jl(seed_everything, request):
-    dist = Uniform(0, 2 * torch.pi)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def distance(seed_everything, request):
-    dist = Uniform(100, 3000)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def distance_far(seed_everything, request):
-    dist = Uniform(400, 3000)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def distance_close(seed_everything, request):
-    dist = Uniform(100, 400)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def theta_jn(seed_everything, request):
-    dist = Uniform(0, torch.pi)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def phase(seed_everything, request):
-    dist = Uniform(0, 2 * torch.pi)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def chi_1(seed_everything, request):
-    dist = Uniform(-0.999, 0.999)
-    return dist.sample((N_SAMPLES,))
-
-
-@pytest.fixture()
-def chi_2(seed_everything, request):
-    dist = Uniform(-0.999, 0.999)
-    return dist.sample((N_SAMPLES,))
+def num_samples():
+    return 100
 
 
 @pytest.fixture(params=[20, 40])
@@ -120,8 +25,8 @@ def f_ref(request):
 def test_taylor_f2(
     chirp_mass,
     mass_ratio,
-    chi_1,
-    chi_2,
+    chi1,
+    chi2,
     phase,
     distance,
     f_ref,
@@ -141,10 +46,10 @@ def test_taylor_f2(
             m2=mass_2[i].item() * lal.MSUN_SI,
             S1x=0,
             S1y=0,
-            S1z=chi_1[i].item(),
+            S1z=chi1[i].item(),
             S2x=0,
             S2y=0,
-            S2z=chi_2[i].item(),
+            S2z=chi2[i].item(),
             distance=(distance[i].item() * u.Mpc).to("m").value,
             inclination=theta_jn[i].item(),
             phiRef=phase[i].item(),
@@ -181,8 +86,8 @@ def test_taylor_f2(
             torch_freqs,
             chirp_mass[i][None],
             mass_ratio[i][None],
-            chi_1[i][None],
-            chi_2[i][None],
+            chi1[i][None],
+            chi2[i][None],
             distance[i][None],
             phase[i][None],
             theta_jn[i][None],
@@ -214,14 +119,14 @@ def test_taylor_f2(
 
         # taylor f2 is symmetric w.r.t m1 --> m2 flip.
         # so test that the waveforms are the same when m1 and m2
-        # (and corresponding chi_1, chi_2 are flipped)
+        # (and corresponding chi1, chi2 are flipped)
         # are flipped this can be done by flipping mass ratio
         hc_ml4gw, hp_ml4gw = waveforms.TaylorF2()(
             torch_freqs,
             chirp_mass[i][None],
             1 / mass_ratio[i][None],
-            chi_2[i][None],
-            chi_1[i][None],
+            chi2[i][None],
+            chi1[i][None],
             distance[i][None],
             phase[i][None],
             theta_jn[i][None],
@@ -248,8 +153,8 @@ def test_taylor_f2(
 def test_phenom_d(
     chirp_mass,
     mass_ratio,
-    chi_1,
-    chi_2,
+    chi1,
+    chi2,
     distance,
     phase,
     theta_jn,
@@ -269,10 +174,10 @@ def test_phenom_d(
             m2=mass_2[i].item() * lal.MSUN_SI,
             S1x=0,
             S1y=0,
-            S1z=chi_1[i].item(),
+            S1z=chi1[i].item(),
             S2x=0,
             S2y=0,
-            S2z=chi_2[i].item(),
+            S2z=chi2[i].item(),
             distance=(distance[i].item() * u.Mpc).to("m").value,
             inclination=theta_jn[i].item(),
             phiRef=phase[i].item(),
@@ -309,8 +214,8 @@ def test_phenom_d(
             torch_freqs,
             chirp_mass[i][None],
             mass_ratio[i][None],
-            chi_1[i][None],
-            chi_2[i][None],
+            chi1[i][None],
+            chi2[i][None],
             distance[i][None],
             phase[i][None],
             theta_jn[i][None],

--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -23,91 +23,91 @@ def sample_rate(request):
 
 
 @pytest.fixture()
-def chirp_mass(request):
+def chirp_mass(seed_everything, request):
     dist = Uniform(5, 100)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def mass_ratio():
+def mass_ratio(seed_everything):
     dist = Uniform(0.125, 0.99)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def a_1(request):
+def a_1(seed_everything, request):
     dist = Uniform(0, 0.90)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def a_2(request):
+def a_2(seed_everything, request):
     dist = Uniform(0, 0.90)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def tilt_1(request):
+def tilt_1(seed_everything, request):
     dist = Uniform(0, torch.pi)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def tilt_2(request):
+def tilt_2(seed_everything, request):
     dist = Uniform(0, torch.pi)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def phi_12(request):
+def phi_12(seed_everything, request):
     dist = Uniform(0, 2 * torch.pi)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def phi_jl(request):
+def phi_jl(seed_everything, request):
     dist = Uniform(0, 2 * torch.pi)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def distance(request):
+def distance(seed_everything, request):
     dist = Uniform(100, 3000)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def distance_far(request):
+def distance_far(seed_everything, request):
     dist = Uniform(400, 3000)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def distance_close(request):
+def distance_close(seed_everything, request):
     dist = Uniform(100, 400)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def theta_jn(request):
+def theta_jn(seed_everything, request):
     dist = Uniform(0, torch.pi)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def phase(request):
+def phase(seed_everything, request):
     dist = Uniform(0, 2 * torch.pi)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def chi_1(request):
+def chi_1(seed_everything, request):
     dist = Uniform(-0.999, 0.999)
     return dist.sample((N_SAMPLES,))
 
 
 @pytest.fixture()
-def chi_2(request):
+def chi_2(seed_everything, request):
     dist = Uniform(-0.999, 0.999)
     return dist.sample((N_SAMPLES,))
 

--- a/tests/waveforms/test_generator.py
+++ b/tests/waveforms/test_generator.py
@@ -11,6 +11,11 @@ from ml4gw.waveforms import IMRPhenomD, conversion
 from ml4gw.waveforms.generator import TimeDomainCBCWaveformGenerator
 
 
+@pytest.fixture()
+def num_samples():
+    return 1000
+
+
 @pytest.fixture(params=[2048])
 def sample_rate(request):
     return request.param


### PR DESCRIPTION
Sets a seed for unit testing so that the tests are really just checking whether a PR breaks any existing functionality. A separate project that we should into is the error distribution of all of the probabilistic tests.

This change means that if a future test doesn't work with this seed due to randomness, a new random seed will have to be found for which things pass.