### PR TITLE
Optimize shift_responses

### DIFF
--- a/ml4gw/gw.py
+++ b/ml4gw/gw.py
@@ -165,15 +165,9 @@ def shift_responses(
 
     # rolling by gathering implementation based on
     # https://stackoverflow.com/a/68641864
-    # start by just creating a big arange along the last axis
-    idx = torch.ones_like(responses).type(torch.int64)
-    idx = torch.cumsum(idx, axis=-1) - 1
-
-    # apply the offset to the indices along the last axis,
-    # then modulo by the waveform size to make all the
-    # specified indices legitimate and unique
-    idx -= dt[:, :, None]
-    idx %= idx.shape[-1]
+    n = responses.shape[-1]
+    idx = torch.arange(n, dtype=torch.int64, device=responses.device)
+    idx = (idx - dt[:, :, None]) % n
 
     return torch.gather(responses, 2, idx)
 


### PR DESCRIPTION
Streamlines the `shift_responses` function. Part of this PR was accidentally included in my previous PR [here](https://github.com/ML4GW/ml4gw/pull/308/changes#diff-084be39b9bedf9a5db9ad6a93dcfe1a1bbe7e8a6689d7c9b49198c3d5d530fe1); this is the remainder of that change.

## Benchmark for both changes (A30)

| Benchmark                       |  Baseline |   Current | Delta             |
|---------------------------------|-----------|-----------|-------------------|
| test_shift_responses[batch_32]  | 248.35 μs | 184.59 μs | Improved (-25.7%) |
| test_shift_responses[batch_128] | 248.86 μs | 184.30 μs | Improved (-25.9%) |
| test_shift_responses[batch_512] | 370.85 μs | 184.39 μs | Improved (-50.3%) |