### PR TITLE
Waveform optimization

### DIFF
--- a/benchmarks/waveforms/conftest.py
+++ b/benchmarks/waveforms/conftest.py
@@ -27,6 +27,11 @@ def cbc_inputs(batch_size, device):
     }
 
 
+@pytest.fixture(params=[2, 4, 8], ids=lambda x: f"dur_{x}")
+def duration(request):
+    return float(request.param)
+
+
 @pytest.fixture
 def spin_vectors(batch_size, device):
     dtype = torch.float64

--- a/benchmarks/waveforms/test_cbc.py
+++ b/benchmarks/waveforms/test_cbc.py
@@ -7,28 +7,35 @@ from ml4gw.waveforms import IMRPhenomD, IMRPhenomPv2, TaylorF2
 F_REF = 20.0
 F_MIN = 20.0
 F_MAX = 1024.0
-DELTA_F = 1.0 / 4.0  # 4-second duration
-FREQS = torch.arange(F_MIN, F_MAX, DELTA_F, dtype=torch.float64)
 
 
-def test_taylorf2_forward(benchmark, cbc_inputs, device, maybe_sync):
+def test_taylorf2_forward(benchmark, cbc_inputs, duration, device, maybe_sync):
     model = TaylorF2().to(device)
-    benchmark(maybe_sync(model), FREQS.to(device), **cbc_inputs, f_ref=F_REF)
+    freqs = torch.arange(F_MIN, F_MAX, 1.0 / duration, dtype=torch.float64).to(
+        device
+    )
+    benchmark(maybe_sync(model), freqs, **cbc_inputs, f_ref=F_REF)
 
 
-def test_phenomd_forward(benchmark, cbc_inputs, device, maybe_sync):
+def test_phenomd_forward(benchmark, cbc_inputs, duration, device, maybe_sync):
     model = IMRPhenomD().to(device)
-    benchmark(maybe_sync(model), FREQS.to(device), **cbc_inputs, f_ref=F_REF)
+    freqs = torch.arange(F_MIN, F_MAX, 1.0 / duration, dtype=torch.float64).to(
+        device
+    )
+    benchmark(maybe_sync(model), freqs, **cbc_inputs, f_ref=F_REF)
 
 
 def test_phenompv2_forward(
-    benchmark, cbc_inputs, spin_vectors, device, maybe_sync
+    benchmark, cbc_inputs, spin_vectors, duration, device, maybe_sync
 ):
     model = IMRPhenomPv2().to(device)
     (s1x, s1y, s1z), (s2x, s2y, s2z) = spin_vectors
+    freqs = torch.arange(F_MIN, F_MAX, 1.0 / duration, dtype=torch.float64).to(
+        device
+    )
     benchmark(
         maybe_sync(model),
-        FREQS.to(device),
+        freqs,
         cbc_inputs["chirp_mass"],
         cbc_inputs["mass_ratio"],
         s1x,

--- a/benchmarks/waveforms/test_generator.py
+++ b/benchmarks/waveforms/test_generator.py
@@ -1,5 +1,6 @@
 """Benchmarks for TimeDomainCBCWaveformGenerator."""
 
+import pytest
 from constants import SAMPLE_RATE
 
 from ml4gw.waveforms import IMRPhenomD
@@ -7,19 +8,25 @@ from ml4gw.waveforms.conversion import chirp_mass_and_mass_ratio_to_components
 from ml4gw.waveforms.generator import TimeDomainCBCWaveformGenerator
 
 DURATION = 4.0
-F_MIN = 20.0
-F_REF = 20.0
 RIGHT_PAD = 0.5
 
 
-def test_td_generator_forward(benchmark, cbc_inputs, device, maybe_sync):
+# f_min controls chirp length, which controls n_freqs.
+@pytest.fixture(params=[20.0, 30.0, 40.0], ids=lambda x: f"fmin_{int(x)}")
+def f_min(request):
+    return request.param
+
+
+def test_td_generator_forward(
+    benchmark, cbc_inputs, f_min, device, maybe_sync
+):
     approximant = IMRPhenomD().to(device)
     model = TimeDomainCBCWaveformGenerator(
         approximant=approximant,
         sample_rate=SAMPLE_RATE,
         duration=DURATION,
-        f_min=F_MIN,
-        f_ref=F_REF,
+        f_min=f_min,
+        f_ref=f_min,
         right_pad=RIGHT_PAD,
     ).to(device)
 

--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -175,13 +175,7 @@ def shift_responses(
     idx -= dt[:, :, None]
     idx %= idx.shape[-1]
 
-    # unfortunately I can't figure out how to do this
-    # last step without doing looping over the ifos
-    rolled = []
-    for i in range(len(vertices)):
-        ifo = torch.gather(responses[:, i], 1, idx[:, i])
-        rolled.append(ifo)
-    return torch.stack(rolled, axis=1)
+    return torch.gather(responses, 2, idx)
 
 
 def compute_observed_strain(
@@ -278,7 +272,7 @@ def get_ifo_geometry(
 
     tensors = torch.stack(tensors)
     vertices = torch.stack(vertices)
-    return torch.Tensor(tensors), torch.Tensor(vertices)
+    return tensors, vertices
 
 
 def compute_ifo_snr(

--- a/ml4gw/waveforms/cbc/phenom_d.py
+++ b/ml4gw/waveforms/cbc/phenom_d.py
@@ -100,6 +100,7 @@ class IMRPhenomD(TaylorF2):
         xi = -1.0 + chi
         M_s = total_mass * MTSUN_SI
 
+        gamma1 = self.gamma1_fun(eta, eta2, xi)
         gamma2 = self.gamma2_fun(eta, eta2, xi)
         gamma3 = self.gamma3_fun(eta, eta2, xi)
 
@@ -110,7 +111,7 @@ class IMRPhenomD(TaylorF2):
         )
 
         Mf = torch.outer(M_s, f)
-        Mf_ref = torch.outer(M_s, f_ref * torch.ones_like(f))
+        Mf_ref = M_s.unsqueeze(-1) * f_ref
 
         Psi, _ = self.phenom_d_phase(
             Mf, mass_1, mass_2, eta, eta2, chi1, chi2, xi, fRD, fDM
@@ -125,8 +126,6 @@ class IMRPhenomD(TaylorF2):
 
         amp, _ = self.phenom_d_amp(
             Mf,
-            mass_1,
-            mass_2,
             eta,
             eta2,
             Seta,
@@ -135,9 +134,12 @@ class IMRPhenomD(TaylorF2):
             chi12,
             chi22,
             xi,
-            distance,
             fRD,
             fDM,
+            gamma1,
+            gamma2,
+            gamma3,
+            Mf_peak,
         )
 
         amp_0 = self.taylorf2_amplitude(
@@ -151,8 +153,6 @@ class IMRPhenomD(TaylorF2):
     def phenom_d_amp(
         self,
         Mf,
-        mass_1,
-        mass_2,
         eta,
         eta2,
         Seta,
@@ -161,24 +161,37 @@ class IMRPhenomD(TaylorF2):
         chi12,
         chi22,
         xi,
-        distance,
         fRD,
         fDM,
+        gamma1,
+        gamma2,
+        gamma3,
+        Mf_peak,
     ):
         ins_amp, ins_Damp = self.phenom_d_inspiral_amp(
             Mf, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
         )
         int_amp, int_Damp = self.phenom_d_int_amp(
-            Mf, eta, eta2, Seta, chi1, chi2, chi12, chi22, xi, fRD, fDM
+            Mf,
+            eta,
+            eta2,
+            Seta,
+            chi1,
+            chi2,
+            chi12,
+            chi22,
+            xi,
+            fRD,
+            fDM,
+            gamma1,
+            gamma2,
+            gamma3,
+            Mf_peak,
         )
         mrd_amp, mrd_Damp = self.phenom_d_mrd_amp(
-            Mf, eta, eta2, chi1, chi2, xi, fRD, fDM
+            Mf, fRD, fDM, gamma1, gamma2, gamma3
         )
 
-        gamma2 = self.gamma2_fun(eta, eta2, xi)
-        gamma3 = self.gamma3_fun(eta, eta2, xi)
-
-        Mf_peak = self.fmaxCalc(fRD, fDM, gamma2, gamma3)
         # Geometric peak and joining frequencies
         Mf_peak = (torch.ones_like(Mf).mT * Mf_peak).mT
         Mf_join_ins = 0.014 * torch.ones_like(Mf)
@@ -212,25 +225,23 @@ class IMRPhenomD(TaylorF2):
         xi,
         fRD,
         fDM,
+        gamma1,
+        gamma2,
+        gamma3,
+        Mf_peak,
     ):
         # Geometric frequency definition from PhenomD header file
         AMP_fJoin_INS = 0.014
 
         Mf1 = AMP_fJoin_INS * torch.ones_like(Mf)
-        gamma2 = self.gamma2_fun(eta, eta2, xi)
-        gamma3 = self.gamma3_fun(eta, eta2, xi)
-
-        fpeak = self.fmaxCalc(fRD, fDM, gamma2, gamma3)
-        Mf3 = (torch.ones_like(Mf).mT * fpeak).mT
+        Mf3 = (torch.ones_like(Mf).mT * Mf_peak).mT
         dfx = 0.5 * (Mf3 - Mf1)
         Mf2 = Mf1 + dfx
 
         v1, d1 = self.phenom_d_inspiral_amp(
             Mf1, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
         )
-        v3, d2 = self.phenom_d_mrd_amp(
-            Mf3, eta, eta2, chi1, chi2, xi, fRD, fDM
-        )
+        v3, d2 = self.phenom_d_mrd_amp(Mf3, fRD, fDM, gamma1, gamma2, gamma3)
         v2 = (
             torch.ones_like(Mf).mT * self.AmpIntColFitCoeff(eta, eta2, xi)
         ).mT
@@ -249,10 +260,7 @@ class IMRPhenomD(TaylorF2):
         )
         return amp, Damp
 
-    def phenom_d_mrd_amp(self, Mf, eta, eta2, chi1, chi2, xi, fRD, fDM):
-        gamma1 = self.gamma1_fun(eta, eta2, xi)
-        gamma2 = self.gamma2_fun(eta, eta2, xi)
-        gamma3 = self.gamma3_fun(eta, eta2, xi)
+    def phenom_d_mrd_amp(self, Mf, fRD, fDM, gamma1, gamma2, gamma3):
         fDMgamma3 = fDM * gamma3
         pow2_fDMgamma3 = (torch.ones_like(Mf).mT * fDMgamma3 * fDMgamma3).mT
         fminfRD = Mf - (torch.ones_like(Mf).mT * fRD).mT

--- a/ml4gw/waveforms/cbc/phenom_d.py
+++ b/ml4gw/waveforms/cbc/phenom_d.py
@@ -502,9 +502,8 @@ class IMRPhenomD(TaylorF2):
         int_Dphasing = (int_Dphasing.mT / eta).mT
         return int_phasing, int_Dphasing
 
-    def subtract3PNSS(self, Mf, mass1, mass2, eta, eta2, xi, chi1, chi2):
+    def subtract3PNSS(self, Mf, mass1, mass2, eta, chi1, chi2):
         M = mass1 + mass2
-        eta = mass1 * mass2 / M / M
         m1byM = mass1 / M
         m2byM = mass2 / M
         chi1sq = chi1 * chi1
@@ -559,7 +558,7 @@ class IMRPhenomD(TaylorF2):
         # implementation, but was not available when PhenomD was tuned.
         # refer https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimIMRPhenomD.c#L397-398 # noqa: E501
         pn_ss3, Dpn_ss3 = self.subtract3PNSS(
-            Mf, mass_1, mass_2, eta, eta2, xi, chi1, chi2
+            Mf, mass_1, mass_2, eta, chi1, chi2
         )
         ins_phasing -= pn_ss3
         ins_Dphasing -= Dpn_ss3

--- a/ml4gw/waveforms/cbc/phenom_d.py
+++ b/ml4gw/waveforms/cbc/phenom_d.py
@@ -193,8 +193,8 @@ class IMRPhenomD(TaylorF2):
         )
 
         # Geometric peak and joining frequencies
-        Mf_peak = (torch.ones_like(Mf).mT * Mf_peak).mT
-        Mf_join_ins = 0.014 * torch.ones_like(Mf)
+        Mf_peak = Mf_peak.unsqueeze(-1)
+        Mf_join_ins = 0.014
 
         # construct full IMR Amp
         theta_minus_f1 = (Mf <= Mf_join_ins).type_as(Mf)
@@ -233,8 +233,8 @@ class IMRPhenomD(TaylorF2):
         # Geometric frequency definition from PhenomD header file
         AMP_fJoin_INS = 0.014
 
-        Mf1 = AMP_fJoin_INS * torch.ones_like(Mf)
-        Mf3 = (torch.ones_like(Mf).mT * Mf_peak).mT
+        Mf1 = Mf.new_full((Mf.shape[0], 1), AMP_fJoin_INS)
+        Mf3 = Mf_peak.unsqueeze(-1)
         dfx = 0.5 * (Mf3 - Mf1)
         Mf2 = Mf1 + dfx
 
@@ -242,9 +242,7 @@ class IMRPhenomD(TaylorF2):
             Mf1, eta, eta2, Seta, xi, chi1, chi2, chi12, chi22
         )
         v3, d2 = self.phenom_d_mrd_amp(Mf3, fRD, fDM, gamma1, gamma2, gamma3)
-        v2 = (
-            torch.ones_like(Mf).mT * self.AmpIntColFitCoeff(eta, eta2, xi)
-        ).mT
+        v2 = self.AmpIntColFitCoeff(eta, eta2, xi).unsqueeze(-1)
 
         delta_0, delta_1, delta_2, delta_3, delta_4 = self.delta_values(
             f1=Mf1, f2=Mf2, f3=Mf3, v1=v1, v2=v2, v3=v3, d1=d1, d2=d2
@@ -262,8 +260,8 @@ class IMRPhenomD(TaylorF2):
 
     def phenom_d_mrd_amp(self, Mf, fRD, fDM, gamma1, gamma2, gamma3):
         fDMgamma3 = fDM * gamma3
-        pow2_fDMgamma3 = (torch.ones_like(Mf).mT * fDMgamma3 * fDMgamma3).mT
-        fminfRD = Mf - (torch.ones_like(Mf).mT * fRD).mT
+        pow2_fDMgamma3 = (fDMgamma3 * fDMgamma3).unsqueeze(-1)
+        fminfRD = Mf - fRD.unsqueeze(-1)
         exp_part = torch.exp(fminfRD.mT * gamma2 / fDMgamma3).mT
         exp_times_lorentzian = exp_part * (fminfRD**2 + pow2_fDMgamma3)
 
@@ -413,7 +411,7 @@ class IMRPhenomD(TaylorF2):
         # definitions in Eq. (35) of arXiv:1508.07253
         # PHI_fJoin_INS in header LALSimIMRPhenomD.h
         # C1 continuity at intermediate region i.e. f_1
-        PHI_fJoin_INS = 0.018 * torch.ones_like(Mf)
+        PHI_fJoin_INS = Mf.new_full((Mf.shape[0], 1), 0.018)
         ins_phase_f1, ins_Dphase_f1 = self.phenom_d_inspiral_phase(
             PHI_fJoin_INS, mass_1, mass_2, eta, eta2, xi, chi1, chi2
         )
@@ -425,7 +423,7 @@ class IMRPhenomD(TaylorF2):
             ins_phase_f1 - (int_phase_f1.mT / eta).mT - C2Int * PHI_fJoin_INS
         )
         # C1 continuity at ringdown
-        fRDJoin = (0.5 * torch.ones_like(Mf).mT * fRD).mT
+        fRDJoin = 0.5 * fRD.unsqueeze(-1)
         int_phase_rd, int_Dphase_rd = self.phenom_d_int_phase(
             fRDJoin, eta, eta2, xi
         )

--- a/ml4gw/waveforms/cbc/phenom_p.py
+++ b/ml4gw/waveforms/cbc/phenom_p.py
@@ -333,6 +333,11 @@ class IMRPhenomPv2(IMRPhenomD):
         # pass M_s * ringdown and M_s * damping frequency to PhenomD functions
         MfRD, MfDM = M_s * fRD, M_s * fDM
 
+        gamma1 = self.gamma1_fun(eta, eta2, xi)
+        gamma2 = self.gamma2_fun(eta, eta2, xi)
+        gamma3 = self.gamma3_fun(eta, eta2, xi)
+        Mf_peak = self.fmaxCalc(MfRD, MfDM, gamma2, gamma3)
+
         phase, _ = self.phenom_d_phase(
             Mf, m1, m2, eta, eta2, chi1, chi2, xi, MfRD, MfDM
         )
@@ -342,8 +347,6 @@ class IMRPhenomPv2(IMRPhenomD):
 
         Amp = self.phenom_d_amp(
             Mf,
-            m1,
-            m2,
             eta,
             eta2,
             Seta,
@@ -352,9 +355,12 @@ class IMRPhenomPv2(IMRPhenomD):
             chi12,
             chi22,
             xi,
-            distance,
             MfRD,
             MfDM,
+            gamma1,
+            gamma2,
+            gamma3,
+            Mf_peak,
         )[0]
         Amp0 = self.get_Amp0(Mf, eta)
         dist_s = distance * MPC_SEC

--- a/ml4gw/waveforms/cbc/phenom_p.py
+++ b/ml4gw/waveforms/cbc/phenom_p.py
@@ -374,9 +374,7 @@ class IMRPhenomPv2(IMRPhenomD):
         x = torch.linspace(0.8, 1.2, n_fixed, device=fRD.device)
         fRDs = torch.outer(fRD, x)
         delta_fRds = (1.2 * fRD - 0.8 * fRD) / (n_fixed - 1)
-        MfRDs = torch.zeros_like(fRDs)
-        for i in range(fRD.shape[0]):
-            MfRDs[i, :] = torch.outer(M_s, fRDs[i, :])[i, :]
+        MfRDs = M_s.unsqueeze(-1) * fRDs
         RD_phase = self.phenom_d_phase(
             MfRDs, m1, m2, eta, eta2, chi1, chi2, xi, MfRD, MfDM
         )[0]

--- a/ml4gw/waveforms/cbc/taylorf2.py
+++ b/ml4gw/waveforms/cbc/taylorf2.py
@@ -154,7 +154,6 @@ class TaylorF2(torch.nn.Module):
         chi1sq = chi1 * chi1
         chi2sq = chi2 * chi2
 
-        v0 = torch.ones_like(Mf)
         v1 = (PI * Mf) ** (1.0 / 3.0)
         v2 = v1 * v1
         v3 = v2 * v1
@@ -169,7 +168,7 @@ class TaylorF2(torch.nn.Module):
         # Phase coeffeciencts from https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimInspiralPNCoefficients.c  # noqa E501
         pfaN = 3.0 / (128.0 * eta)
         pfa_v0 = 1.0
-        pfa_v1 = 0.0
+        # pfa_v1 = 0; no need to calculate terms involving it
         pfa_v2 = 5.0 * (74.3 / 8.4 + 11.0 * eta) / 9.0
         pfa_v3 = -16.0 * PI
         # SO contributions at 1.5 PN
@@ -312,8 +311,8 @@ class TaylorF2(torch.nn.Module):
         phasing += (v4.mT * pfa_v4).mT
         phasing += (v3.mT * pfa_v3).mT
         phasing += (v2.mT * pfa_v2).mT
-        phasing += (v1.mT * pfa_v1).mT
-        phasing += (v0.mT * pfa_v0).mT
+        # v0 = v^0 = 1; scalar arithmetic avoids allocating a ones_like(Mf)
+        phasing += pfa_v0
         # Divide by 0PN v-dependence
         phasing /= v5
         # Multiply by 0PN coefficient
@@ -328,8 +327,7 @@ class TaylorF2(torch.nn.Module):
         Dphasing += (-1.0 * v4.mT * pfa_v4).mT
         Dphasing += (-2.0 * v3.mT * pfa_v3).mT
         Dphasing += (-3.0 * v2.mT * pfa_v2).mT
-        Dphasing += (-4.0 * v1.mT * pfa_v1).mT
-        Dphasing += -5.0 * v0
+        Dphasing -= 5.0
         Dphasing /= 3.0 * v1 * v7
         Dphasing *= PI
         Dphasing = (Dphasing.mT * pfaN).mT

--- a/ml4gw/waveforms/cbc/taylorf2.py
+++ b/ml4gw/waveforms/cbc/taylorf2.py
@@ -97,7 +97,7 @@ class TaylorF2(torch.nn.Module):
         eta = mass1_s * mass2_s / M_s / M_s
 
         Mf = torch.outer(M_s, f)
-        Mf_ref = torch.outer(M_s, f_ref * torch.ones_like(f))
+        Mf_ref = M_s.unsqueeze(-1) * f_ref
 
         Psi, _ = self.taylorf2_phase(Mf, mass1, mass2, chi1, chi2)
         Psi_ref, _ = self.taylorf2_phase(Mf_ref, mass1, mass2, chi1, chi2)


### PR DESCRIPTION
Remove some redundant/unnecessary operations in waveform calculations and replace full `(batch, n_freqs)` tensors with `(batch, 1)` tensors where possible. Also parameterizes CBC waveform benchmarks by duration to measure scaling there. There's a significant improvement for large batches/long waveforms. This should make waveform generation in AMPLFI ~70% faster.

## Benchmarks (A30)

```
| Benchmark                                    |  Baseline |   Current | Delta             |
|----------------------------------------------|-----------|-----------|-------------------|
| test_td_generator_forward[fmin_20-batch_32]  |  75.06 ms |  68.42 ms | Improved (-8.8%)  |
| test_td_generator_forward[fmin_20-batch_128] | 231.98 ms |  89.75 ms | Improved (-61.3%) |
| test_td_generator_forward[fmin_20-batch_512] | 727.83 ms | 198.25 ms | Improved (-72.8%) |
| test_td_generator_forward[fmin_30-batch_32]  |  76.67 ms |  62.36 ms | Improved (-18.7%) |
| test_td_generator_forward[fmin_30-batch_128] | 143.46 ms |  85.31 ms | Improved (-40.5%) |
| test_td_generator_forward[fmin_30-batch_512] | 407.84 ms | 147.62 ms | Improved (-63.8%) |
| test_td_generator_forward[fmin_40-batch_32]  |  67.98 ms |  61.09 ms | Improved (-10.1%) |
| test_td_generator_forward[fmin_40-batch_128] | 128.91 ms |  91.18 ms | Improved (-29.3%) |
| test_td_generator_forward[fmin_40-batch_512] | 419.52 ms | 151.96 ms | Improved (-63.8%) |
| test_taylorf2_forward[dur_2-batch_32]        |   5.01 ms |   4.94 ms | Stable (-1.5%)    |
| test_taylorf2_forward[dur_2-batch_128]       |   5.03 ms |   4.96 ms | Stable (-1.3%)    |
| test_taylorf2_forward[dur_2-batch_512]       |   5.19 ms |   5.06 ms | Stable (-2.4%)    |
| test_taylorf2_forward[dur_4-batch_32]        |   5.02 ms |   4.95 ms | Stable (-1.5%)    |
| test_taylorf2_forward[dur_4-batch_128]       |   5.03 ms |   4.96 ms | Stable (-1.4%)    |
| test_taylorf2_forward[dur_4-batch_512]       |  10.39 ms |   6.29 ms | Improved (-39.5%) |
| test_taylorf2_forward[dur_8-batch_32]        |   5.01 ms |   4.94 ms | Stable (-1.5%)    |
| test_taylorf2_forward[dur_8-batch_128]       |   5.36 ms |   4.98 ms | Improved (-7.0%)  |
| test_taylorf2_forward[dur_8-batch_512]       |  21.56 ms |  11.06 ms | Improved (-48.7%) |
| test_phenomd_forward[dur_2-batch_32]         |  38.92 ms |  39.08 ms | Stable (+0.4%)    |
| test_phenomd_forward[dur_2-batch_128]        |  46.95 ms |  39.10 ms | Improved (-16.7%) |
| test_phenomd_forward[dur_2-batch_512]        |  80.10 ms |  39.50 ms | Improved (-50.7%) |
| test_phenomd_forward[dur_4-batch_32]         |  39.09 ms |  38.92 ms | Stable (-0.4%)    |
| test_phenomd_forward[dur_4-batch_128]        |  52.49 ms |  39.10 ms | Improved (-25.5%) |
| test_phenomd_forward[dur_4-batch_512]        | 173.85 ms |  48.69 ms | Improved (-72.0%) |
| test_phenomd_forward[dur_8-batch_32]         |  41.66 ms |  39.16 ms | Improved (-6.0%)  |
| test_phenomd_forward[dur_8-batch_128]        |  78.89 ms |  38.97 ms | Improved (-50.6%) |
| test_phenomd_forward[dur_8-batch_512]        | 327.09 ms |  65.91 ms | Improved (-79.8%) |
| test_phenompv2_forward[dur_2-batch_32]       |  45.06 ms |  43.71 ms | Stable (-3.0%)    |
| test_phenompv2_forward[dur_2-batch_128]      |  49.26 ms |  43.60 ms | Improved (-11.5%) |
| test_phenompv2_forward[dur_2-batch_512]      |  89.09 ms |  45.77 ms | Improved (-48.6%) |
| test_phenompv2_forward[dur_4-batch_32]       |  45.96 ms |  44.10 ms | Stable (-4.0%)    |
| test_phenompv2_forward[dur_4-batch_128]      |  61.53 ms |  43.13 ms | Improved (-29.9%) |
| test_phenompv2_forward[dur_4-batch_512]      | 185.72 ms |  58.75 ms | Improved (-68.4%) |
| test_phenompv2_forward[dur_8-batch_32]       |  46.78 ms |  42.76 ms | Improved (-8.6%)  |
| test_phenompv2_forward[dur_8-batch_128]      |  78.45 ms |  44.95 ms | Improved (-42.7%) |
| test_phenompv2_forward[dur_8-batch_512]      | 306.63 ms |  93.66 ms | Improved (-69.5%) |
```