### PR TITLE
Bug when calculating log prob of samples outside cosine distribution

### DIFF
--- a/ml4gw/distributions.py
+++ b/ml4gw/distributions.py
@@ -42,7 +42,7 @@ class Cosine(dist.Distribution):
     def log_prob(self, value: float) -> Float[Tensor, ""]:
         value = torch.as_tensor(value)
         inside_range = (value >= self.low) & (value <= self.high)
-        return value.cos().log() * inside_range
+        return (value.cos() * inside_range).log()
 
 
 class Sine(dist.TransformedDistribution):

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -40,6 +40,8 @@ def test_cosine():
     assert len(samples) == 100
     assert ((-3 <= samples) & (samples <= 5)).all()
 
+    assert torch.all(sampler.log_prob(torch.tensor([-4, 6])) == float("-inf"))
+
 
 def test_power_law():
     """Test PowerLaw distribution"""


### PR DESCRIPTION
Fixes bug where the `log_prob` of samples outside the cosine distribution was given a value of 0 instead of `-inf`