### PR TITLE
Add testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 line-length = 79
-extend-select = ["T201"]
 extend-exclude = ["docs", "examples"]
 target-version = "py312"
 
 [tool.ruff.lint]
+extend-select = ["T201"]
 extend-safe-fixes = ["C408"]
 mccabe = {"max-complexity" = 18}
 select = ["B", "C", "E", "F", "I", "UP", "W"]

--- a/tests/dataloading/test_chunked_dataset.py
+++ b/tests/dataloading/test_chunked_dataset.py
@@ -80,3 +80,35 @@ class TestChunkedTimeseriesDataset:
             length += 1
 
         assert length == 42
+
+    def test_len(
+        self,
+        chunk_it,
+        chunks_per_epoch,
+        kernel_length,
+        batch_size,
+        batches_per_chunk,
+        coincident,
+    ):
+        ds = ChunkedTimeSeriesDataset(
+            list(chunk_it()),
+            int(kernel_length * 128),
+            batch_size=batch_size,
+            batches_per_chunk=batches_per_chunk,
+            coincident=coincident,
+            device="cpu",
+        )
+        assert len(ds) == chunks_per_epoch * batches_per_chunk
+
+    def test_chunk_too_small(self, chunk_it, batch_size, batches_per_chunk):
+        with pytest.raises(ValueError, match="Can't sample kernels"):
+            ds = ChunkedTimeSeriesDataset(
+                chunk_it(),
+                kernel_size=99999,
+                batch_size=batch_size,
+                batches_per_chunk=batches_per_chunk,
+                coincident=True,
+                device="cpu",
+            )
+            for _ in ds:
+                pass

--- a/tests/dataloading/test_hdf5_dataset.py
+++ b/tests/dataloading/test_hdf5_dataset.py
@@ -186,3 +186,17 @@ class TestHdf5TimeSeriesDataset:
         for x in dataset:
             assert x.shape == (128, 2, kernel_size)
         assert len(dataset) == 10
+
+    def test_num_files_per_batch_too_large(
+        self, fnames, channels, kernel_size, batch_size, batches_per_epoch
+    ):
+        with pytest.raises(ValueError, match="Number of files per batch"):
+            Hdf5TimeSeriesDataset(
+                sorted(fnames.keys()),
+                channels,
+                kernel_size,
+                batch_size,
+                batches_per_epoch,
+                coincident=True,
+                num_files_per_batch=len(fnames) + 1,
+            )

--- a/tests/dataloading/test_in_memory_dataset.py
+++ b/tests/dataloading/test_in_memory_dataset.py
@@ -355,3 +355,49 @@ def test_in_memory_dataset_non_coincident_stochastic(
 
     with pytest.raises(StopIteration):
         next(data_it)
+
+
+def test_in_memory_dataset_coincident_shuffle(
+    X, num_kernels, kernel_size, batch_size, stride, validate_shape
+):
+    perm = torch.randperm(num_kernels)
+    dataset = InMemoryDataset(
+        X,
+        kernel_size,
+        batch_size=batch_size,
+        stride=stride,
+        coincident=True,
+        shuffle=True,
+    )
+    with patch("torch.randperm", return_value=perm) as mock:
+        dataset.init_indices()
+    mock.assert_called_once_with(num_kernels, device=dataset.X.device)
+
+    with patch.object(InMemoryDataset, "init_indices", return_value=perm):
+        dataset = InMemoryDataset(
+            X,
+            kernel_size,
+            batch_size=batch_size,
+            stride=stride,
+            coincident=True,
+            shuffle=True,
+        )
+
+        data_it = iter(dataset)
+        idx = perm.cpu().numpy()
+        num_samples = X.shape[-1]
+
+        for i in range(len(dataset)):
+            x = next(data_it)
+            validate_shape(i, x, len(dataset))
+            for j, sample in enumerate(x.cpu().numpy()):
+                sample_idx = i * batch_size + j
+                start_idx = idx[sample_idx]
+                for k, channel in enumerate(sample):
+                    start = start_idx * stride + k * num_samples
+                    stop = start + kernel_size
+                    expected = np.arange(start, stop).astype("float32")
+                    assert (channel == expected).all(), (i, j, k)
+
+    with pytest.raises(StopIteration):
+        next(data_it)

--- a/tests/nn/resnet/test_resnet_1d.py
+++ b/tests/nn/resnet/test_resnet_1d.py
@@ -11,12 +11,12 @@ from ml4gw.nn.resnet.resnet_1d import (
 )
 
 
-@pytest.fixture(params=[3, 7, 8])
+@pytest.fixture(params=[3, 8])
 def kernel_size(request):
     return request.param
 
 
-@pytest.fixture(params=[64, 128])
+@pytest.fixture(params=[64])
 def sample_rate(request):
     return request.param
 
@@ -26,12 +26,12 @@ def stride(request):
     return request.param
 
 
-@pytest.fixture(params=[2, 4])
+@pytest.fixture(params=[2])
 def inplanes(request):
     return request.param
 
 
-@pytest.fixture(params=[1, 2])
+@pytest.fixture(params=[2])
 def classes(request):
     return request.param
 
@@ -72,12 +72,12 @@ def test_blocks(block, kernel_size, stride, sample_rate, inplanes):
     assert y.shape[2] == sample_rate // stride
 
 
-@pytest.fixture(params=[1, 2, 3])
+@pytest.fixture(params=[1, 3])
 def in_channels(request):
     return request.param
 
 
-@pytest.fixture(params=[[2, 2, 2, 2], [2, 4, 4], [3, 4, 6, 3]])
+@pytest.fixture(params=[[2, 2, 2, 2]])
 def layers(request):
     return request.param
 
@@ -87,12 +87,12 @@ def stride_type(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[False])
 def zero_init_residual(request):
     return request.param
 
 
-@pytest.fixture(params=[None, torch.nn.BatchNorm1d])
+@pytest.fixture(params=[None])
 def norm_layer(request):
     return request.param
 
@@ -164,3 +164,23 @@ def test_resnet(
         nn = architecture(
             in_channels, layers, kernel_size, stride_type=stride_type
         )
+
+
+def test_resnet1d_zero_init_residual():
+    nn = ResNet1D(
+        1,
+        [2, 2, 2, 2],
+        2,
+        3,
+        zero_init_residual=True,
+        norm_layer=torch.nn.BatchNorm1d,
+    )
+    # the flag should zero-initialize the last BN weight in each residual block
+    for m in nn.modules():
+        if isinstance(m, Bottleneck):
+            assert (m.bn3.weight == 0).all()
+        elif isinstance(m, BasicBlock):
+            assert (m.bn2.weight == 0).all()
+    x = torch.randn(4, 1, 64)
+    y = nn(x)
+    assert y.shape == (4, 2)

--- a/tests/nn/resnet/test_resnet_2d.py
+++ b/tests/nn/resnet/test_resnet_2d.py
@@ -11,12 +11,12 @@ from ml4gw.nn.resnet.resnet_2d import (
 )
 
 
-@pytest.fixture(params=[3, 7, 8])
+@pytest.fixture(params=[3, 8])
 def kernel_size(request):
     return request.param
 
 
-@pytest.fixture(params=[10, 50])
+@pytest.fixture(params=[10])
 def spectrogram_size(request):
     return request.param
 
@@ -26,12 +26,12 @@ def stride(request):
     return request.param
 
 
-@pytest.fixture(params=[2, 4])
+@pytest.fixture(params=[2])
 def inplanes(request):
     return request.param
 
 
-@pytest.fixture(params=[1, 2])
+@pytest.fixture(params=[2])
 def classes(request):
     return request.param
 
@@ -73,12 +73,12 @@ def test_blocks(block, kernel_size, stride, spectrogram_size, inplanes):
     assert y.shape[3] == spectrogram_size // stride
 
 
-@pytest.fixture(params=[1, 2, 3])
+@pytest.fixture(params=[1, 3])
 def in_channels(request):
     return request.param
 
 
-@pytest.fixture(params=[[2, 2, 2, 2], [2, 4, 4], [3, 4, 6, 3]])
+@pytest.fixture(params=[[2, 2, 2, 2]])
 def layers(request):
     return request.param
 
@@ -88,7 +88,7 @@ def stride_type(request):
     return request.param
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[False])
 def zero_init_residual(request):
     return request.param
 
@@ -158,3 +158,16 @@ def test_resnet(
         nn = architecture(
             in_channels, layers, kernel_size, stride_type=stride_type
         )
+
+
+def test_resnet2d_zero_init_residual():
+    nn = ResNet2D(1, [2, 2, 2, 2], 2, 3, zero_init_residual=True)
+    # the flag should zero-initialize the last BN weight in each residual block
+    for m in nn.modules():
+        if isinstance(m, Bottleneck):
+            assert (m.bn3.weight == 0).all()
+        elif isinstance(m, BasicBlock):
+            assert (m.bn2.weight == 0).all()
+    x = torch.randn(4, 1, 10, 10)
+    y = nn(x)
+    assert y.shape == (4, 2)

--- a/tests/nn/test_norm.py
+++ b/tests/nn/test_norm.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from ml4gw.nn.norm import GroupNorm1D
+from ml4gw.nn.norm import GroupNorm1D, GroupNorm1DGetter, GroupNorm2DGetter
 
 
 @pytest.fixture(params=[1, 2, 3, 4])
@@ -73,3 +73,21 @@ def test_group_norm(num_groups, factor):
     close = torch.isclose(x, x_ref, rtol=1e-6)
     num_wrong = (~close).sum()
     assert (num_wrong / x.numel()) < 0.01
+
+
+def test_norm_getters():
+    getter = GroupNorm1DGetter(groups=2)
+    norm = getter(8)
+    assert isinstance(norm, GroupNorm1D)
+
+    getter_none = GroupNorm1DGetter()
+    norm_none = getter_none(4)
+    assert isinstance(norm_none, GroupNorm1D)
+
+    getter2d = GroupNorm2DGetter(groups=2)
+    norm2d = getter2d(8)
+    assert isinstance(norm2d, torch.nn.GroupNorm)
+
+    getter2d_none = GroupNorm2DGetter()
+    norm2d_none = getter2d_none(4)
+    assert isinstance(norm2d_none, torch.nn.GroupNorm)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -39,6 +39,7 @@ def test_log_normal(seed_everything):
     sampler = distributions.LogNormal(mu, sigma, low=0)
     samples = sampler.sample((10,))
     assert len(samples) == 10
+    assert sampler.support() is not None
     assert (samples > 0).all()
 
     # check that the mean is roughly correct

--- a/tests/test_gw.py
+++ b/tests/test_gw.py
@@ -1,5 +1,3 @@
-from itertools import combinations
-
 import bilby
 import lal
 import lalsimulation
@@ -22,7 +20,7 @@ def test_outer():
                 assert value == x[i, j] * y[i, k], (i, j, k)
 
 
-@pytest.fixture(params=[["H1"], ["H1", "L1"], ["H1", "L1", "V1", "K1"]])
+@pytest.fixture(params=[["H1"], ["H1", "L1", "V1", "K1"]])
 def ifos(request):
     return request.param
 
@@ -255,7 +253,7 @@ def test_compute_observed_strain(
     compare_against_numpy(result, expected)
 
 
-@pytest.fixture(params=combinations([25, 30, 35, 40], 2), scope="session")
+@pytest.fixture(params=[(25, 35), (30, 40)], scope="session")
 def _get_waveforms_from_lalsimulation(request):
     m1, m2 = request.param
     params = {

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -8,7 +8,7 @@ from scipy import signal
 from ml4gw.spectral import fast_spectral_density, spectral_density, whiten
 
 
-@pytest.fixture(params=[1, 4, 8])
+@pytest.fixture(params=[4, 8])
 def length(request):
     return request.param
 
@@ -18,14 +18,12 @@ def sample_rate(request):
     return request.param
 
 
-# The 1/9 tests odd `nperseg` for the sample
-# rates above
-@pytest.fixture(params=[1 / 9, 0.5, 2, 4])
+@pytest.fixture(params=[0.5, 2])
 def fftlength(request):
     return request.param
 
 
-@pytest.fixture(params=[None, 0.1, 0.5, 1])
+@pytest.fixture(params=[None, 0.5])
 def overlap(request):
     return request.param
 
@@ -333,7 +331,7 @@ def test_spectral_density(
         assert str(exc_info.value).startswith("Can't compute spectral")
 
 
-@pytest.fixture(params=[1, 2])
+@pytest.fixture(params=[2])
 def fduration(request):
     return request.param
 
@@ -348,13 +346,8 @@ def lowpass(request):
     return request.param
 
 
-@pytest.fixture(params=[64, 128])
+@pytest.fixture(params=[64])
 def whiten_length(request):
-    return request.param
-
-
-@pytest.fixture(params=[64, 128])
-def background_length(request):
     return request.param
 
 
@@ -444,3 +437,30 @@ def test_whiten(
     maxs = whitened.argmax(-1) / sample_rate + fduration / 2
     target = torch.ones_like(maxs) * whiten_length / 2
     torch.testing.assert_close(maxs, target, rtol=0, atol=0.01)
+
+
+def test_spectral_density_short_input():
+    nperseg = 512
+    window = torch.hann_window(nperseg)
+    with pytest.raises(ValueError, match="Number of samples"):
+        fast_spectral_density(
+            torch.randn(100),
+            nperseg=nperseg,
+            nstride=256,
+            window=window,
+            scale=1.0,
+        )
+
+
+def test_spectral_density_odd_nperseg():
+    nperseg = 511
+    x = torch.randn(nperseg * 4)
+    window = torch.hann_window(nperseg)
+    result = spectral_density(
+        x,
+        nperseg=nperseg,
+        nstride=256,
+        window=window,
+        scale=1.0 / (window**2).sum(),
+    )
+    assert result.shape[-1] == nperseg // 2 + 1

--- a/tests/transforms/test_iirfilter.py
+++ b/tests/transforms/test_iirfilter.py
@@ -26,22 +26,8 @@ def high_cutoff():
 
 @pytest.fixture(
     params=[
-        (
-            0.5,
-            None,
-            "cheby1",
-        ),
-        (None, 20, "cheby2"),
-        (
-            0.5,
-            20,
-            "ellip",
-        ),
-        (
-            None,
-            None,
-            "bessel",
-        ),
+        (0.5, None, "cheby1"),
+        (0.5, 20, "ellip"),
         (None, None, "butter"),
     ]
 )
@@ -49,12 +35,12 @@ def rp_rs_filter(request):
     return request.param
 
 
-@pytest.fixture(params=[256, 512, 1024, 2048])
+@pytest.fixture(params=[512, 2048])
 def sample_rate(request):
     return request.param
 
 
-@pytest.fixture(params=[2, 4, 6, 8])
+@pytest.fixture(params=[2, 8])
 def order(request):
     return request.param
 
@@ -161,7 +147,7 @@ def num_samples():
     return 1
 
 
-@pytest.fixture(params=[20, 40])
+@pytest.fixture(params=[20])
 def f_ref(request):
     return request.param
 

--- a/tests/transforms/test_pearson.py
+++ b/tests/transforms/test_pearson.py
@@ -4,78 +4,84 @@ import torch
 from ml4gw.transforms import ShiftedPearsonCorrelation
 
 
-class TestShiftedPearsonCorrelation:
-    @pytest.fixture
-    def max_shift(self):
-        return 5
+@pytest.fixture
+def max_shift():
+    return 5
 
-    @pytest.fixture
-    def transform(self, max_shift):
-        return ShiftedPearsonCorrelation(max_shift)
 
-    def check_in_range(self, corr):
-        in_range = (-1 <= corr) & (corr <= 1)
-        assert in_range.all().item()
+@pytest.fixture
+def transform(max_shift):
+    return ShiftedPearsonCorrelation(max_shift)
 
-    def test_x_ndim_3(self, transform, max_shift):
-        expected_shape = (2 * max_shift + 1, 4, 2)
 
-        x = torch.randn(2, 2048)
+def test_shifted_pearson_correlation(transform, max_shift):
+    expected_shape = (2 * max_shift + 1, 4, 2)
 
-        # set up a y which is just a shifted
-        # version of x at each batch index
-        y = torch.zeros((4, 2, 2048))
-        for i in range(4):
-            j = i - 2
-            if j < 0:
-                y[i, :, -j:] = x[:, :j]
-            elif j > 0:
-                y[i, :, :-j] = x[:, j:]
-            else:
-                y[i] = x
+    x = torch.randn(2, 2048)
 
-        # make all batch elements of x the same
-        x = x.view(1, 2, -1).repeat(4, 1, 1)
-        corr = transform(x, y)
+    # set up a y which is just a shifted version of x at each batch index
+    y = torch.zeros((4, 2, 2048))
+    for i in range(4):
+        j = i - 2
+        if j < 0:
+            y[i, :, -j:] = x[:, :j]
+        elif j > 0:
+            y[i, :, :-j] = x[:, j:]
+        else:
+            y[i] = x
 
-        # first check that we have the expected shape
-        assert corr.shape == expected_shape
+    # make all batch elements of x the same
+    x = x.view(1, 2, -1).repeat(4, 1, 1)
+    corr = transform(x, y)
 
-        # check that all our values are in the expected range
-        self.check_in_range(corr)
+    # first check that we have the expected shape
+    assert corr.shape == expected_shape
 
-        # check that we get our maximum matches
-        # at the expected indices
-        idx = corr[:, :, 0].argmax(dim=0)
-        expected_shifts = torch.arange(4) + max_shift - 2
-        assert torch.equal(idx, expected_shifts)
+    # check that all our values are in the expected range
+    assert ((-1 <= corr) & (corr <= 1)).all().item()
 
-        # and that those matches are nearly 1
-        maxs = corr[idx, torch.arange(4), 0]
-        expected_max = torch.ones(4)
-        assert torch.allclose(maxs, expected_max, rtol=0.01)
+    # check that we get our maximum matches at the expected indices
+    idx = corr[:, :, 0].argmax(dim=0)
+    expected_shifts = torch.arange(4) + max_shift - 2
+    assert torch.equal(idx, expected_shifts)
 
-        # do similar checks for 2dim y
-        corr = transform(x, y[0])
-        assert corr.shape == expected_shape
-        self.check_in_range(corr)
+    # and that those matches are nearly 1
+    maxs = corr[idx, torch.arange(4), 0]
+    assert torch.allclose(maxs, torch.ones(4), rtol=0.01)
 
-        idx = corr[:, :, 0].argmax(dim=0)
-        expected_shifts = torch.ones(4) * (max_shift - 2)
-        assert torch.equal(idx, expected_shifts)
+    # do similar checks for 2dim y
+    corr = transform(x, y[0])
+    assert corr.shape == expected_shape
+    assert ((-1 <= corr) & (corr <= 1)).all().item()
 
-        maxs = corr[max_shift - 2, :, 0]
-        assert torch.allclose(maxs, expected_max, rtol=0.01)
+    idx = corr[:, :, 0].argmax(dim=0)
+    expected_shifts = torch.ones(4) * (max_shift - 2)
+    assert torch.equal(idx, expected_shifts)
 
-        # and finally for 1dim y. We've only been checking
-        # against y's first channel, so this will just
-        # look exactly like the last one.
-        corr = transform(x, y[0, 0])
-        assert corr.shape == expected_shape
-        self.check_in_range(corr)
+    maxs = corr[max_shift - 2, :, 0]
+    assert torch.allclose(maxs, torch.ones(4), rtol=0.01)
 
-        idx = corr[:, :, 0].argmax(dim=0)
-        assert torch.equal(idx, expected_shifts)
+    # and finally for 1dim y; we've only been checking against y's first
+    # channel, so this will look exactly like the last case
+    corr = transform(x, y[0, 0])
+    assert corr.shape == expected_shape
+    assert ((-1 <= corr) & (corr <= 1)).all().item()
 
-        maxs = corr[max_shift - 2, :, 0]
-        assert torch.allclose(maxs, expected_max, rtol=0.01)
+    idx = corr[:, :, 0].argmax(dim=0)
+    assert torch.equal(idx, expected_shifts)
+
+    maxs = corr[max_shift - 2, :, 0]
+    assert torch.allclose(maxs, torch.ones(4), rtol=0.01)
+
+
+def test_shifted_pearson_shape_errors(transform):
+    x = torch.randn(2, 2, 2048)
+
+    with pytest.raises(ValueError, match="up to 3 dimensions"):
+        transform(x[None], x[None])
+
+    with pytest.raises(ValueError, match="more dimensions"):
+        transform(x[0], x)
+
+    with pytest.raises(ValueError, match="same size along last"):
+        transform(x, x[..., :-1])

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -8,12 +8,12 @@ from ml4gw.transforms import QScan, SingleQTransform
 from ml4gw.transforms.qtransform import QTile
 
 
-@pytest.fixture(params=[1, 2])
+@pytest.fixture(params=[1])
 def duration(request):
     return request.param
 
 
-@pytest.fixture(params=[1024, 2048])
+@pytest.fixture(params=[1024])
 def sample_rate(request):
     return request.param
 
@@ -23,7 +23,7 @@ def norm(request):
     return request.param
 
 
-@pytest.fixture(params=[[64, 64], [64, 128], [128, 128]])
+@pytest.fixture(params=[[64, 64], [64, 128]])
 def spectrogram_shape(request):
     return request.param
 
@@ -33,12 +33,12 @@ def q(request):
     return request.param
 
 
-@pytest.fixture(params=[0.2, 0.35])
+@pytest.fixture(params=[0.2])
 def mismatch(request):
     return request.param
 
 
-@pytest.fixture(params=[128, 256])
+@pytest.fixture(params=[128])
 def frequency(request):
     return request.param
 
@@ -79,6 +79,15 @@ def test_qtile(
     X = torch.randn(2, 2, 2, int(sample_rate * duration))
     with pytest.raises(ValueError):
         torch_qtile(X)
+
+
+def test_qtile_invalid_norm():
+    X = torch.randn(1024)
+    X = torch.fft.rfft(X, norm="forward")
+    X[..., 1:] *= 2
+    qtile = QTile(12, 128, 1, 1024, 0.2)
+    with pytest.raises(ValueError, match="Invalid normalisation"):
+        qtile(X, norm="bogus")
 
 
 def test_singleqtransform(
@@ -153,6 +162,16 @@ def test_singleqtransform(
     assert list(transformed.shape[-2:]) == spectrogram_shape
 
 
+def test_get_max_energy_invalid_dimension():
+    qtransform = SingleQTransform(
+        1, 1024, [64, 64], 12, frange=[0, torch.inf], mismatch=0.2
+    )
+    X = torch.randn(1024)
+    qtransform.compute_qtiles(X, norm="median")
+    with pytest.raises(ValueError, match="Dimension must be one of"):
+        qtransform.get_max_energy(dimension="invalid")
+
+
 def test_get_qs(
     duration,
     sample_rate,
@@ -179,3 +198,30 @@ def test_get_qs(
     # Just check that the QScan runs
     data = torch.randn(int(sample_rate * duration))
     _ = qscan(data)
+
+
+def test_get_max_energy_dimensions_and_fsearch():
+    qtransform = SingleQTransform(
+        1, 1024, [64, 64], 12, frange=[0, torch.inf], mismatch=0.2
+    )
+
+    # pure tone at 200 Hz concentrates energy in that frequency band
+    t = torch.arange(1024) / 1024.0
+    X = torch.sin(2 * torch.pi * 200.0 * t)
+    qtransform.compute_qtiles(X, norm=None)
+
+    result = qtransform.get_max_energy(dimension="neither")
+    assert result.ndim == 2
+
+    result = qtransform.get_max_energy(dimension="batch")
+    assert result.ndim == 1
+
+    # restricting to a band containing the tone should
+    # give higher max energy than a band well above it
+    result_with_signal = qtransform.get_max_energy(
+        dimension="both", fsearch_range=(150.0, 250.0)
+    )
+    result_without_signal = qtransform.get_max_energy(
+        dimension="both", fsearch_range=(300.0, 370.0)
+    )
+    assert result_with_signal > result_without_signal

--- a/tests/transforms/test_snr_rescaler.py
+++ b/tests/transforms/test_snr_rescaler.py
@@ -1,5 +1,7 @@
 import pytest
+import torch
 
+from ml4gw.gw import compute_network_snr
 from ml4gw.transforms import SnrRescaler
 
 
@@ -47,6 +49,16 @@ class TestSnrRescaler:
             num_channels, sample_rate, waveform_duration, highpass, lowpass
         )
 
+    @pytest.fixture
+    def background(self, num_channels, sample_rate):
+        size = int(8 * sample_rate)
+        return [torch.randn(size) for _ in range(num_channels)]
+
+    @pytest.fixture
+    def responses(self, num_channels, sample_rate, waveform_duration):
+        size = int(waveform_duration * sample_rate)
+        return torch.randn(4, num_channels, size)
+
     def test_init(
         self,
         transform,
@@ -84,3 +96,64 @@ class TestSnrRescaler:
             assert len(transform._buffers) == 1
             assert transform.highpass_mask is None
             assert transform.lowpass_mask is None
+
+    def test_fit(self, transform, background, num_channels):
+        # wrong number of channels raises an error before any state changes
+        with pytest.raises(ValueError, match="Expected to fit"):
+            transform.fit(*background[:-1], fftlength=1.0)
+        assert not transform.built
+
+        # fitting from time-domain background populates the buffer
+        transform.fit(*background, fftlength=1.0)
+        assert transform.built
+        assert (transform.background != 0).all()
+
+    def test_forward(self, transform, background, responses, sample_rate):
+        transform.fit(*background, fftlength=1.0)
+
+        batch_size = responses.shape[0]
+        target_snrs = torch.full((batch_size,), 10.0)
+
+        rescaled, returned_snrs = transform(responses, target_snrs)
+
+        assert rescaled.shape == responses.shape
+        torch.testing.assert_close(returned_snrs, target_snrs)
+
+        # rescaled responses should have SNRs matching the targets
+        actual_snrs = compute_network_snr(
+            rescaled,
+            transform.background,
+            sample_rate,
+            transform.highpass_mask,
+            transform.lowpass_mask,
+        )
+        torch.testing.assert_close(
+            actual_snrs.float(), target_snrs, rtol=1e-4, atol=0
+        )
+
+        # without explicit targets the returned SNRs are a permutation
+        # of the input SNRs
+        input_snrs = compute_network_snr(
+            responses,
+            transform.background,
+            sample_rate,
+            transform.highpass_mask,
+            transform.lowpass_mask,
+        )
+        rescaled_rand, returned_rand = transform(responses)
+        torch.testing.assert_close(
+            torch.sort(returned_rand)[0],
+            torch.sort(input_snrs)[0],
+            rtol=1e-5,
+            atol=0,
+        )
+        actual_rand_snrs = compute_network_snr(
+            rescaled_rand,
+            transform.background,
+            sample_rate,
+            transform.highpass_mask,
+            transform.lowpass_mask,
+        )
+        torch.testing.assert_close(
+            actual_rand_snrs.float(), returned_rand.float(), rtol=1e-4, atol=0
+        )

--- a/tests/transforms/test_spectral_density.py
+++ b/tests/transforms/test_spectral_density.py
@@ -10,12 +10,12 @@ from ml4gw.transforms.spectral import SpectralDensity
 TOL = 1e-7
 
 
-@pytest.fixture(params=[1, 4, 8])
+@pytest.fixture(params=[4, 8])
 def length(request):
     return request.param
 
 
-@pytest.fixture(params=[1024, 4096])
+@pytest.fixture(params=[1024])
 def sample_rate(request):
     return request.param
 
@@ -49,12 +49,12 @@ def test_init(overlap, fftlength, sample_rate):
     transform.load_state_dict(torch.load(weights_io))
 
 
-@pytest.fixture(params=[0.5, 2, 4])
+@pytest.fixture(params=[0.5, 2])
 def fftlength(request):
     return request.param
 
 
-@pytest.fixture(params=[None, 0.1, 0.5, 1])
+@pytest.fixture(params=[None, 0.5])
 def overlap(request):
     return request.param
 

--- a/tests/transforms/test_spline_interpolation.py
+++ b/tests/transforms/test_spline_interpolation.py
@@ -7,155 +7,129 @@ from torch import Tensor
 from ml4gw.transforms import SplineInterpolate1D, SplineInterpolate2D
 
 
-class TestSplineInterpolate1D:
-    @pytest.fixture(params=[50, 100, 200])
-    def x_out_len(self, request):
-        return request.param
+@pytest.mark.parametrize("x_out_len", [50, 100, 200])
+def test_spline_1d_interpolation(x_out_len):
+    x_min, x_max = 0, 10
+    x_in = np.linspace(x_min, x_max, 100)
+    data = np.sin(x_in)
+    x_out = np.linspace(x_min, x_max, x_out_len)
 
-    def test_interpolation(self, x_out_len):
-        x_min = 0
-        x_max = 10
+    scipy_spline = UnivariateSpline(x_in, data, k=3, s=0)
+    expected = scipy_spline(x_out)
 
-        x_in = np.linspace(x_min, x_max, 100)
-        data = np.sin(x_in)
-        x_out = np.linspace(x_min, x_max, x_out_len)
+    data_t = Tensor(data)
+    x_in_t = Tensor(x_in)
+    x_out_t = Tensor(x_out)
 
-        scipy_spline = UnivariateSpline(x_in, data, k=3, s=0)
-        expected = scipy_spline(x_out)
+    torch_spline = SplineInterpolate1D(x_in=x_in_t, x_out=x_out_t, kx=3)
+    actual = torch_spline(data_t).squeeze().numpy()
+    assert np.allclose(actual, expected, rtol=1e-4)
 
-        data = Tensor(data)
-        x_in = Tensor(x_in)
-        x_out = Tensor(x_out)
+    # Check that passing output grid behaves as expected
+    actual = torch_spline(data_t, x_out_t).squeeze().numpy()
+    assert np.allclose(actual, expected, rtol=1e-4)
 
-        torch_spline = SplineInterpolate1D(
-            x_in=x_in,
-            x_out=x_out,
-            kx=3,
-        )
-        actual = torch_spline(data).squeeze().numpy()
-
-        assert np.allclose(actual, expected, rtol=1e-4)
-
-        # Check that passing output grid behaves as expected
-        actual = torch_spline(data, x_out).squeeze().numpy()
-        assert np.allclose(actual, expected, rtol=1e-4)
-
-        # Test data with height dimension
-        height = 5
-        data = Tensor(data).repeat(5, 1)
-        actual = torch_spline(data).squeeze().numpy()
-        for i in range(height):
-            assert np.allclose(actual[i], expected, rtol=1e-4)
-
-    def test_errors(self):
-        x_in = torch.arange(2)
-        with pytest.raises(ValueError) as exc:
-            SplineInterpolate1D(x_in=x_in)
-        assert str(exc.value).startswith("Input x-coordinates must have")
-
-        x_in = torch.arange(10)
-        x_out = x_in
-        torch_spline = SplineInterpolate1D(x_in)
-        data = torch.randn(len(x_in))
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data)
-        assert str(exc.value).startswith("Output x-coordinates were not")
-
-        data = torch.randn((1, 2, 3, 4, 5))
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data, x_out=x_out)
-        assert str(exc.value).startswith("Input data has more than 4")
-
-        data = torch.randn(len(x_in) - 1)
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data, x_out=x_out)
-        assert str(exc.value).startswith("The spatial dimensions of the data")
+    # Test data with height dimension
+    height = 5
+    data_batch = Tensor(data).repeat(5, 1)
+    actual = torch_spline(data_batch).squeeze().numpy()
+    for i in range(height):
+        assert np.allclose(actual[i], expected, rtol=1e-4)
 
 
-class TestSplineInterpolate2D:
-    @pytest.fixture(params=[50, 100, 200])
-    def x_out_len(self, request):
-        return request.param
+def test_spline_1d_errors():
+    x_in = torch.arange(2)
+    with pytest.raises(ValueError) as exc:
+        SplineInterpolate1D(x_in=x_in)
+    assert str(exc.value).startswith("Input x-coordinates must have")
 
-    @pytest.fixture(params=[25, 200, 1000])
-    def y_out_len(self, request):
-        return request.param
+    x_in = torch.arange(10)
+    x_out = x_in
+    torch_spline = SplineInterpolate1D(x_in)
+    data = torch.randn(len(x_in))
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data)
+    assert str(exc.value).startswith("Output x-coordinates were not")
 
-    def test_interpolation(self, x_out_len, y_out_len):
-        x_min = 0
-        x_max = 10
-        y_min = 0
-        y_max = 5
+    data = torch.randn((1, 2, 3, 4, 5))
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data, x_out=x_out)
+    assert str(exc.value).startswith("Input data has more than 4")
 
-        x_in = np.linspace(x_min, x_max, 100)
-        y_in = np.linspace(y_min, y_max, 200)
-        x_grid, y_grid = np.meshgrid(x_in, y_in)
-        data = np.sin(x_grid) * np.cos(y_grid)
+    data = torch.randn(len(x_in) - 1)
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data, x_out=x_out)
+    assert str(exc.value).startswith("The spatial dimensions of the data")
 
-        x_out = np.linspace(x_min, x_max, x_out_len)
-        y_out = np.linspace(y_min, y_max, y_out_len)
 
-        scipy_spline = RectBivariateSpline(x_in, y_in, data.T, kx=3, ky=3, s=0)
-        expected = scipy_spline(x_out, y_out).T
+@pytest.mark.parametrize("x_out_len", [50, 100, 200])
+@pytest.mark.parametrize("y_out_len", [25, 200, 1000])
+def test_spline_2d_interpolation(x_out_len, y_out_len):
+    x_min, x_max = 0, 10
+    y_min, y_max = 0, 5
 
-        data = Tensor(data)
-        x_in = Tensor(x_in)
-        x_out = Tensor(x_out)
-        y_in = Tensor(y_in)
-        y_out = Tensor(y_out)
+    x_in = np.linspace(x_min, x_max, 100)
+    y_in = np.linspace(y_min, y_max, 200)
+    x_grid, y_grid = np.meshgrid(x_in, y_in)
+    data = np.sin(x_grid) * np.cos(y_grid)
 
-        torch_spline = SplineInterpolate2D(
-            x_in=x_in,
-            x_out=x_out,
-            y_in=y_in,
-            y_out=y_out,
-            kx=3,
-            ky=3,
-        )
-        actual = torch_spline(data).squeeze().numpy()
+    x_out = np.linspace(x_min, x_max, x_out_len)
+    y_out = np.linspace(y_min, y_max, y_out_len)
 
-        assert np.allclose(actual, expected, rtol=1e-4)
+    scipy_spline = RectBivariateSpline(x_in, y_in, data.T, kx=3, ky=3, s=0)
+    expected = scipy_spline(x_out, y_out).T
 
-        # Check that passing output grid behaves as expected
-        actual = torch_spline(data, x_out, y_out).squeeze().numpy()
-        assert np.allclose(actual, expected, rtol=1e-4)
+    data_t = Tensor(data)
+    x_in_t, x_out_t = Tensor(x_in), Tensor(x_out)
+    y_in_t, y_out_t = Tensor(y_in), Tensor(y_out)
 
-    def test_errors(self):
-        x_in = torch.arange(2)
-        y_in = torch.arange(2)
-        with pytest.raises(ValueError) as exc:
-            SplineInterpolate2D(x_in=x_in, y_in=y_in)
-        assert str(exc.value).startswith("Input x-coordinates must have")
+    torch_spline = SplineInterpolate2D(
+        x_in=x_in_t, x_out=x_out_t, y_in=y_in_t, y_out=y_out_t, kx=3, ky=3
+    )
+    actual = torch_spline(data_t).squeeze().numpy()
+    assert np.allclose(actual, expected, rtol=1e-4)
 
-        with pytest.raises(ValueError) as exc:
-            SplineInterpolate2D(x_in=torch.arange(10), y_in=y_in)
-        assert str(exc.value).startswith("Input y-coordinates must have")
+    # Check that passing output grid behaves as expected
+    actual = torch_spline(data_t, x_out_t, y_out_t).squeeze().numpy()
+    assert np.allclose(actual, expected, rtol=1e-4)
 
-        x_in = torch.arange(10)
-        x_out = x_in
-        y_in = torch.arange(10)
-        y_out = y_in
-        torch_spline = SplineInterpolate2D(x_in=x_in, y_in=y_in)
-        data = torch.randn(len(x_in))
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data)
-        assert str(exc.value).startswith("Output x-coordinates were not")
 
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data, x_out=x_out)
-        assert str(exc.value).startswith("Output y-coordinates were not")
+def test_spline_2d_errors():
+    x_in = torch.arange(2)
+    y_in = torch.arange(2)
+    with pytest.raises(ValueError) as exc:
+        SplineInterpolate2D(x_in=x_in, y_in=y_in)
+    assert str(exc.value).startswith("Input x-coordinates must have")
 
-        data = torch.randn((1, 2, 3, 4, 5))
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data, x_out=x_out, y_out=y_out)
-        assert str(exc.value).startswith("Input data has more than 4")
+    with pytest.raises(ValueError) as exc:
+        SplineInterpolate2D(x_in=torch.arange(10), y_in=y_in)
+    assert str(exc.value).startswith("Input y-coordinates must have")
 
-        data = torch.randn(10)
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data, x_out=x_out, y_out=y_out)
-        assert str(exc.value).startswith("Input data has fewer than 2")
+    x_in = torch.arange(10)
+    x_out = x_in
+    y_in = torch.arange(10)
+    y_out = y_in
+    torch_spline = SplineInterpolate2D(x_in=x_in, y_in=y_in)
+    data = torch.randn(len(x_in))
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data)
+    assert str(exc.value).startswith("Output x-coordinates were not")
 
-        data = torch.randn((len(y_in) - 1, len(x_in) - 1))
-        with pytest.raises(ValueError) as exc:
-            torch_spline(data, x_out=x_out, y_out=y_out)
-        assert str(exc.value).startswith("The spatial dimensions of the data")
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data, x_out=x_out)
+    assert str(exc.value).startswith("Output y-coordinates were not")
+
+    data = torch.randn((1, 2, 3, 4, 5))
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data, x_out=x_out, y_out=y_out)
+    assert str(exc.value).startswith("Input data has more than 4")
+
+    data = torch.randn(10)
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data, x_out=x_out, y_out=y_out)
+    assert str(exc.value).startswith("Input data has fewer than 2")
+
+    data = torch.randn((len(y_in) - 1, len(x_in) - 1))
+    with pytest.raises(ValueError) as exc:
+        torch_spline(data, x_out=x_out, y_out=y_out)
+    assert str(exc.value).startswith("The spatial dimensions of the data")

--- a/tests/utils/test_interferometer.py
+++ b/tests/utils/test_interferometer.py
@@ -1,0 +1,37 @@
+import pytest
+import torch
+
+from ml4gw.utils.interferometer import InterferometerGeometry
+
+
+@pytest.mark.parametrize("name", ["H1", "L1", "V1", "K1"])
+def test_geometry_attributes_exist(name):
+    geo = InterferometerGeometry(name)
+    for attr in ("x_arm", "y_arm", "vertex"):
+        assert isinstance(getattr(geo, attr), torch.Tensor)
+        assert getattr(geo, attr).shape == (3,)
+
+
+@pytest.mark.parametrize("name", ["H1", "L1", "V1", "K1"])
+def test_arms_are_unit_vectors(name):
+    geo = InterferometerGeometry(name)
+    torch.testing.assert_close(
+        torch.linalg.norm(geo.x_arm), torch.tensor(1.0), atol=1e-5, rtol=0
+    )
+    torch.testing.assert_close(
+        torch.linalg.norm(geo.y_arm), torch.tensor(1.0), atol=1e-5, rtol=0
+    )
+
+
+@pytest.mark.parametrize("name", ["E1", "GEO600", "h1", ""])
+def test_invalid_name_raises(name):
+    with pytest.raises(
+        ValueError, match="is not recognized as an interferometer"
+    ):
+        InterferometerGeometry(name)
+
+
+def test_h1_known_values():
+    geo = InterferometerGeometry("H1")
+    expected = torch.tensor([-0.22389266154, 0.79983062746, 0.55690487831])
+    torch.testing.assert_close(geo.x_arm, expected, atol=1e-5, rtol=0)

--- a/tests/utils/test_slicing.py
+++ b/tests/utils/test_slicing.py
@@ -358,3 +358,19 @@ def test_sample_kernels_3D(kernel_size, num_channels, max_center_offset, N):
                 stop = start + kernel_size
 
             assert (channel == np.arange(start, stop)).all()
+
+
+def test_sample_kernels_1d_return_idx():
+    x = torch.arange(100, dtype=torch.float)
+    kernel_size = 10
+    result, idx = slicing.sample_kernels(x, kernel_size, N=5, return_idx=True)
+    assert result.shape == (5, kernel_size)
+    assert idx.shape == (5,)
+
+
+def test_sample_kernels_2d_return_idx():
+    X = torch.randn(3, 100)
+    kernel_size = 10
+    result, idx = slicing.sample_kernels(X, kernel_size, N=5, return_idx=True)
+    assert result.shape == (5, 3, kernel_size)
+    assert idx.shape == (5,)

--- a/tests/waveforms/adhoc/test_sine_gaussian.py
+++ b/tests/waveforms/adhoc/test_sine_gaussian.py
@@ -6,22 +6,22 @@ from lalinference import BurstSineGaussian
 from ml4gw.waveforms import SineGaussian
 
 
-@pytest.fixture(params=[2048, 4096])
+@pytest.fixture(params=[2048])
 def sample_rate(request):
     return request.param
 
 
-@pytest.fixture(params=[2.0, 4.0, 8.0])
+@pytest.fixture(params=[4.0])
 def duration(request):
     return request.param
 
 
-@pytest.fixture(params=[3.0, 10.0, 100.0, 55.0])
+@pytest.fixture(params=[10.0, 55.0])
 def quality(request):
     return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[100.0, 500.0, 800.0, 961.0])
+@pytest.fixture(params=[100.0, 800.0])
 def frequency(request):
     return torch.tensor(request.param, dtype=torch.float64)
 
@@ -29,24 +29,17 @@ def frequency(request):
 # for amplitudes above ~7e-20, the difference between torch imp
 # and lalsim is > ~1e-24. Our implementations are 1 to 1, so
 # discrep must be from numerical issues?
-@pytest.fixture(params=[1e-23, 1e-22, 1e-21, 1e-20, 7e-20])
+@pytest.fixture(params=[1e-22, 7e-20])
 def hrss(request):
     return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(params=[0.0, np.pi / 2.0, np.pi, 2 * np.pi])
+@pytest.fixture(params=[0.0, np.pi / 2.0])
 def phase(request):
     return torch.tensor(request.param, dtype=torch.float64)
 
 
-@pytest.fixture(
-    params=[
-        0.0,
-        0.5,
-        1.0,
-        0.1,
-    ]
-)
+@pytest.fixture(params=[0.0, 0.5, 1.0])
 def eccentricity(request):
     return torch.tensor(request.param, dtype=torch.float64)
 


### PR DESCRIPTION
Adds testing in areas missing coverage and cuts down on unnecessary permutations of pytest fixtures. The goal is to test meaningfully different configurations, rather than just probing a range of values. The waveform tests are still slow, and I'll address those in a separate PR.