### PR TITLE
device consistency in UniformInComovingVolume; fix #232

### DIFF
--- a/ml4gw/distributions.py
+++ b/ml4gw/distributions.py
@@ -268,8 +268,8 @@ class UniformComovingVolume(dist.Distribution):
         """
         self._generate_distance_grids()
         bounds = torch.tensor(
-            [self.minimum, self.maximum],
-            device=self.minimum.device)
+            [self.minimum, self.maximum], device=self.minimum.device
+        )
         z_min, z_max = self._linear_interp_1d(
             self.distance_grid, self.z_grid, bounds
         )
@@ -280,8 +280,9 @@ class UniformComovingVolume(dist.Distribution):
         """
         Generate distance grids based on the specified redshift range.
         """
-        self.z_grid = torch.linspace(0, self.z_grid_max, self.grid_size,
-                                     device=self.minimum.device)
+        self.z_grid = torch.linspace(
+            0, self.z_grid_max, self.grid_size, device=self.minimum.device
+        )
         self.dz = self.z_grid[1] - self.z_grid[0]
         # C is specfied in m/s, h0 in km/s/Mpc, so divide by 1000 to convert
         comoving_dist_grid = (
@@ -290,8 +291,9 @@ class UniformComovingVolume(dist.Distribution):
             )
             / 1000
         )
-        zero_prefix = torch.zeros(1, dtype=comoving_dist_grid.dtype,
-                                  device=self.minimum.device)
+        zero_prefix = torch.zeros(
+            1, dtype=comoving_dist_grid.dtype, device=self.minimum.device
+        )
         self.comoving_dist_grid = torch.cat([zero_prefix, comoving_dist_grid])
         self.luminosity_dist_grid = self.comoving_dist_grid * (1 + self.z_grid)
 
@@ -321,7 +323,9 @@ class UniformComovingVolume(dist.Distribution):
             p_of_distance, self.distance_grid
         )
         cdf = torch.cumulative_trapezoid(self.pdf, self.distance_grid)
-        zero_prefix = torch.zeros(1, dtype=cdf.dtype, device=self.minimum.device)
+        zero_prefix = torch.zeros(
+            1, dtype=cdf.dtype, device=self.minimum.device
+        )
         self.cdf = torch.cat([zero_prefix, cdf])
         self.log_pdf = torch.log(self.pdf)
 
@@ -348,8 +352,7 @@ class UniformComovingVolume(dist.Distribution):
         )
         inside_range = (value >= self.minimum) & (value <= self.maximum)
         log_prob[~inside_range] = torch.as_tensor(
-            float("-inf"),
-            device=self.minimum.device
+            float("-inf"), device=self.minimum.device
         )
         return log_prob
 


### PR DESCRIPTION
Correct behavior

```
>>> u = UniformComovingVolume(torch.tensor(10, device='cuda'), torch.tensor(500, device='cuda'), distance_type='luminosity_distance')
>>> u.sample([10])
tensor([443.0536, 377.2384, 481.7238, 297.4012, 404.1351, 432.7634, 440.1178,
        194.7355, 213.3020, 233.6047], device='cuda:0')
>>> u.log_prob(u.sample([10]))
tensor([-5.2120, -5.4859, -5.4920, -5.3027, -5.8847, -5.7780, -5.4121, -5.5976,
        -5.8301, -5.5144], device='cuda:0')
>>> #existing behavior preserved
>>> u = UniformComovingVolume(10, 500, distance_type='luminosity_distance')
>>> u.log_prob(u.sample([10]))
tensor([-5.2227, -5.5708, -5.4034, -6.2353, -5.9081, -6.1413, -5.8589, -5.4844,
        -6.4799, -6.7946])
```