### PR TITLE
Differentiability

### DIFF
--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -452,8 +452,8 @@ def normalize_by_psd(
     # corresponding bin to 0
     X = X - X.mean(-1, keepdims=True)
     X_tilde = torch.fft.rfft(X.double(), norm="forward", dim=-1)
-    X_tilde = X_tilde / psd**0.5
-    X_tilde[torch.isnan(X_tilde)] = 0
+    inv_asd = torch.nan_to_num(psd**-0.5)
+    X_tilde = X_tilde * inv_asd
 
     # convert back to the time domain and normalize
     # TODO: what's this normalization factor?

--- a/ml4gw/waveforms/cbc/phenom_d.py
+++ b/ml4gw/waveforms/cbc/phenom_d.py
@@ -93,7 +93,7 @@ class IMRPhenomD(TaylorF2):
         mass_2 = mass_1 * mass_ratio
         eta = (chirp_mass / total_mass) ** (5 / 3)
         eta2 = eta * eta
-        Seta = torch.sqrt(1.0 - 4.0 * eta)
+        Seta = torch.sqrt(torch.clamp(1.0 - 4.0 * eta, min=0.0))
         chi = self.chiPN(Seta, eta, chi1, chi2)
         chi22 = chi2 * chi2
         chi12 = chi1 * chi1
@@ -256,8 +256,8 @@ class IMRPhenomD(TaylorF2):
         fDMgamma3 = fDM * gamma3
         pow2_fDMgamma3 = (torch.ones_like(Mf).mT * fDMgamma3 * fDMgamma3).mT
         fminfRD = Mf - (torch.ones_like(Mf).mT * fRD).mT
-        exp_times_lorentzian = torch.exp(fminfRD.mT * gamma2 / fDMgamma3).mT
-        exp_times_lorentzian *= fminfRD**2 + pow2_fDMgamma3
+        exp_part = torch.exp(fminfRD.mT * gamma2 / fDMgamma3).mT
+        exp_times_lorentzian = exp_part * (fminfRD**2 + pow2_fDMgamma3)
 
         amp = (1 / exp_times_lorentzian.mT * gamma1 * gamma3 * fDM).mT
         Damp = (fminfRD.mT * -2 * fDM * gamma1 * gamma3) / (
@@ -586,16 +586,8 @@ class IMRPhenomD(TaylorF2):
         return fRD, fDM
 
     def fmaxCalc(self, fRD, fDM, gamma2, gamma3):
-        mask = gamma2 <= 1
-        radicand = torch.where(
-            mask, 1 - gamma2.pow(2), torch.zeros_like(gamma2)
-        )
-        sqrt_term = torch.sqrt(radicand)
-        result = torch.where(
-            mask,
-            fRD + (fDM * (-1 + sqrt_term) * gamma3) / gamma2,
-            fRD + (-fDM * gamma3) / gamma2,
-        )
+        sqrt_term = torch.sqrt(torch.clamp(1 - gamma2**2, min=0.0))
+        result = fRD + (fDM * (-1 + sqrt_term) * gamma3) / gamma2
         return torch.abs(result)
 
     def _linear_interp_finspin(self, finspin):
@@ -1085,8 +1077,7 @@ class IMRPhenomD(TaylorF2):
         )
 
     def FinalSpin0815(self, eta, eta2, chi1, chi2):
-        Seta = torch.sqrt(1.0 - 4.0 * eta)
-        Seta = torch.nan_to_num(Seta)  # avoid nan around eta = 0.25
+        Seta = torch.sqrt(torch.clamp(1.0 - 4.0 * eta, min=0.0))
         m1 = 0.5 * (1.0 + Seta)
         m2 = 0.5 * (1.0 - Seta)
         m1s = m1 * m1
@@ -1110,7 +1101,7 @@ class IMRPhenomD(TaylorF2):
         )
 
     def PhenomInternal_EradRational0815(self, eta, eta2, chi1, chi2):
-        Seta = torch.sqrt(1.0 - 4.0 * eta)
+        Seta = torch.sqrt(torch.clamp(1.0 - 4.0 * eta, min=0.0))
         m1 = 0.5 * (1.0 + Seta)
         m2 = 0.5 * (1.0 - Seta)
         m1s = m1 * m1

--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 from astropy import units as u
+from torch.autograd import gradcheck
 
 import ml4gw.waveforms as waveforms
 from ml4gw.waveforms.conversion import (
@@ -477,91 +478,121 @@ def test_phenom_d_finspin_out_of_bounds(finspin):
 
 
 def test_taylorf2_differentiability():
-    torch_freqs = torch.arange(20, 100, dtype=FLOAT64)
     f_ref = 20.0
+    model = waveforms.TaylorF2()
 
-    params = {
-        "chirp_mass": torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
-        "mass_ratio": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "chi1": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "chi2": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "distance": torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
-        "phic": torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
-        "inclination": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-    }
-
-    hc_ml4gw, hp_ml4gw = waveforms.TaylorF2()(
-        torch_freqs,
-        f_ref=f_ref,
-        **params,
+    inputs = (
+        torch.arange(20, 50, dtype=FLOAT64, requires_grad=True),
+        torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
     )
 
-    loss = hc_ml4gw.abs().sum() + hp_ml4gw.abs().sum()
-    loss.backward()
+    def h(
+        freqs, chirp_mass, mass_ratio, chi1, chi2, distance, phic, inclination
+    ):
+        hc, hp = model(
+            freqs,
+            f_ref=f_ref,
+            chirp_mass=chirp_mass,
+            mass_ratio=mass_ratio,
+            chi1=chi1,
+            chi2=chi2,
+            distance=distance,
+            phic=phic,
+            inclination=inclination,
+        )
+        return torch.cat([hc.real, hc.imag, hp.real, hp.imag])
 
-    for param_name in params:
-        param = params[param_name]
-        assert param.grad is not None
-        assert not torch.isnan(param.grad).any()
+    assert gradcheck(h, inputs)
 
 
 def test_phenom_d_differentiability():
-    torch_freqs = torch.arange(20, 100, dtype=FLOAT64)
     f_ref = 20.0
+    model = waveforms.IMRPhenomD()
 
-    params = {
-        "chirp_mass": torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
-        "mass_ratio": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "chi1": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "chi2": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "distance": torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
-        "phic": torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
-        "inclination": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-    }
-
-    hc_ml4gw, hp_ml4gw = waveforms.IMRPhenomD()(
-        torch_freqs,
-        f_ref=f_ref,
-        **params,
+    inputs = (
+        torch.arange(20, 50, dtype=FLOAT64, requires_grad=True),
+        torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
     )
 
-    loss = hc_ml4gw.abs().sum() + hp_ml4gw.abs().sum()
-    loss.backward()
+    def h(
+        freqs, chirp_mass, mass_ratio, chi1, chi2, distance, phic, inclination
+    ):
+        hc, hp = model(
+            freqs,
+            f_ref=f_ref,
+            chirp_mass=chirp_mass,
+            mass_ratio=mass_ratio,
+            chi1=chi1,
+            chi2=chi2,
+            distance=distance,
+            phic=phic,
+            inclination=inclination,
+        )
+        return torch.cat([hc.real, hc.imag, hp.real, hp.imag])
 
-    for param_name in params:
-        param = params[param_name]
-        assert param.grad is not None
-        assert not torch.isnan(param.grad).any()
+    assert gradcheck(h, inputs)
 
 
 def test_phenom_p_differentiability():
-    torch_freqs = torch.arange(20, 100, dtype=FLOAT64)
     f_ref = 20.0
+    model = waveforms.IMRPhenomPv2()
 
-    params = {
-        "chirp_mass": torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
-        "mass_ratio": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "s1x": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "s1y": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "s1z": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "s2x": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "s2y": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "s2z": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-        "distance": torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
-        "phic": torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
-        "inclination": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
-    }
-
-    hc_ml4gw, hp_ml4gw = waveforms.IMRPhenomPv2()(
-        torch_freqs,
-        f_ref=f_ref,
-        **params,
+    inputs = (
+        torch.arange(20, 50, dtype=FLOAT64, requires_grad=True),
+        torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
     )
 
-    loss = hc_ml4gw.abs().sum() + hp_ml4gw.abs().sum()
-    loss.backward()
+    def h(
+        freqs,
+        chirp_mass,
+        mass_ratio,
+        s1x,
+        s1y,
+        s1z,
+        s2x,
+        s2y,
+        s2z,
+        distance,
+        phic,
+        inclination,
+    ):
+        hc, hp = model(
+            freqs,
+            f_ref=f_ref,
+            chirp_mass=chirp_mass,
+            mass_ratio=mass_ratio,
+            s1x=s1x,
+            s1y=s1y,
+            s1z=s1z,
+            s2x=s2x,
+            s2y=s2y,
+            s2z=s2z,
+            distance=distance,
+            phic=phic,
+            inclination=inclination,
+        )
+        return torch.cat([hc.real, hc.imag, hp.real, hp.imag])
 
-    for param_name in params:
-        param = params[param_name]
-        assert param.grad is not None
-        assert not torch.isnan(param.grad).any()
+    assert gradcheck(h, inputs)

--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -506,7 +506,8 @@ def test_taylorf2_differentiability():
             phic=phic,
             inclination=inclination,
         )
-        return torch.cat([hc.real, hc.imag, hp.real, hp.imag])
+        out = torch.cat([hc.real, hc.imag, hp.real, hp.imag])
+        return out / out.abs().max()
 
     assert gradcheck(h, inputs)
 
@@ -540,7 +541,8 @@ def test_phenom_d_differentiability():
             phic=phic,
             inclination=inclination,
         )
-        return torch.cat([hc.real, hc.imag, hp.real, hp.imag])
+        out = torch.cat([hc.real, hc.imag, hp.real, hp.imag])
+        return out / out.abs().max()
 
     assert gradcheck(h, inputs)
 
@@ -593,6 +595,7 @@ def test_phenom_p_differentiability():
             phic=phic,
             inclination=inclination,
         )
-        return torch.cat([hc.real, hc.imag, hp.real, hp.imag])
+        out = torch.cat([hc.real, hc.imag, hp.real, hp.imag])
+        return out / out.abs().max()
 
     assert gradcheck(h, inputs)

--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -11,6 +11,7 @@ from ml4gw.waveforms.conversion import (
 )
 
 TARGET_OVERLAP = 1 - 1e-7
+FLOAT64 = torch.float64
 
 
 @pytest.fixture(params=[20])
@@ -102,13 +103,13 @@ def test_taylor_f2(
     f_ref,
     sample_rate,
 ):
-    chirp_mass = torch.tensor([chirp_mass], dtype=torch.float64)
-    mass_ratio = torch.tensor([mass_ratio], dtype=torch.float64)
-    chi1 = torch.tensor([chi1], dtype=torch.float64)
-    chi2 = torch.tensor([chi2], dtype=torch.float64)
-    distance = torch.tensor([distance], dtype=torch.float64)
-    phase = torch.tensor([phase], dtype=torch.float64)
-    theta_jn = torch.tensor([theta_jn], dtype=torch.float64)
+    chirp_mass = torch.tensor([chirp_mass], dtype=FLOAT64)
+    mass_ratio = torch.tensor([mass_ratio], dtype=FLOAT64)
+    chi1 = torch.tensor([chi1], dtype=FLOAT64)
+    chi2 = torch.tensor([chi2], dtype=FLOAT64)
+    distance = torch.tensor([distance], dtype=FLOAT64)
+    phase = torch.tensor([phase], dtype=FLOAT64)
+    theta_jn = torch.tensor([theta_jn], dtype=FLOAT64)
 
     # Test that a difference in the length of a
     # parameter tensor raises an error
@@ -164,7 +165,7 @@ def test_taylor_f2(
     lal_mask = (lal_freqs > params["f_min"]) & (lal_freqs < params["f_max"])
 
     lal_freqs = lal_freqs[lal_mask]
-    torch_freqs = torch.tensor(lal_freqs, dtype=torch.float64)
+    torch_freqs = torch.tensor(lal_freqs, dtype=FLOAT64)
 
     # generate waveforms using ml4gw
     hc_ml4gw, hp_ml4gw = waveforms.TaylorF2()(
@@ -231,13 +232,13 @@ def test_phenom_d(
     sample_rate,
     f_ref,
 ):
-    chirp_mass = torch.tensor([chirp_mass], dtype=torch.float64)
-    mass_ratio = torch.tensor([mass_ratio], dtype=torch.float64)
-    chi1 = torch.tensor([chi1], dtype=torch.float64)
-    chi2 = torch.tensor([chi2], dtype=torch.float64)
-    distance = torch.tensor([distance], dtype=torch.float64)
-    theta_jn = torch.tensor([theta_jn], dtype=torch.float64)
-    phase = torch.tensor([phase], dtype=torch.float64)
+    chirp_mass = torch.tensor([chirp_mass], dtype=FLOAT64)
+    mass_ratio = torch.tensor([mass_ratio], dtype=FLOAT64)
+    chi1 = torch.tensor([chi1], dtype=FLOAT64)
+    chi2 = torch.tensor([chi2], dtype=FLOAT64)
+    distance = torch.tensor([distance], dtype=FLOAT64)
+    theta_jn = torch.tensor([theta_jn], dtype=FLOAT64)
+    phase = torch.tensor([phase], dtype=FLOAT64)
 
     # Test that a difference in the length of a
     # parameter tensor raises an error
@@ -292,7 +293,7 @@ def test_phenom_d(
     lal_mask = (lal_freqs > params["f_min"]) & (lal_freqs < params["f_max"])
 
     lal_freqs = lal_freqs[lal_mask]
-    torch_freqs = torch.tensor(lal_freqs, dtype=torch.float64)
+    torch_freqs = torch.tensor(lal_freqs, dtype=FLOAT64)
 
     # generate waveforms using ml4gw
     hc_ml4gw, hp_ml4gw = waveforms.IMRPhenomD()(
@@ -336,13 +337,13 @@ def test_phenom_p(
     sample_rate,
     f_ref,
 ):
-    chirp_mass = torch.tensor([chirp_mass], dtype=torch.float64)
-    mass_ratio = torch.tensor([mass_ratio], dtype=torch.float64)
-    chi1x, chi1y, chi1z = [torch.tensor(c, dtype=torch.float64) for c in chi1]
-    chi2x, chi2y, chi2z = [torch.tensor(c, dtype=torch.float64) for c in chi2]
-    distance = torch.tensor([distance], dtype=torch.float64)
-    theta_jn = torch.tensor([theta_jn], dtype=torch.float64)
-    phase = torch.tensor([phase], dtype=torch.float64)
+    chirp_mass = torch.tensor([chirp_mass], dtype=FLOAT64)
+    mass_ratio = torch.tensor([mass_ratio], dtype=FLOAT64)
+    chi1x, chi1y, chi1z = [torch.tensor(c, dtype=FLOAT64) for c in chi1]
+    chi2x, chi2y, chi2z = [torch.tensor(c, dtype=FLOAT64) for c in chi2]
+    distance = torch.tensor([distance], dtype=FLOAT64)
+    theta_jn = torch.tensor([theta_jn], dtype=FLOAT64)
+    phase = torch.tensor([phase], dtype=FLOAT64)
 
     mass_1, mass_2 = chirp_mass_and_mass_ratio_to_components(
         chirp_mass, mass_ratio
@@ -403,7 +404,7 @@ def test_phenom_p(
     lal_mask = (lal_freqs > params["f_min"]) & (lal_freqs < params["f_max"])
 
     lal_freqs = lal_freqs[lal_mask]
-    torch_freqs = torch.tensor(lal_freqs, dtype=torch.float64)
+    torch_freqs = torch.tensor(lal_freqs, dtype=FLOAT64)
 
     hc_ml4gw, hp_ml4gw = waveforms.IMRPhenomPv2()(
         torch_freqs,
@@ -468,8 +469,99 @@ def test_phenom_p(
 
 @pytest.mark.parametrize("finspin", [-1.1, 1.1])
 def test_phenom_d_finspin_out_of_bounds(finspin):
-    finspin_tensor = torch.tensor([finspin], dtype=torch.float64)
+    finspin_tensor = torch.tensor([finspin], dtype=FLOAT64)
     with pytest.raises(
         RuntimeError, match="Final spin is outside the QNM data grid"
     ):
         waveforms.IMRPhenomD()._linear_interp_finspin(finspin_tensor)
+
+
+def test_taylorf2_differentiability():
+    torch_freqs = torch.arange(20, 100, dtype=FLOAT64)
+    f_ref = 20.0
+
+    params = {
+        "chirp_mass": torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
+        "mass_ratio": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "chi1": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "chi2": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "distance": torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
+        "phic": torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
+        "inclination": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+    }
+
+    hc_ml4gw, hp_ml4gw = waveforms.TaylorF2()(
+        torch_freqs,
+        f_ref=f_ref,
+        **params,
+    )
+
+    loss = hc_ml4gw.abs().sum() + hp_ml4gw.abs().sum()
+    loss.backward()
+
+    for param_name in params:
+        param = params[param_name]
+        assert param.grad is not None
+        assert not torch.isnan(param.grad).any()
+
+
+def test_phenom_d_differentiability():
+    torch_freqs = torch.arange(20, 100, dtype=FLOAT64)
+    f_ref = 20.0
+
+    params = {
+        "chirp_mass": torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
+        "mass_ratio": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "chi1": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "chi2": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "distance": torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
+        "phic": torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
+        "inclination": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+    }
+
+    hc_ml4gw, hp_ml4gw = waveforms.IMRPhenomD()(
+        torch_freqs,
+        f_ref=f_ref,
+        **params,
+    )
+
+    loss = hc_ml4gw.abs().sum() + hp_ml4gw.abs().sum()
+    loss.backward()
+
+    for param_name in params:
+        param = params[param_name]
+        assert param.grad is not None
+        assert not torch.isnan(param.grad).any()
+
+
+def test_phenom_p_differentiability():
+    torch_freqs = torch.arange(20, 100, dtype=FLOAT64)
+    f_ref = 20.0
+
+    params = {
+        "chirp_mass": torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
+        "mass_ratio": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "s1x": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "s1y": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "s1z": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "s2x": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "s2y": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "s2z": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        "distance": torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
+        "phic": torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
+        "inclination": torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+    }
+
+    hc_ml4gw, hp_ml4gw = waveforms.IMRPhenomPv2()(
+        torch_freqs,
+        f_ref=f_ref,
+        **params,
+    )
+
+    loss = hc_ml4gw.abs().sum() + hp_ml4gw.abs().sum()
+    loss.backward()
+
+    for param_name in params:
+        param = params[param_name]
+        assert param.grad is not None
+        assert not torch.isnan(param.grad).any()

--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -507,7 +507,7 @@ def test_taylorf2_differentiability():
             inclination=inclination,
         )
         out = torch.cat([hc.real, hc.imag, hp.real, hp.imag])
-        return out / out.abs().max()
+        return out * 1e21
 
     assert gradcheck(h, inputs)
 
@@ -542,7 +542,7 @@ def test_phenom_d_differentiability():
             inclination=inclination,
         )
         out = torch.cat([hc.real, hc.imag, hp.real, hp.imag])
-        return out / out.abs().max()
+        return out * 1e21
 
     assert gradcheck(h, inputs)
 
@@ -596,6 +596,6 @@ def test_phenom_p_differentiability():
             inclination=inclination,
         )
         out = torch.cat([hc.real, hc.imag, hp.real, hp.imag])
-        return out / out.abs().max()
+        return out * 1e21
 
     assert gradcheck(h, inputs)

--- a/tests/waveforms/test_generator.py
+++ b/tests/waveforms/test_generator.py
@@ -7,9 +7,12 @@ from lalsimulation.gwsignal.core.waveform import (
     LALCompactBinaryCoalescenceGenerator,
 )
 from scipy.signal import hilbert
+from torch.autograd import gradcheck
 
 from ml4gw.waveforms import IMRPhenomD, conversion
 from ml4gw.waveforms.generator import TimeDomainCBCWaveformGenerator
+
+FLOAT64 = torch.float64
 
 TARGET_OVERLAP = 1 - 1e-6
 
@@ -191,3 +194,46 @@ def test_cbc_waveform_generator(
         compute_match(hc_ml4gw[0], torch.tensor(hc_gws_td), sample_rate, f_min)
         > TARGET_OVERLAP
     )
+
+
+def test_cbc_generator_differentiability():
+    generator = TimeDomainCBCWaveformGenerator(
+        approximant=IMRPhenomD(),
+        sample_rate=64,
+        duration=1.0,
+        f_min=20.0,
+        f_ref=20.0,
+        right_pad=0.5,
+    )
+
+    inputs = (
+        torch.tensor([30.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([100.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.0], dtype=FLOAT64, requires_grad=True),
+        torch.tensor([0.5], dtype=FLOAT64, requires_grad=True),
+    )
+
+    def h(chirp_mass, mass_ratio, chi1, chi2, distance, phic, inclination):
+        mass_1, mass_2 = conversion.chirp_mass_and_mass_ratio_to_components(
+            chirp_mass, mass_ratio
+        )
+        hc, hp = generator(
+            mass_1=mass_1,
+            mass_2=mass_2,
+            chirp_mass=chirp_mass,
+            mass_ratio=mass_ratio,
+            chi1=chi1,
+            chi2=chi2,
+            s1z=chi1,
+            s2z=chi2,
+            distance=distance,
+            phic=phic,
+            inclination=inclination,
+        )
+        out = torch.cat([hc, hp])
+        return out / out.abs().max()
+
+    assert gradcheck(h, inputs)

--- a/tests/waveforms/test_generator.py
+++ b/tests/waveforms/test_generator.py
@@ -234,6 +234,6 @@ def test_cbc_generator_differentiability():
             inclination=inclination,
         )
         out = torch.cat([hc, hp])
-        return out / out.abs().max()
+        return out * 1e21
 
     assert gradcheck(h, inputs)


### PR DESCRIPTION
@chreissel I think this PR should address the issues with differentiating waveforms. Can you take a look and confirm? I also fixed an in-place modification in `spectral.py`, so I _think_ the whole chain should be differentiable now.

### Benchmarks (A30)

**Waveforms**

```
| Benchmark                         |  Baseline |   Current | Delta          |
|-----------------------------------|-----------|-----------|----------------|
| test_taylorf2_forward[batch_32]   |   5.11 ms |   5.16 ms | Stable (+1.1%) |
| test_taylorf2_forward[batch_128]  |   5.12 ms |   5.16 ms | Stable (+0.8%) |
| test_taylorf2_forward[batch_512]  |   9.09 ms |   9.08 ms | Stable (-0.1%) |
| test_phenomd_forward[batch_32]    |  39.25 ms |  39.51 ms | Stable (+0.7%) |
| test_phenomd_forward[batch_128]   |  43.96 ms |  44.09 ms | Stable (+0.3%) |
| test_phenomd_forward[batch_512]   | 116.61 ms | 116.50 ms | Stable (-0.1%) |
| test_phenompv2_forward[batch_32]  |  45.37 ms |  45.69 ms | Stable (+0.7%) |
| test_phenompv2_forward[batch_128] |  47.86 ms |  48.05 ms | Stable (+0.4%) |
| test_phenompv2_forward[batch_512] | 115.71 ms | 115.61 ms | Stable (-0.1%) |
```

**normalize_by_psd**

```
| Benchmark                        |  Baseline |   Current | Delta             |
|----------------------------------|-----------|-----------|-------------------|
| test_normalize_by_psd[batch_32]  | 185.91 μs | 164.74 μs | Improved (-11.4%) |
| test_normalize_by_psd[batch_128] | 490.82 μs | 433.22 μs | Improved (-11.7%) |
| test_normalize_by_psd[batch_512] |   1.97 ms |   1.70 ms | Improved (-13.7%) |
```