### PR TITLE
Use OIDC for codecov

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -45,5 +47,5 @@ jobs:
       with:
         files: ./coverage.xml
         flags: py${{ matrix.python-version }}
-        token: ${{ secrets.CODECOV_TOKEN }}
+        use-oidc: true
         fail_ci_if_error: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -47,5 +47,5 @@ jobs:
       with:
         files: ./coverage.xml
         flags: py${{ matrix.python-version }}
-        use-oidc: true
+        use_oidc: true
         fail_ci_if_error: true


### PR DESCRIPTION
CI fails for PRs created by dependabot because it doesn't have token access. This PR replaces the token-based authentication with OIDC.