### PR TITLE
Increment version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml4gw"
-version = "0.7.3"
+version = "0.7.4"
 description = "Tools for training torch models on gravitational wave data"
 authors = [
     { name = "Ethan Marx", email = "emarx@mit.edu" },

--- a/uv.lock
+++ b/uv.lock
@@ -1713,7 +1713,7 @@ wheels = [
 
 [[package]]
 name = "ml4gw"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "jaxtyping" },


### PR DESCRIPTION
Incrementing the version number in prep for a release in order to get the `Cosine` log-prob bug fix (#207). The switch to `uv` and `ruff` will also be in this release, but as nothing changes from a user's point of view, I'm not making this a new minor release number.