### PR TITLE
Add classifiers to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,14 @@ authors = [
     { name = "Alec Gunny", email = "alec.gunny@ligo.org" },
 ]
 requires-python = ">=3.9,<3.13"
+classifiers = [
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 readme = "README.md"
 dependencies = [
     "jaxtyping>=0.2,<0.3",


### PR DESCRIPTION
Adds classifiers to the pyproject.toml that will be displayed on PyPI. This will fix the Python version badge, which currently displays "Missing".