### PR TITLE
Add module-level docstrings to top-level modules

### DIFF
--- a/ml4gw/augmentations.py
+++ b/ml4gw/augmentations.py
@@ -1,3 +1,8 @@
+"""
+This module contains transformations that may be useful
+for augmenting timeseries data during training
+"""
+
 import torch
 from jaxtyping import Float
 from torch import Tensor

--- a/ml4gw/dataloading/__init__.py
+++ b/ml4gw/dataloading/__init__.py
@@ -1,3 +1,8 @@
+"""
+This module contains tools for efficient in-memory and
+out-of-memory dataloading.
+"""
+
 from .chunked_dataset import ChunkedTimeSeriesDataset
 from .hdf5_dataset import Hdf5TimeSeriesDataset
 from .in_memory_dataset import InMemoryDataset

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -1,6 +1,7 @@
 """
-Tools for manipulating raw gravitational waveforms
-and projecting them onto interferometer responses.
+Tools for manipulating raw gravitational waveforms,
+projecting them onto interferometer responses, and
+calculating SNRs.
 Much of the projection code is an extension of the
 implementation made available in
 `bilby <https://arxiv.org/abs/1811.02042>`_.

--- a/ml4gw/nn/__init__.py
+++ b/ml4gw/nn/__init__.py
@@ -1,0 +1,6 @@
+"""
+This module contains neural network architectures and
+architecture components. These can be a good place
+to get started, rather than defining your own
+architecture from the start.
+"""

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -1,4 +1,7 @@
 """
+This module provides functions for calculation of spectral densities
+and for whitening.
+
 Several implementation details are derived from the scipy csd and welch
 implementations. For more info, see
 

--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -1,3 +1,9 @@
+"""
+This module contains a variety of data transformation classes,
+including objects to calculate spectral densities, whiten data,
+and compute Q-transforms.
+"""
+
 from .iirfilter import IIRFilter
 from .pearson import ShiftedPearsonCorrelation
 from .qtransform import QScan, SingleQTransform

--- a/ml4gw/types.py
+++ b/ml4gw/types.py
@@ -1,3 +1,8 @@
+"""
+This module defines common types used for type
+annotation throughout the package
+"""
+
 from jaxtyping import Float
 from torch import Tensor
 

--- a/ml4gw/utils/interferometer.py
+++ b/ml4gw/utils/interferometer.py
@@ -1,10 +1,27 @@
+"""
+This module contains the interferometer geometry
+used to calculate waveform projection.
+
+Values taken from
+https://lscsoft.docs.ligo.org/lalsuite/lal/_l_a_l_detectors_8h_source.html
+"""
+
+from typing import Literal
+
 import torch
 
 
-# based on values from
-# https://lscsoft.docs.ligo.org/lalsuite/lal/_l_a_l_detectors_8h_source.html
 class InterferometerGeometry:
-    def __init__(self, name: str) -> None:
+    """
+    Contains geometric information for the LIGO, Virgo, and KAGRA
+    interferometers.
+
+    Args:
+        name: The name of the interferometer. This should be either
+        'H1', 'L1', 'V1', or 'K1'.
+    """
+
+    def __init__(self, name: Literal["H1", "L1", "V1", "K1"]) -> None:
         if name == "H1":
             self.x_arm = torch.Tensor(
                 (-0.22389266154, +0.79983062746, +0.55690487831)

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -1,3 +1,10 @@
+"""
+This module contains functions for randomly sampling
+windows of data from timeseries data, as well as for
+unfolding timeseries data into potentially overlapping
+windows.
+"""
+
 import torch
 from jaxtyping import Float, Int64
 from torch import Tensor

--- a/ml4gw/waveforms/__init__.py
+++ b/ml4gw/waveforms/__init__.py
@@ -1,2 +1,8 @@
+"""
+This module contains tools for generating waveforms,
+both CBC approximants and more generic waveforms like
+sine-gaussians.
+"""
+
 from .adhoc import *
 from .cbc import *


### PR DESCRIPTION
This PR adds brief module docstrings to all of the top-level modules so that those descriptions aren't blank for new users looking through our documentation.