### PR TITLE
update myst config for correct latex rendering in markdown

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,18 @@ autodoc_typehints = "description"
 autodoc_inherit_docstrings = False
 nb_execution_mode = "off"
 
+# MyST configuration
+myst_enable_extensions = [
+    "dollarmath",      # Enable $...$ and $$...$$ for math
+    "amsmath",         # Enable advanced math environments
+    "colon_fence",     # Enable ::: fences
+    "deflist",         # Enable definition lists
+    "html_image",      # Enable HTML images
+    "replacements",    # Enable replacements
+    "smartquotes",     # Enable smart quotes
+    "substitution",    # Enable substitutions
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
fixes math rendering with latex in markdown

<img width="779" height="367" alt="image" src="https://github.com/user-attachments/assets/b07339f9-d87a-405d-a9a1-8c540859ca39" />
