### PR TITLE
Convert coverage file to xml before upload

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,29 +17,33 @@ jobs:
     - uses: actions/checkout@v4
 
     # set up our environment
-    - 
-      name: Install Python
+    - name: Install Python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    -
-      name: Install tox
+
+    - name: Install tox and coverage
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox tox-gh-actions coverage
 
     # run the library's tests
-    -
-      name: run tests
+    - name: run tests
       env:
         pyver: ${{ matrix.python-version }}
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}
       run: |
         tox -e py${pyver//./}
 
-    - 
-      name: Upload coverage to Codecov
+    - name: Generate XML coverage report
+      env:
+        COVERAGE_FILE: .coverage.${{ matrix.python-version }}
+      run: |
+        coverage xml -o coverage.xml
+
+    - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        files: .coverage.${{ matrix.python-version }}
+        files: ./coverage.xml
         flags: py${{ matrix.python-version }}
+        fail_ci_if_error: true


### PR DESCRIPTION
The files generated by `coverage` need to be converted to XML before being uploaded to Codecov. Added that step to the workflow.