### PR TITLE
Add `crop` parameter to whitening

### DIFF
--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -436,6 +436,7 @@ def normalize_by_psd(
     psd: PSDTensor,
     sample_rate: float,
     pad: int,
+    crop: bool = True,
 ):
     # compute the FFT of the section we want to whiten
     # and divide it by the ASD of the background section.
@@ -452,7 +453,8 @@ def normalize_by_psd(
     X = X.float() / sample_rate**0.5
 
     # slice off corrupted data at edges of kernel
-    X = X[:, :, pad:-pad]
+    if crop:
+        X = X[:, :, pad:-pad]
     return X
 
 
@@ -463,6 +465,7 @@ def whiten(
     sample_rate: float,
     highpass: float | None = None,
     lowpass: float | None = None,
+    crop: bool = True,
 ) -> WaveformTensor:
     """
     Whiten a batch of timeseries using the specified
@@ -506,9 +509,14 @@ def whiten(
             the data, setting the frequency response in the
             whitening filter to 0. If left as ``None``, no
             lowpass filtering will be applied.
+        crop:
+            If ``True``, crop ``fduration / 2`` seconds of data
+            from both sides of the time dimension to remove the
+            corruption from the filter. If ``False``, return the
+            full timeseries.
     Returns:
-        Batch of whitened multichannel timeseries with
-            ``fduration / 2`` seconds trimmed from each side.
+        Batch of whitened multichannel timeseries with ``fduration / 2``
+            seconds optionally trimmed from each side.
     """
 
     # figure out how much data we'll need to slice
@@ -549,4 +557,4 @@ def whiten(
         lowpass,
     )
 
-    return normalize_by_psd(X, psd, sample_rate, pad)
+    return normalize_by_psd(X, psd, sample_rate, pad, crop)

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -135,6 +135,11 @@ class FixedWhiten(FittableSpectralTransform):
             frequency bins in the fit PSD.
         sample_rate:
             Rate at which timeseries will be sampled, in Hz
+        crop:
+            If ``True``, crop ``fduration / 2`` seconds of data
+            from both sides of the time dimension to remove the
+            corruption from the filter. If ``False``, return the
+            full timeseries.
         dtype:
             Datatype with which background PSD will be stored
     """
@@ -144,12 +149,14 @@ class FixedWhiten(FittableSpectralTransform):
         num_channels: float,
         kernel_length: float,
         sample_rate: float,
+        crop: bool = True,
         dtype: torch.dtype = torch.float64,
     ) -> None:
         super().__init__()
         self.num_channels = num_channels
         self.sample_rate = sample_rate
         self.kernel_length = kernel_length
+        self.crop = crop
 
         N = int(kernel_length * sample_rate)
         num_freqs = N // 2 + 1
@@ -266,4 +273,6 @@ class FixedWhiten(FittableSpectralTransform):
             )
 
         pad = int(self.fduration.item() * self.sample_rate / 2)
-        return spectral.normalize_by_psd(X, self.psd, self.sample_rate, pad)
+        return spectral.normalize_by_psd(
+            X, self.psd, self.sample_rate, pad, self.crop
+        )

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -47,6 +47,11 @@ class Whiten(torch.nn.Module):
             Cutoff frequency to apply lowpass filtering
             during whitening. If left as ``None``, no lowpass
             filtering will be performed.
+        crop:
+            If ``True``, crop ``fduration / 2`` seconds of data
+            from both sides of the time dimension to remove the
+            corruption from the filter. If ``False``, return the
+            full timeseries.
     """
 
     def __init__(
@@ -55,12 +60,14 @@ class Whiten(torch.nn.Module):
         sample_rate: float,
         highpass: float | None = None,
         lowpass: float | None = None,
+        crop: bool = True,
     ) -> None:
         super().__init__()
         self.fduration = fduration
         self.sample_rate = sample_rate
         self.highpass = highpass
         self.lowpass = lowpass
+        self.crop = crop
 
         # register a window up front to signify our
         # fduration at inference time
@@ -109,6 +116,7 @@ class Whiten(torch.nn.Module):
             sample_rate=self.sample_rate,
             highpass=self.highpass,
             lowpass=self.lowpass,
+            crop=self.crop,
         )
 
 

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -137,11 +137,6 @@ class FixedWhiten(FittableSpectralTransform):
         sample_rate:
             Rate at which timeseries will be sampled, in Hz
         crop:
-            If ``True``, crop ``fduration / 2`` seconds of data
-            from both sides of the time dimension to remove the
-            corruption from the filter. If ``False``, return the
-            full timeseries.
-        dtype:
             Datatype with which background PSD will be stored
     """
 
@@ -150,7 +145,6 @@ class FixedWhiten(FittableSpectralTransform):
         num_channels: float,
         kernel_length: float,
         sample_rate: float,
-        crop: bool = True,
         dtype: torch.dtype = torch.float64,
     ) -> None:
         super().__init__()


### PR DESCRIPTION
This PR adds a `crop` parameter to the `whiten` function and the whitening transforms that allows data to be returned uncropped. By default, `crop = True`.