### PR TITLE
Improve spline interpolation

### DIFF
--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -5,6 +5,6 @@ from .scaler import ChannelWiseScaler
 from .snr_rescaler import SnrRescaler
 from .spectral import SpectralDensity
 from .spectrogram import MultiResolutionSpectrogram
-from .spline_interpolation import SplineInterpolate
+from .spline_interpolation import SplineInterpolate1D, SplineInterpolate2D
 from .waveforms import WaveformProjector, WaveformSampler
 from .whitening import FixedWhiten, Whiten

--- a/ml4gw/transforms/qtransform.py
+++ b/ml4gw/transforms/qtransform.py
@@ -8,7 +8,7 @@ from jaxtyping import Float, Int
 from torch import Tensor
 
 from ..types import FrequencySeries1to3d, TimeSeries1to3d, TimeSeries3d
-from .spline_interpolation import SplineInterpolate
+from .spline_interpolation import SplineInterpolate1D, SplineInterpolate2D
 
 """
 All based on https://github.com/gwpy/gwpy/blob/v3.0.8/gwpy/signal/qtransform.py
@@ -260,12 +260,10 @@ class SingleQTransform(torch.nn.Module):
         )
         self.qtile_interpolators = torch.nn.ModuleList(
             [
-                SplineInterpolate(
+                SplineInterpolate1D(
                     kx=3,
                     x_in=torch.arange(0, self.duration, self.duration / tiles),
-                    y_in=torch.arange(len(idx)),
                     x_out=t_out,
-                    y_out=torch.arange(len(idx)),
                 )
                 for tiles, idx in zip(unique_ntiles, self.stack_idx)
             ]
@@ -279,7 +277,7 @@ class SingleQTransform(torch.nn.Module):
             self.spectrogram_shape[0],
         )
 
-        self.interpolator = SplineInterpolate(
+        self.interpolator = SplineInterpolate2D(
             kx=3,
             ky=3,
             x_in=t_in,

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -451,7 +451,7 @@ class SplineInterpolate2D(SplineInterpolateBase):
         if dims > 4:
             raise ValueError("Input data has more than 4 dimensions")
         if dims < 2:
-            raise ValueError("Input data has less than 2 dimensions")
+            raise ValueError("Input data has fewer than 2 dimensions")
 
         if Z.shape[-2:] != torch.Size([len(self.y_in), len(self.x_in)]):
             raise ValueError(

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -236,7 +236,8 @@ class SplineInterpolate1D(SplineInterpolateBase):
         self.register_buffer("BxT_Bx", BxT_Bx)
 
         if self.x_out is not None:
-            Bx_out = self.bspline_basis_natural(x_out, kx, self.tx)
+            x_clamped = torch.clamp(x_out, tx[kx], tx[-kx - 1])
+            Bx_out = self.bspline_basis_natural(x_clamped, kx, self.tx)
             self.register_buffer("Bx_out", Bx_out)
 
     def spline_fit_natural(self, Z):
@@ -312,7 +313,12 @@ class SplineInterpolate1D(SplineInterpolateBase):
 
         if x_out is not None:
             x_out = x_out.float()
-            self.Bx_out = self.bspline_basis_natural(x_out, self.kx, self.tx)
+            x_clamped = torch.clamp(
+                x_out, self.tx[self.kx], self.tx[-self.kx - 1]
+            )
+            self.Bx_out = self.bspline_basis_natural(
+                x_clamped, self.kx, self.tx
+            )
 
         coef = self.spline_fit_natural(Z)
         Z_interp = self.evaluate_spline(coef)
@@ -406,10 +412,12 @@ class SplineInterpolate2D(SplineInterpolateBase):
         self.register_buffer("ByT_By", ByT_By)
 
         if self.x_out is not None:
-            Bx_out = self.bspline_basis_natural(x_out, kx, self.tx)
+            x_clamped = torch.clamp(x_out, tx[kx], tx[-kx - 1])
+            Bx_out = self.bspline_basis_natural(x_clamped, kx, self.tx)
             self.register_buffer("Bx_out", Bx_out)
         if self.y_out is not None:
-            By_out = self.bspline_basis_natural(y_out, ky, self.ty)
+            y_clamped = torch.clamp(y_out, ty[ky], ty[-ky - 1])
+            By_out = self.bspline_basis_natural(y_clamped, ky, self.ty)
             self.register_buffer("By_out", By_out)
 
     def bivariate_spline_fit_natural(self, Z):
@@ -500,10 +508,20 @@ class SplineInterpolate2D(SplineInterpolateBase):
 
         if x_out is not None:
             x_out = x_out.float()
-            self.Bx_out = self.bspline_basis_natural(x_out, self.kx, self.tx)
+            x_clamped = torch.clamp(
+                x_out, self.tx[self.kx], self.tx[-self.kx - 1]
+            )
+            self.Bx_out = self.bspline_basis_natural(
+                x_clamped, self.kx, self.tx
+            )
         if y_out is not None:
             y_out = y_out.float()
-            self.By_out = self.bspline_basis_natural(y_out, self.ky, self.ty)
+            y_clamped = torch.clamp(
+                y_out, self.ty[self.ky], self.ty[-self.ky - 1]
+            )
+            self.By_out = self.bspline_basis_natural(
+                y_clamped, self.ky, self.ty
+            )
 
         coef = self.bivariate_spline_fit_natural(Z)
         Z_interp = self.evaluate_bivariate_spline(coef)

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -5,111 +5,14 @@ Adaptation of code from https://github.com/dottormale/Qtransform_torch/
 from typing import Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 from torch import Tensor
-from jaxtyping import Float
 
 
-class SplineInterpolate(torch.nn.Module):
+class SplineInterpolateBase(torch.nn.Module):
     """
-    Perform 1D or 2D spline interpolation based on De Boor's method.
-    Supports batched, multi-channel inputs, so acceptable data
-    shapes are ``(width)``, ``(height, width)``, ``(batch, width)``,
-    ``(batch, height, width)``, ``(batch, channel, width)``, and
-    ``(batch, channel, height, width)``.
-
-    During initialization of this Module, both the desired input
-    and output coordinate Tensors can be specified to allow
-    pre-computation of the B-spline basis matrices, though the only
-    mandatory argument is the coordinates of the data along the
-    ``width`` dimension. If no argument is given for coordinates along
-    the ``height`` dimension, it is assumed that 1D interpolation is
-    desired.
-
-    Unlike scipy's implementation of spline interpolation, the data
-    to be interpolated is not passed until actually calling the
-    object. This is useful for cases where the input and output
-    coordinates are known in advance, but the data is not, so that
-    the interpolator can be set up ahead of time.
-
-    WARNING: compared to scipy's spline interpolation, this method
-    produces edge artifacts when the output coordinates are near
-    the boundaries of the input coordinates. Therefore, it is
-    recommended to interpolate only to coordinates that are well
-    within the input coordinate range. Unfortunately, the specific
-    definition of "well within" changes based on the size of the
-    data, so some testing may be required to get good results.
-
-    Args:
-        x_in:
-            Coordinates of the width dimension of the data
-        y_in:
-            Coordinates of the height dimension of the data. If not
-            specified, it is assumed the 1D interpolation is desired,
-            and so the default value is a Tensor of length 1
-        kx:
-            Degree of spline interpolation along the width dimension.
-            Default is cubic.
-        ky:
-            Degree of spline interpolation along the height dimension.
-            Default is cubic.
-        sx:
-            Regularization factor to avoid singularities during matrix
-            inversion for interpolation along the width dimension. Not
-            to be confused with the ``s`` parameter in scipy's spline
-            methods, which controls the number of knots.
-        sy:
-            Regularization factor to avoid singularities during matrix
-            inversion for interpolation along the height dimension.
-        x_out:
-            Coordinates for the data to be interpolated to along the
-            width dimension. If not specified during initialization,
-            this must be specified during the object call.
-        y_out:
-            Coordinates for the data to be interpolated to along the
-            height dimension. If not specified during initialization,
-            this must be specified during the object call.
-
+    Base class for spline interpolation.
     """
-
-    def __init__(
-        self,
-        x_in: Float[Tensor, " width"],
-        y_in: Float[Tensor, " height"] = None,
-        kx: int = 3,
-        ky: int = 3,
-        sx: float = 0.0,
-        sy: float = 0.0,
-        x_out: Optional[Float[Tensor, " width"]] = None,
-        y_out: Optional[Float[Tensor, " height"]] = None,
-    ):
-        super().__init__()
-        if y_in is None:
-            y_in = Tensor([1])
-        self.kx = kx
-        self.ky = ky
-        self.sx = sx
-        self.sy = sy
-        self.register_buffer("x_in", x_in)
-        self.register_buffer("y_in", y_in)
-        self.register_buffer("x_out", x_out)
-        self.register_buffer("y_out", y_out)
-
-        tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, kx, sx)
-        self.register_buffer("tx", tx)
-        self.register_buffer("Bx", Bx)
-        self.register_buffer("BxT_Bx", BxT_Bx)
-
-        ty, By, ByT_By = self._compute_knots_and_basis_matrices(y_in, ky, sy)
-        self.register_buffer("ty", ty)
-        self.register_buffer("By", By)
-        self.register_buffer("ByT_By", ByT_By)
-
-        if self.x_out is not None:
-            Bx_out = self.bspline_basis_natural(x_out, kx, self.tx)
-            self.register_buffer("Bx_out", Bx_out)
-        if self.y_out is not None:
-            By_out = self.bspline_basis_natural(y_out, ky, self.ty)
-            self.register_buffer("By_out", By_out)
 
     def _compute_knots_and_basis_matrices(self, x, k, s):
         knots = self.generate_fitpack_knots(x, k)
@@ -130,12 +33,16 @@ class SplineInterpolate(torch.nn.Module):
         Returns:
             Tensor of knot positions.
         """
-        if x.shape[-1] == 1:
-            return None
+        # If the input array is smaller than the degree of the spline,
+        # place knots where the data is and pad the boundaries
+        if x.shape[-1] < k + 1:
+            return F.pad(x[None], (k, k), mode="replicate")[0]
+
         num_knots = x.shape[-1] + k + 1
         knots = torch.zeros(num_knots, dtype=x.dtype)
         knots[: k + 1] = x[0]
         knots[-(k + 1) :] = x[-1]
+
         # Interior knots are the rolling average of the data points
         # excluding the first and last points
         windows = x[1:-1].unfold(dimension=-1, size=k, step=1)
@@ -262,6 +169,249 @@ class SplineInterpolate(torch.nn.Module):
 
         return b[:, :, -1]
 
+
+class SplineInterpolate1D(SplineInterpolateBase):
+    """
+    Perform 1D spline interpolation based on De Boor's method.
+    It is allowed to have two spatial dimensions, but the second
+    dimension cannot be interpolated along. To interpolate along both
+    dimensions, use :class:`SplineInterpolate2D`.
+
+    Supports batched, multi-channel inputs, so acceptable data
+    shapes are ``(width)``, ``(height, width)``, ``(batch, width)``,
+    ``(batch, height, width)``, ``(batch, channel, width)``, and
+    ``(batch, channel, height, width)``.
+
+    During initialization of this Module, both the desired input
+    and output coordinate Tensors can be specified to allow
+    pre-computation of the B-spline basis matrices, though the only
+    mandatory argument is the coordinates of the data along the
+    ``width`` dimension.
+
+    Unlike scipy's implementation of spline interpolation, the data
+    to be interpolated is not passed until actually calling the
+    object. This is useful for cases where the input and output
+    coordinates are known in advance, but the data is not, so that
+    the interpolator can be set up ahead of time.
+
+    Args:
+        x_in:
+            Coordinates of the width dimension of the data
+        kx:
+            Degree of spline interpolation along the width dimension.
+            Default is cubic.
+        sx:
+            Regularization factor to avoid singularities during matrix
+            inversion for interpolation along the width dimension. Not
+            to be confused with the ``s`` parameter in scipy's spline
+            methods, which controls the number of knots.
+        x_out:
+            Coordinates for the data to be interpolated to along the
+            width dimension. If not specified during initialization,
+            this must be specified during the object call.
+
+    """
+
+    def __init__(
+        self,
+        x_in: Tensor,
+        kx: int = 3,
+        sx: float = 0.0,
+        x_out: Optional[Tensor] = None,
+    ):
+        super().__init__()
+
+        # Ensure that coordinates are floats
+        x_in = x_in.float()
+        x_out = x_out.float() if x_out is not None else None
+
+        self.kx = kx
+        self.sx = sx
+        self.register_buffer("x_in", x_in)
+        self.register_buffer("x_out", x_out)
+
+        tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, kx, sx)
+        self.register_buffer("tx", tx)
+        self.register_buffer("Bx", Bx)
+        self.register_buffer("BxT_Bx", BxT_Bx)
+
+        if self.x_out is not None:
+            Bx_out = self.bspline_basis_natural(x_out, kx, self.tx)
+            self.register_buffer("Bx_out", Bx_out)
+
+    def spline_fit_natural(self, Z):
+        # Adding batch/channel dimension handling
+        # Bx @ Z
+        BxT_Z = torch.einsum("ij,bchj->bchi", self.Bx.T, Z)
+        # (BxT @ Bx)^-1 @ (BxT @ Z) = Bx^-1 @ Z
+        C = torch.linalg.solve(self.BxT_Bx, BxT_Z.unsqueeze(-1))
+        return C.squeeze(-1)
+
+    def evaluate_spline(self, C: Tensor):
+        """
+        Evaluate a bivariate spline on a grid of x and y points.
+
+        Args:
+            C: Coefficient tensor of shape (batch_size, mx, my).
+
+        Returns:
+            Z_interp: Interpolated values at the grid points.
+        """
+        # Perform matrix multiplication using einsum to get Z_interp
+        return torch.einsum("ij,bchj->bchi", self.Bx_out, C)
+
+    def _validate_inputs(self, Z, x_out):
+        if x_out is None and self.x_out is None:
+            raise ValueError(
+                "Output x-coordinates were not specified in either object "
+                "creation or in forward call"
+            )
+
+        dims = len(Z.shape)
+        if dims > 4:
+            raise ValueError("Input data has more than 4 dimensions")
+
+        if Z.shape[-1] != len(self.x_in):
+            raise ValueError(
+                "The spatial dimensions of the data tensor do not match "
+                "the given input dimensions. "
+                f"Expected {len(self.x_in)}, but got {Z.shape[-1]}"
+            )
+
+        # Expand Z to have a batch, channel, and height dimension if needed
+        while len(Z.shape) < 4:
+            Z = Z.unsqueeze(0)
+
+        return Z
+
+    def forward(
+        self,
+        Z: Tensor,
+        x_out: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Compute the interpolated data
+
+        Args:
+            Z:
+                Tensor of data to be interpolated. Must be between 2 and 4
+                dimensions. The shape of the tensor must agree with the
+                input coordinates given on initialization.
+            x_out:
+                Coordinates to interpolate the data to along the width
+                dimension. Overrides any value that was set during
+                initialization.
+
+        Returns:
+            A 4D tensor with shape ``(batch, channel, height, width)``.
+            Depending on the input data shape, many of these dimensions
+            may have length 1.
+        """
+
+        Z = self._validate_inputs(Z, x_out)
+
+        if x_out is not None:
+            x_out = x_out.float()
+            self.Bx_out = self.bspline_basis_natural(x_out, self.kx, self.tx)
+
+        coef = self.spline_fit_natural(Z)
+        Z_interp = self.evaluate_spline(coef)
+        return Z_interp
+
+
+class SplineInterpolate2D(SplineInterpolateBase):
+    """
+    Perform 2D spline interpolation based on De Boor's method.
+    Supports batched, multi-channel inputs, so acceptable data
+    shapes are ``(height, width)``, ``(batch, height, width)``,
+    and ``(batch, channel, height, width)``.
+
+    During initialization of this Module, both the desired input
+    and output coordinate Tensors can be specified to allow
+    pre-computation of the B-spline basis matrices, though the only
+    mandatory arguments are the input coordinates.
+
+    Unlike scipy's implementation of spline interpolation, the data
+    to be interpolated is not passed until actually calling the
+    object. This is useful for cases where the input and output
+    coordinates are known in advance, but the data is not, so that
+    the interpolator can be set up ahead of time.
+
+    Args:
+        x_in:
+            Coordinates of the width dimension of the data
+        y_in:
+            Coordinates of the height dimension of the data.
+        kx:
+            Degree of spline interpolation along the width dimension.
+            Default is cubic.
+        ky:
+            Degree of spline interpolation along the height dimension.
+            Default is cubic.
+        sx:
+            Regularization factor to avoid singularities during matrix
+            inversion for interpolation along the width dimension. Not
+            to be confused with the ``s`` parameter in scipy's spline
+            methods, which controls the number of knots.
+        sy:
+            Regularization factor to avoid singularities during matrix
+            inversion for interpolation along the height dimension.
+        x_out:
+            Coordinates for the data to be interpolated to along the
+            width dimension. If not specified during initialization,
+            this must be specified during the object call.
+        y_out:
+            Coordinates for the data to be interpolated to along the
+            height dimension. If not specified during initialization,
+            this must be specified during the object call.
+
+    """
+
+    def __init__(
+        self,
+        x_in: Tensor,
+        y_in: Tensor,
+        kx: int = 3,
+        ky: int = 3,
+        sx: float = 0.0,
+        sy: float = 0.0,
+        x_out: Optional[Tensor] = None,
+        y_out: Optional[Tensor] = None,
+    ):
+        super().__init__()
+
+        # Ensure that coordinates are floats
+        x_in = x_in.float()
+        y_in = y_in.float()
+        x_out = x_out.float() if x_out is not None else None
+        y_out = y_out.float() if y_out is not None else None
+
+        self.kx = kx
+        self.ky = ky
+        self.sx = sx
+        self.sy = sy
+        self.register_buffer("x_in", x_in)
+        self.register_buffer("y_in", y_in)
+        self.register_buffer("x_out", x_out)
+        self.register_buffer("y_out", y_out)
+
+        tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, kx, sx)
+        self.register_buffer("tx", tx)
+        self.register_buffer("Bx", Bx)
+        self.register_buffer("BxT_Bx", BxT_Bx)
+
+        ty, By, ByT_By = self._compute_knots_and_basis_matrices(y_in, ky, sy)
+        self.register_buffer("ty", ty)
+        self.register_buffer("By", By)
+        self.register_buffer("ByT_By", ByT_By)
+
+        if self.x_out is not None:
+            Bx_out = self.bspline_basis_natural(x_out, kx, self.tx)
+            self.register_buffer("Bx_out", Bx_out)
+        if self.y_out is not None:
+            By_out = self.bspline_basis_natural(y_out, ky, self.ty)
+            self.register_buffer("By_out", By_out)
+
     def bivariate_spline_fit_natural(self, Z):
         # Adding batch/channel dimension handling
         # ByT @ Z @ BxW
@@ -292,29 +442,16 @@ class SplineInterpolate(torch.nn.Module):
             )
 
         if y_out is None and self.y_out is None:
-            y_out = self.y_in
+            raise ValueError(
+                "Output y-coordinates were not specified in either object "
+                "creation or in forward call"
+            )
 
         dims = len(Z.shape)
         if dims > 4:
             raise ValueError("Input data has more than 4 dimensions")
-
-        if len(self.y_in) > 1 and dims == 1:
-            raise ValueError(
-                "An input y-coordinate array with length greater than 1 "
-                "was given, but the input data is 1-dimensional. Expected "
-                "input data to be at least 2-dimensional"
-            )
-
-        # Expand Z to have 4 dimensions
-        # There are 6 valid input shapes: (w), (b, w), (b, c, w),
-        # (h, w), (b, h, w), and (b, c, h, w).
-
-        # If the input y coordinate array has length 1,
-        # assume the first dimension(s) are batch dimensions
-        # and that no height dimension is included in Z
-        idx = -2 if len(self.y_in) == 1 else -3
-        while len(Z.shape) < 4:
-            Z = Z.unsqueeze(idx)
+        if dims < 2:
+            raise ValueError("Input data has less than 2 dimensions")
 
         if Z.shape[-2:] != torch.Size([len(self.y_in), len(self.x_in)]):
             raise ValueError(
@@ -323,6 +460,10 @@ class SplineInterpolate(torch.nn.Module):
                 f"Expected [{len(self.y_in)}, {len(self.x_in)}], but got "
                 f"[{Z.shape[-2]}, {Z.shape[-1]}]"
             )
+
+        # Expand Z to have a batch and channel dimension if needed
+        while len(Z.shape) < 4:
+            Z = Z.unsqueeze(0)
 
         return Z, y_out
 
@@ -337,11 +478,9 @@ class SplineInterpolate(torch.nn.Module):
 
         Args:
             Z:
-                Tensor of data to be interpolated. Must be between 1 and 4
+                Tensor of data to be interpolated. Must be between 2 and 4
                 dimensions. The shape of the tensor must agree with the
-                input coordinates given on initialization. If ``y_in`` was
-                not specified during initialization, it is assumed that
-                Z does not have a height dimension.
+                input coordinates given on initialization.
             x_out:
                 Coordinates to interpolate the data to along the width
                 dimension. Overrides any value that was set during
@@ -360,8 +499,10 @@ class SplineInterpolate(torch.nn.Module):
         Z, y_out = self._validate_inputs(Z, x_out, y_out)
 
         if x_out is not None:
+            x_out = x_out.float()
             self.Bx_out = self.bspline_basis_natural(x_out, self.kx, self.tx)
         if y_out is not None:
+            y_out = y_out.float()
             self.By_out = self.bspline_basis_natural(y_out, self.ky, self.ty)
 
         coef = self.bivariate_spline_fit_natural(Z)

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -141,9 +141,7 @@ def test_singleqtransform(
         mismatch=mismatch,
     )
 
-    assert (
-        qtransform.get_freqs().numpy() == list(qplane._iter_frequencies())
-    ).all()
+    assert (qtransform.freqs.numpy() == qplane.frequencies).all()
 
     qtransform.compute_qtiles(X, norm)
     torch_qtiles = qtransform.qtiles

--- a/tests/transforms/test_spline_interpolation.py
+++ b/tests/transforms/test_spline_interpolation.py
@@ -22,12 +22,6 @@ class TestSplineInterpolate:
 
         x_in = np.linspace(x_min, x_max, 100)
         data = np.sin(x_in)
-        # There are edge effects in the torch transform that
-        # aren't present in scipy. Would be great to solve that,
-        # but a workaround is to interpolate well within the
-        # boundaries of the input coordinates. Unfortunately,
-        # what specifically that means depends on the size of
-        # the input array.
         x_out = np.linspace(x_min, x_max, x_out_len)
 
         scipy_spline = UnivariateSpline(x_in, data, k=3, s=0)
@@ -44,10 +38,6 @@ class TestSplineInterpolate:
         )
         actual = torch_spline(data).squeeze().numpy()
 
-        # The "steady-state" ratio between the torch and scipy
-        # interpolations is about 0.9990, with some minor fluctuations.
-        # Would be nice to know why the torch interpolation is
-        # consistently smaller
         assert np.allclose(actual, expected, rtol=1e-4)
 
         # Check that passing output grid behaves as expected
@@ -87,10 +77,6 @@ class TestSplineInterpolate:
         )
         actual = torch_spline(data).squeeze().numpy()
 
-        # The "steady-state" ratio between the torch and scipy
-        # interpolations is about 0.999, with some minor fluctuations.
-        # Would be nice to know why the torch interpolation is
-        # consistently smaller
         assert np.allclose(actual, expected, rtol=1e-4)
 
         # Check that passing output grid behaves as expected


### PR DESCRIPTION
Thanks to Lorenzo figuring out how to place knots more accurately, the spline interpolation now agrees much more closely with SciPy's and the boundary effects are gone.

Additionally, in the PR I split the interpolation method into 1D and 2D cases and added handling for when the output coordinates go beyond the input coordinate range, though the portion outside the input space doesn't agree with SciPy.