### PR TITLE
Remove tox

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,24 +22,23 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install tox and coverage
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox tox-gh-actions coverage
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install dependencies
+      run: uv sync --group dev
 
     # run the library's tests
-    - name: run tests
+    - name: Run tests with coverage
       env:
-        pyver: ${{ matrix.python-version }}
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}
-      run: |
-        tox -e py${pyver//./}
+      run: uv run coverage run -m pytest
 
     - name: Generate XML coverage report
       env:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}
-      run: |
-        coverage xml -o coverage.xml
+      run: coverage xml -o coverage.xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Generate XML coverage report
       env:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}
-      run: coverage xml -o coverage.xml
+      run: uv run coverage xml -o coverage.xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,8 @@ dev = [
     "pytest~=7.0",
     "lalsuite~=7.0",
     "bilby~=2.1",
-    "jupyter>=1.0.0,<2",
-    "gwpy~=3.0",
     "pytest-repeat>=0.9.3,<0.10",
     "h5py~=3.12",
-    "torchmetrics~=1.6.0",
-    "lightning~=2.4.0",
-    "rich>=10.2.2,<14.0",
 ]
 docs = [
     "Sphinx>5.0",
@@ -54,6 +49,11 @@ docs = [
     "myst-parser>=2.0.0,<3",
     "myst-nb>=1.3.0",
     "sphinx-autodoc-typehints>=2.0.0,<3",
+    "torchmetrics~=1.6.0",
+    "lightning~=2.4.0",
+    "rich>=10.2.2,<14.0",
+    "gwpy~=3.0",
+    "jupyter>=1.0.0,<2",
 ]
 
 [tool.uv]
@@ -88,30 +88,8 @@ ignore = ["W605", "E203", "F722"]
 # import errors in __init__ files
 per-file-ignores =  {"**/__init__.py" = ["F401", "F403"]}
 
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py{310,311,312}
-isolated_build = true
-
-[gh-actions]
-python =
-    3.10: py310
-    3.11: py311
-    3.12: py312
-
-[testenv:py{310,311,312}]
-deps = 
-    coverage[toml]>=7.6,<8
-    pytest>=7,<8
-    lalsuite>=7,<8
-    bilby>=2.1,<3.0
-    gwpy>=3.0,<4.0
-    numpy>=1
-    scipy>=1.9,<1.14
-pass_env = COVERAGE_FILE
-commands = coverage run -m pytest tests
-"""
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.coverage.run]
 source = ["ml4gw"]

--- a/uv.lock
+++ b/uv.lock
@@ -1877,23 +1877,23 @@ dependencies = [
 dev = [
     { name = "bilby" },
     { name = "coverage", extra = ["toml"] },
-    { name = "gwpy" },
     { name = "h5py" },
-    { name = "jupyter" },
     { name = "lalsuite" },
-    { name = "lightning" },
     { name = "prek" },
     { name = "pytest" },
     { name = "pytest-repeat" },
-    { name = "rich" },
-    { name = "torchmetrics" },
 ]
 docs = [
+    { name = "gwpy" },
+    { name = "jupyter" },
+    { name = "lightning" },
     { name = "myst-nb" },
     { name = "myst-parser" },
+    { name = "rich" },
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-rtd-theme" },
+    { name = "torchmetrics" },
 ]
 
 [package.metadata]
@@ -1909,23 +1909,23 @@ requires-dist = [
 dev = [
     { name = "bilby", specifier = "~=2.1" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.10,<8" },
-    { name = "gwpy", specifier = "~=3.0" },
     { name = "h5py", specifier = "~=3.12" },
-    { name = "jupyter", specifier = ">=1.0.0,<2" },
     { name = "lalsuite", specifier = "~=7.0" },
-    { name = "lightning", specifier = "~=2.4.0" },
     { name = "prek", specifier = ">=0.1" },
     { name = "pytest", specifier = "~=7.0" },
     { name = "pytest-repeat", specifier = ">=0.9.3,<0.10" },
-    { name = "rich", specifier = ">=10.2.2,<14.0" },
-    { name = "torchmetrics", specifier = "~=1.6.0" },
 ]
 docs = [
+    { name = "gwpy", specifier = "~=3.0" },
+    { name = "jupyter", specifier = ">=1.0.0,<2" },
+    { name = "lightning", specifier = "~=2.4.0" },
     { name = "myst-nb", specifier = ">=1.3.0" },
     { name = "myst-parser", specifier = ">=2.0.0,<3" },
+    { name = "rich", specifier = ">=10.2.2,<14.0" },
     { name = "sphinx", specifier = ">5.0" },
     { name = "sphinx-autodoc-typehints", specifier = ">=2.0.0,<3" },
     { name = "sphinx-rtd-theme", specifier = ">=2.0.0,<3" },
+    { name = "torchmetrics", specifier = "~=1.6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
We're not doing anything with `tox` that can't be straightforwardly handled with the testing matrix, so I've removed it from the workflow to simplify things. I've also moved the dependencies that appear only in the tutorial notesbooks into the `docs` group.