### PR TITLE
Optimize transforms

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -33,11 +33,13 @@ git checkout my-feature-branch
 uv run pytest benchmarks/ --benchmark-save=feature
 
 # 4. Compare
-uv run python benchmarks/compare_benchmarks.py <baseline_file> <feature_file>
+uv run python benchmarks/compare_benchmarks.py baseline feature
 ```
 
 Saved files are written to `.benchmarks/<platform>/NNNN_<name>.json`, where
 `NNNN` is a zero-padded counter that increments with each save.
+Benchmark files can be specified by substrings rather than full paths;
+the script will `rglob` in `.benchmarks/` for any matching `.json` files.
 
 Options for `compare_benchmarks.py`:
 

--- a/benchmarks/compare_benchmarks.py
+++ b/benchmarks/compare_benchmarks.py
@@ -7,8 +7,28 @@ from rich import box, print
 from rich.markup import escape
 from rich.table import Table
 
+ROOT_DIR = Path(__file__).parent.parent
 
-def _load_json(path: Path) -> dict:
+
+def _find_json(identifier: str) -> Path:
+    if Path(identifier).is_file():
+        return Path(identifier)
+
+    matches = list((ROOT_DIR / ".benchmarks").rglob(f"*{identifier}*.json"))
+    if not matches:
+        raise FileNotFoundError(
+            f"No benchmark JSON file found matching: {identifier}"
+        )
+    if len(matches) > 1:
+        raise ValueError(
+            f"Multiple benchmark JSON files found matching: {identifier}\n"
+            + "\n".join(str(m) for m in matches)
+        )
+    return matches[0]
+
+
+def _load_json(identifier: str) -> dict:
+    path = _find_json(identifier)
     if not path.exists():
         raise FileNotFoundError(f"File not found: {path}")
     with open(path) as f:
@@ -67,8 +87,8 @@ def _compare_key(
 
 
 def main(
-    baseline: Path,
-    current: Path,
+    baseline: str,
+    current: str,
     metric: Literal["min", "max", "mean", "median"] = "median",
     threshold: float = 5.0,
     sort: bool = False,
@@ -76,8 +96,12 @@ def main(
     """Compare benchmarks between two JSON files from pytest-benchmark.
 
     Args:
-        baseline: Path to the baseline JSON file.
-        current: Path to the current JSON file.
+        baseline: Identifier for the baseline JSON file
+            (can be a filename or a substring to search for in .benchmarks
+            in the repository root).
+        current: Identifier for the current JSON file
+            (can be a filename or a substring to search for in .benchmarks
+            in the repository root).
         metric: The metric to compare (min, max, mean, median).
         threshold: Percentage threshold for highlighting differences.
         sort: Whether to sort the output by percent change in the metric.

--- a/benchmarks/transforms/test_spectral_density.py
+++ b/benchmarks/transforms/test_spectral_density.py
@@ -1,15 +1,24 @@
 """Benchmarks for SpectralDensity."""
 
+import pytest
 import torch
 from constants import KERNEL_LEN, NUM_CHANNELS, SAMPLE_RATE
 
 from ml4gw.transforms import SpectralDensity
 
 
-def test_spectral_density_forward(benchmark, batch_size, device, maybe_sync):
+@pytest.fixture(params=["mean", "median"])
+def average(request):
+    return request.param
+
+
+def test_spectral_density_forward(
+    benchmark, batch_size, average, device, maybe_sync
+):
     spectral_density = SpectralDensity(
         sample_rate=SAMPLE_RATE,
         fftlength=KERNEL_LEN,
+        average=average,
     ).to(device)
     x = torch.randn(batch_size, NUM_CHANNELS, SAMPLE_RATE * 4, device=device)
     benchmark(maybe_sync(spectral_density), x)

--- a/ml4gw/nn/streaming/online_average.py
+++ b/ml4gw/nn/streaming/online_average.py
@@ -100,8 +100,7 @@ class OnlineAverager(torch.nn.Module):
         # window the existing snapshot into overlapping
         # segments and average them with our new updates
         windowed = unfold_windows(state, x.size(-1), self.update_size)
-        windowed /= self.weights
-        windowed += x
+        windowed = windowed / self.weights + x
 
         # embed these windowed averages into a blank
         # array with offsets so that we can add the

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -12,6 +12,8 @@ and
 https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.csd.html
 """
 
+from functools import lru_cache
+
 import torch
 from jaxtyping import Float
 from torch import Tensor
@@ -24,6 +26,14 @@ from .types import (
 )
 
 
+@lru_cache(maxsize=64)
+def _median_bias(n: int) -> float:
+    bias = 1.0
+    for k in range(1, (n - 1) // 2 + 1):
+        bias += 1.0 / (2 * k + 1) - 1.0 / (2 * k)
+    return bias
+
+
 def median(x: Float[Tensor, "... size"], axis: int) -> Float[Tensor, "..."]:
     """
     Implements a median calculation that matches numpy's
@@ -31,10 +41,7 @@ def median(x: Float[Tensor, "... size"], axis: int) -> Float[Tensor, "..."]:
     the same bias correction used by
     `scipy's implementation <https://github.com/scipy/scipy/blob/main/scipy/signal/_spectral_py.py#L2066>`_.
     """  # noqa: E501
-    n = x.shape[axis]
-    ii_2 = 2 * torch.arange(1.0, (n - 1) // 2 + 1)
-    bias = 1 + torch.sum(1.0 / (ii_2 + 1) - 1.0 / ii_2)
-    return torch.quantile(x, q=0.5, axis=axis) / bias
+    return torch.quantile(x, q=0.5, dim=axis) / _median_bias(x.shape[axis])
 
 
 def _validate_shapes(x: Tensor, nperseg: int, y: Tensor | None = None) -> None:

--- a/ml4gw/transforms/decimator.py
+++ b/ml4gw/transforms/decimator.py
@@ -115,6 +115,19 @@ class Decimator(torch.nn.Module):
             * self.sample_rate
         )
 
+        # Pre-register per-segment index buffers for split_by_schedule so
+        # forward() doesn't recompute on every call.
+        if split:
+            self._num_segments = len(self.schedule)
+            for i, s in enumerate(self.schedule):
+                start = int(s[0] * self.sample_rate)
+                stop = int(s[1] * self.sample_rate)
+                step = int(self.sample_rate // s[2])
+                self.register_buffer(
+                    f"_seg{i}_idx",
+                    torch.arange(start, stop, step, dtype=torch.long),
+                )
+
     def _validate_inputs(self) -> None:
         r"""
         Validate the schedule and sample_rate. This method also checks
@@ -186,19 +199,9 @@ class Decimator(torch.nn.Module):
         """
         segments = []
 
-        for s in self.schedule:
-            start = int(s[0] * self.sample_rate)
-            stop = int(s[1] * self.sample_rate)
-            step = int(self.sample_rate // s[2])
-            idx = torch.arange(
-                start,
-                stop,
-                step,
-                dtype=torch.long,
-                device=self.schedule.device,
-            )
-            seg = X.index_select(dim=-1, index=idx)
-            segments.append(seg)
+        for i in range(self._num_segments):
+            idx = getattr(self, f"_seg{i}_idx")
+            segments.append(X.index_select(dim=-1, index=idx))
 
         return segments
 

--- a/ml4gw/transforms/integrator.py
+++ b/ml4gw/transforms/integrator.py
@@ -39,12 +39,12 @@ class TophatIntegrator(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         shape = x.shape
-        L = shape[-1]
-
-        x = x.reshape(-1, 1, L)
+        x = x.reshape(-1, 1, shape[-1])
         x = torch.nn.functional.pad(x, (self.window_size - 1, 0))
-        x = torch.nn.functional.conv1d(x, self.window)
-
+        cs = torch.nn.functional.pad(torch.cumsum(x, dim=-1), (1, 0))
+        x = (
+            cs[..., self.window_size :] - cs[..., : -self.window_size]
+        ) / self.window_size
         return x.reshape(shape)
 
 

--- a/ml4gw/transforms/pearson.py
+++ b/ml4gw/transforms/pearson.py
@@ -1,9 +1,9 @@
 import torch
+import torch.nn.functional as F
 from jaxtyping import Float
 from torch import Tensor
 
 from ..types import TimeSeries1to3d
-from ..utils.slicing import unfold_windows
 
 
 class ShiftedPearsonCorrelation(torch.nn.Module):
@@ -71,19 +71,35 @@ class ShiftedPearsonCorrelation(torch.nn.Module):
         # pad x along time dimension so that it has shape
         # batch x channels x (time + 2 * max_shift)
         pad = (self.max_shift, self.max_shift)
-        x = torch.nn.functional.pad(x, pad)
-
-        # num_windows x batch x channels x time
-        x = unfold_windows(x, dim, 1)
-
-        # now compute the correlation between each window
-        # of x and the single window of y. Start by de-meaning
-        x = x - x.mean(-1, keepdims=True)
+        x = F.pad(x, pad)
         y = y - y.mean(-1, keepdims=True)
 
-        # apply formula and sum along time dimension to give final shape
-        # num_windows x batch x channels
-        corr = (x * y).sum(axis=-1)
-        norm = (x**2).sum(-1) * (y**2).sum(-1)
+        num_shifts = 2 * self.max_shift + 1
+        n_fft = 2 * (dim + self.max_shift)
 
-        return corr / norm**0.5
+        # Compute correlation via FFT
+        x_fft = torch.fft.rfft(x, n=n_fft, dim=-1)
+        y_fft = torch.fft.rfft(y, n=n_fft, dim=-1)
+
+        corr = torch.fft.irfft(x_fft * y_fft.conj(), n=n_fft, dim=-1)
+        corr = corr[..., :num_shifts]
+        corr = corr.movedim(-1, 0)
+
+        # Compute the variance of x at each shift via cumsum
+        cumsum_x = F.pad(torch.cumsum(x, dim=-1), (1, 0))
+        cumsum_x2 = F.pad(torch.cumsum(x**2, dim=-1), (1, 0))
+        window_sum_x = (
+            cumsum_x[..., dim : dim + num_shifts] - cumsum_x[..., :num_shifts]
+        )
+        window_sum_x2 = (
+            cumsum_x2[..., dim : dim + num_shifts]
+            - cumsum_x2[..., :num_shifts]
+        )
+
+        var_x = window_sum_x2 - (window_sum_x**2) / dim
+        var_y = (y**2).sum(-1)
+
+        norm = (var_x * var_y.unsqueeze(-1)) ** 0.5
+        norm = norm.movedim(-1, 0)
+
+        return corr / norm

--- a/ml4gw/transforms/qtransform.py
+++ b/ml4gw/transforms/qtransform.py
@@ -3,10 +3,10 @@ import warnings
 
 import torch
 import torch.nn.functional as F
-from jaxtyping import Float, Int
+from jaxtyping import Float
 from torch import Tensor
 
-from ..types import FrequencySeries1to3d, TimeSeries1to3d, TimeSeries3d
+from ..types import TimeSeries1to3d, TimeSeries3d
 from .spline_interpolation import SplineInterpolate1D
 
 """
@@ -17,142 +17,98 @@ input on GPU.
 """
 
 
-class QTile(torch.nn.Module):
-    """
-    Compute the row of Q-tiles for a single Q value and a single
-    frequency for a batch of multi-channel frequency series data.
-    Should really be called ``QRow``, but I want to match GWpy.
-    Input data should have three dimensions or fewer.
-    If fewer, dimensions will be added until the input is
-    three-dimensional.
-
-    Args:
-        q:
-            The Q value to use in computing the Q tile
-        frequency:
-            The frequency for which to compute the Q tile in Hz
-        duration:
-            The length of time in seconds that the input frequency
-            series represents
-        sample_rate:
-            The sample rate of the original time series in Hz
-        mismatch:
-            The maximum fractional mismatch between neighboring tiles
-
-    """
+class _TileGroup(torch.nn.Module):
+    """Batched Q-tile computation for one group of QTiles that share the same
+    ntiles() value."""
 
     def __init__(
         self,
-        q: float,
-        frequency: float,
-        duration: float,
-        sample_rate: float,
-        mismatch: float,
+        indices: Tensor,
+        windows: Tensor,
+        scatter: Tensor,
+        ntiles_val: int,
+        tile_indices: list[int],
     ) -> None:
         super().__init__()
-        self.mismatch = mismatch
-        self.q = q
-        self.deltam = torch.tensor(2 * (self.mismatch / 3.0) ** (1 / 2.0))
-        self.qprime = self.q / 11 ** (1 / 2.0)
-        self.frequency = frequency
-        self.duration = duration
-        self.sample_rate = sample_rate
+        self.register_buffer("indices", indices)
+        self.register_buffer("windows", windows)
+        self.register_buffer("scatter", scatter)
+        self.ntiles_val = ntiles_val
+        self.tile_indices = tile_indices
 
-        self.windowsize = (
-            2 * int(self.frequency / self.qprime * self.duration) + 1
-        )
-        pad = self.ntiles() - self.windowsize
-        padding = torch.Tensor((int((pad - 1) / 2.0), int((pad + 1) / 2.0)))
-        self.register_buffer("padding", padding)
-        self.register_buffer("indices", self.get_data_indices())
-        self.register_buffer("window", self.get_window())
-
-    def ntiles(self) -> int:
+    def forward(self, X: Tensor, norm: str | None) -> Tensor:
         """
-        Number of tiles in this frequency row
-        """
-        tcum_mismatch = self.duration * 2 * torch.pi * self.frequency / self.q
-        return int(2 ** torch.ceil(torch.log2(tcum_mismatch / self.deltam)))
-
-    def _get_indices(self) -> Int[Tensor, " windowsize"]:
-        half = int((self.windowsize - 1) / 2)
-        return torch.arange(-half, half + 1)
-
-    def get_window(self) -> Float[Tensor, " windowsize"]:
-        """
-        Generate the bi-square window for this row
-        """
-        wfrequencies = self._get_indices() / self.duration
-        xfrequencies = wfrequencies * self.qprime / self.frequency
-        norm = (
-            self.ntiles()
-            / (self.duration * self.sample_rate)
-            * (315 * self.qprime / (128 * self.frequency)) ** (1 / 2.0)
-        )
-        return torch.Tensor((1 - xfrequencies**2) ** 2 * norm)
-
-    def get_data_indices(self) -> Int[Tensor, " windowsize"]:
-        """
-        Get the index array of relevant frequencies for this row
-        """
-        n_rfft = int(self.duration * self.sample_rate) // 2
-        return (
-            torch.round(
-                self._get_indices() + 1 + self.frequency * self.duration,
-            )
-            .type(torch.long)
-            .clamp(0, n_rfft)
-        )
-
-    def forward(
-        self,
-        fseries: FrequencySeries1to3d,
-        norm: str = "median",
-    ) -> TimeSeries1to3d:
-        """
-        Compute the transform for this row
-
         Args:
-            fseries:
-                Frequency series of data. Should correspond to data with
-                the duration and sample rate used to initialize this object.
-                Expected input shape is ``(B, C, F)``, where F is the number
-                of samples, C is the number of channels, and B is the number
-                of batches. If less than three-dimensional, axes will be
-                added.
-            norm:
-                The method of normalization. Options are "median", "mean", or
-                ``None``.
+            X: rfft output, shape ``(B, C, F)``
+            norm: normalization method ("median", "mean", or ``None``).
 
         Returns:
-            The row of Q-tiles for the given Q and frequency. Output is
-            three-dimensional: ``(B, C, T)``
+            Energy tensor of shape ``(B, C, N, ntiles_val)``.
         """
-        if len(fseries.shape) > 3:
-            raise ValueError("Input data has more than 3 dimensions")
+        N = self.indices.shape[0]
+        gathered = X[..., self.indices] * self.windows  # (B, C, N, max_ws)
 
-        while len(fseries.shape) < 3:
-            fseries = fseries[None]
+        # Scatter into the ntiles-length buffer. scatter_ is needed because
+        # each tile has a different left-padding offset.
+        padded = torch.zeros(
+            *X.shape[:-1], N, self.ntiles_val, dtype=X.dtype, device=X.device
+        )
+        padded.scatter_(
+            dim=-1,
+            index=self.scatter.expand(*X.shape[:-1], -1, -1),
+            src=gathered,
+        )
 
-        windowed = fseries[..., self.indices] * self.window
-        left, right = self.padding
-        padded = F.pad(windowed, (int(left), int(right)), mode="constant")
-        wenergy = torch.fft.ifftshift(padded, dim=-1)
-
-        tdenergy = torch.fft.ifft(wenergy)
+        tdenergy = torch.fft.ifft(torch.fft.ifftshift(padded, dim=-1))
         energy = tdenergy.real**2.0 + tdenergy.imag**2.0
+
         if norm:
-            norm = norm.lower() if isinstance(norm, str) else norm
-            if norm == "median":
-                medians = torch.quantile(energy, q=0.5, dim=-1, keepdim=True)
-                energy /= medians
-            elif norm == "mean":
-                means = torch.mean(energy, dim=-1, keepdim=True)
-                energy /= means
+            norm_lower = norm.lower()
+            if norm_lower == "median":
+                energy = energy / torch.quantile(
+                    energy, q=0.5, dim=-1, keepdim=True
+                )
+            elif norm_lower == "mean":
+                energy = energy / energy.mean(dim=-1, keepdim=True)
             else:
                 raise ValueError(f"Invalid normalisation {norm}")
-            energy = energy.type(torch.float32)
+            energy = energy.float()
         return energy
+
+
+def _qtile_geometry(
+    q: float,
+    frequency: float,
+    duration: float,
+    sample_rate: float,
+    mismatch: float,
+) -> tuple[int, int, Tensor, Tensor, int]:
+    """Compute the geometry for one Q-tile row."""
+    qprime = q / 11**0.5
+    deltam = 2 * (mismatch / 3.0) ** 0.5
+    windowsize = 2 * int(frequency / qprime * duration) + 1
+    tcum_mismatch = duration * 2 * math.pi * frequency / q
+    ntiles = int(2 ** math.ceil(math.log2(tcum_mismatch / deltam)))
+
+    half = (windowsize - 1) // 2
+    indices = torch.arange(-half, half + 1)
+
+    xfrequencies = (indices / duration) * qprime / frequency
+    norm = (
+        ntiles
+        / (duration * sample_rate)
+        * (315 * qprime / (128 * frequency)) ** 0.5
+    )
+    window = torch.tensor((1 - xfrequencies**2) ** 2 * norm)
+
+    n_rfft = int(duration * sample_rate) // 2
+    data_indices = (
+        torch.round(indices + 1 + frequency * duration).long().clamp(0, n_rfft)
+    )
+
+    left_pad = int((ntiles - windowsize - 1) / 2.0)
+
+    return ntiles, windowsize, window, data_indices, left_pad
 
 
 class SingleQTransform(torch.nn.Module):
@@ -206,6 +162,7 @@ class SingleQTransform(torch.nn.Module):
     ) -> None:
         super().__init__()
         self.q = q
+        self.sample_rate = sample_rate
         self.spectrogram_shape = spectrogram_shape
         self.frange = frange or [0, torch.inf]
         self.duration = duration
@@ -234,30 +191,61 @@ class SingleQTransform(torch.nn.Module):
             self.frange[1] = sample_rate / 2 / (1 + 1 / qprime)
 
         self.freqs = self.get_freqs()
-        self.qtile_transforms = torch.nn.ModuleList(
-            [
-                QTile(
-                    q=self.q,
-                    frequency=freq,
-                    duration=self.duration,
-                    sample_rate=sample_rate,
-                    mismatch=self.mismatch,
-                )
-                for freq in self.freqs
-            ]
-        )
         self.qtiles = None
+        self._setup_batched_tile_groups()
 
         if self.interpolation_method == "spline":
             self._set_up_spline_interp()
 
+    def _setup_batched_tile_groups(self):
+        # Group tiles that share the same ntiles value so their IFFTs can be
+        # batched in compute_qtiles rather than called one tile at a time.
+        geometries = [
+            _qtile_geometry(
+                self.q,
+                float(f),
+                self.duration,
+                self.sample_rate,
+                self.mismatch,
+            )
+            for f in self.freqs
+        ]
+        ntiles_list = [g[0] for g in geometries]
+        unique_ntiles = sorted(set(ntiles_list))
+
+        groups = []
+        for ntiles_val in unique_ntiles:
+            tile_indices = [
+                i for i, n in enumerate(ntiles_list) if n == ntiles_val
+            ]
+            N = len(tile_indices)
+            max_ws = max(geometries[i][1] for i in tile_indices)
+
+            indices_padded = torch.zeros(N, max_ws, dtype=torch.long)
+            windows_padded = torch.zeros(N, max_ws, dtype=torch.float32)
+            scatter_idx = torch.zeros(N, max_ws, dtype=torch.long)
+
+            for row, tile_idx in enumerate(tile_indices):
+                _, ws, window, data_indices, left_pad = geometries[tile_idx]
+                indices_padded[row, :ws] = data_indices
+                windows_padded[row, :ws] = window
+                scatter_idx[row, :ws] = left_pad + torch.arange(ws)
+
+            groups.append(
+                _TileGroup(
+                    indices_padded,
+                    windows_padded,
+                    scatter_idx,
+                    ntiles_val,
+                    tile_indices,
+                )
+            )
+
+        self.tile_groups = torch.nn.ModuleList(groups)
+
     def _set_up_spline_interp(self):
-        ntiles = [qtile.ntiles() for qtile in self.qtile_transforms]
-        # For efficiency, we'll stack all qtiles of the same length before
-        # interpolating, so we need to figure out which those are
-        unique_ntiles = sorted(set(ntiles))
-        idx = torch.arange(len(ntiles))
-        self.stack_idx = [idx[Tensor(ntiles) == n] for n in unique_ntiles]
+        # tile_groups is already grouped by ntiles_val, so reuse it directly
+        self.stack_idx = [group.tile_indices for group in self.tile_groups]
 
         t_out = torch.arange(
             0, self.duration, self.duration / self.spectrogram_shape[1]
@@ -266,10 +254,12 @@ class SingleQTransform(torch.nn.Module):
             [
                 SplineInterpolate1D(
                     kx=3,
-                    x_in=torch.arange(0, self.duration, self.duration / tiles),
+                    x_in=torch.arange(
+                        0, self.duration, self.duration / group.ntiles_val
+                    ),
                     x_out=t_out,
                 )
-                for tiles in unique_ntiles
+                for group in self.tile_groups
             ]
         )
 
@@ -361,9 +351,21 @@ class SingleQTransform(torch.nn.Module):
         for each ``QTile``
         """
         # Computing the FFT with the same normalization and scaling as GWpy
+        if X.ndim == 1:
+            X = X[None, None]
+        elif X.ndim == 2:
+            X = X[None]
         X = torch.fft.rfft(X, norm="forward")
         X[..., 1:] *= 2
-        self.qtiles = [qtile(X, norm) for qtile in self.qtile_transforms]
+
+        results = [None] * len(self.freqs)
+
+        for group in self.tile_groups:
+            energy = group(X, norm)  # (B, C, N, ntiles_val)
+            for row, tile_idx in enumerate(group.tile_indices):
+                results[tile_idx] = energy[..., row, :]
+
+        self.qtiles = results
 
     def interpolate(self) -> TimeSeries3d:
         if self.qtiles is None:
@@ -387,21 +389,24 @@ class SingleQTransform(torch.nn.Module):
             # Transpose because the final dimension gets interpolated
             return self.interpolator(time_interped.mT).mT
         num_f_bins, num_t_bins = self.spectrogram_shape
-        resampled = [
+        time_interped = torch.stack(
+            [
+                F.interpolate(
+                    qtile.unsqueeze(0),
+                    (qtile.shape[-2], num_t_bins),
+                    mode=self.interpolation_method,
+                ).squeeze(0)
+                for qtile in self.qtiles
+            ],
+            dim=-2,
+        )
+        return torch.squeeze(
             F.interpolate(
-                qtile[None],
-                (qtile.shape[-2], num_t_bins),
+                time_interped,
+                (num_f_bins, num_t_bins),
                 mode=self.interpolation_method,
             )
-            for qtile in self.qtiles
-        ]
-        resampled = torch.stack(resampled, dim=-2)
-        resampled = F.interpolate(
-            resampled[0],
-            (num_f_bins, num_t_bins),
-            mode=self.interpolation_method,
         )
-        return torch.squeeze(resampled)
 
     def forward(
         self,
@@ -551,7 +556,7 @@ class QScan(torch.nn.Module):
         for transform in self.q_transforms:
             transform.compute_qtiles(X, norm)
         idx = torch.argmax(
-            torch.Tensor(
+            torch.stack(
                 [
                     transform.get_max_energy(fsearch_range=fsearch_range)
                     for transform in self.q_transforms

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -16,7 +16,8 @@ class SplineInterpolateBase(torch.nn.Module):
         basis_matrix = self.bspline_basis_natural(x, k, knots)
         identity = torch.eye(basis_matrix.shape[-1])
         B_T_B = basis_matrix.T @ basis_matrix + s * identity
-        return knots, basis_matrix, B_T_B
+        L = torch.linalg.cholesky(B_T_B)
+        return knots, basis_matrix, L
 
     def generate_fitpack_knots(self, x: Tensor, k: int) -> Tensor:
         """
@@ -150,9 +151,7 @@ class SplineInterpolateBase(torch.nn.Module):
         for d in range(1, k + 1):
             L, R = self.compute_L_R(x, t, d, m)
             left = L * b[:, :, d - 1]
-
             temp_b = torch.cat([b[:, 1:, d - 1], zeros_tensor], dim=1)
-
             right = R * temp_b
             b[:, :, d] = left + right
 
@@ -224,10 +223,10 @@ class SplineInterpolate1D(SplineInterpolateBase):
         self.register_buffer("x_in", x_in)
         self.register_buffer("x_out", x_out)
 
-        tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, kx, sx)
+        tx, Bx, BxT_Bx_L = self._compute_knots_and_basis_matrices(x_in, kx, sx)
         self.register_buffer("tx", tx)
         self.register_buffer("Bx", Bx)
-        self.register_buffer("BxT_Bx", BxT_Bx)
+        self.register_buffer("BxT_Bx_L", BxT_Bx_L)
 
         if self.x_out is not None:
             x_clamped = torch.clamp(x_out, tx[kx], tx[-kx - 1])
@@ -235,11 +234,10 @@ class SplineInterpolate1D(SplineInterpolateBase):
             self.register_buffer("Bx_out", Bx_out)
 
     def spline_fit_natural(self, Z):
-        # Adding batch/channel dimension handling
-        # Bx @ Z
+        # BxT @ Z, handling batch/channel dimensions
         BxT_Z = torch.einsum("ij,bchj->bchi", self.Bx.T, Z)
-        # (BxT @ Bx)^-1 @ (BxT @ Z) = Bx^-1 @ Z
-        C = torch.linalg.solve(self.BxT_Bx, BxT_Z.unsqueeze(-1))
+        # Solve (BxT @ Bx) C = BxT @ Z using the pre-factored Cholesky L
+        C = torch.cholesky_solve(BxT_Z.unsqueeze(-1), self.BxT_Bx_L)
         return C.squeeze(-1)
 
     def evaluate_spline(self, C: Tensor):
@@ -404,15 +402,15 @@ class SplineInterpolate2D(SplineInterpolateBase):
         self.register_buffer("x_out", x_out)
         self.register_buffer("y_out", y_out)
 
-        tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, kx, sx)
+        tx, Bx, BxT_Bx_L = self._compute_knots_and_basis_matrices(x_in, kx, sx)
         self.register_buffer("tx", tx)
         self.register_buffer("Bx", Bx)
-        self.register_buffer("BxT_Bx", BxT_Bx)
+        self.register_buffer("BxT_Bx_L", BxT_Bx_L)
 
-        ty, By, ByT_By = self._compute_knots_and_basis_matrices(y_in, ky, sy)
+        ty, By, ByT_By_L = self._compute_knots_and_basis_matrices(y_in, ky, sy)
         self.register_buffer("ty", ty)
         self.register_buffer("By", By)
-        self.register_buffer("ByT_By", ByT_By)
+        self.register_buffer("ByT_By_L", ByT_By_L)
 
         if self.x_out is not None:
             x_clamped = torch.clamp(x_out, tx[kx], tx[-kx - 1])
@@ -424,13 +422,18 @@ class SplineInterpolate2D(SplineInterpolateBase):
             self.register_buffer("By_out", By_out)
 
     def bivariate_spline_fit_natural(self, Z):
-        # Adding batch/channel dimension handling
-        # ByT @ Z @ BxW
+        # ByT @ Z @ Bx, handling batch/channel dimensions
         ByT_Z_Bx = torch.einsum("ij,bcik,kl->bcjl", self.By, Z, self.Bx)
-        # (ByT @ By)^-1 @ (ByT @ Z @ Bx) = By^-1 @ Z @ Bx
-        E = torch.linalg.solve(self.ByT_By, ByT_Z_Bx)
-        # ((BxT @ Bx)^-1 @ (By^-1 @ Z @ Bx)T)T = By^-1 @ Z @ BxT^-1
-        return torch.linalg.solve(self.BxT_Bx, E.mT).mT
+        # Solve (ByT @ By) E = ByT @ Z @ Bx  ->  E = By^-1 @ Z @ Bx
+        E = torch.cholesky_solve(ByT_Z_Bx, self.ByT_By_L)
+        # Solve (BxT @ Bx) CT = ET  ->  C = By^-1 @ Z @ Bx^-T
+        # Make E.mT contiguous to avoid an implicit copy
+        # and free E to reduce peak memory.
+        E_T = E.mT.contiguous()
+        del E
+        C_T = torch.cholesky_solve(E_T, self.BxT_Bx_L)
+        del E_T
+        return C_T.mT
 
     def evaluate_bivariate_spline(self, C: Tensor):
         """

--- a/ml4gw/transforms/spline_interpolation.py
+++ b/ml4gw/transforms/spline_interpolation.py
@@ -16,8 +16,7 @@ class SplineInterpolateBase(torch.nn.Module):
         basis_matrix = self.bspline_basis_natural(x, k, knots)
         identity = torch.eye(basis_matrix.shape[-1])
         B_T_B = basis_matrix.T @ basis_matrix + s * identity
-        L = torch.linalg.cholesky(B_T_B)
-        return knots, basis_matrix, L
+        return knots, basis_matrix, B_T_B
 
     def generate_fitpack_knots(self, x: Tensor, k: int) -> Tensor:
         """
@@ -223,10 +222,10 @@ class SplineInterpolate1D(SplineInterpolateBase):
         self.register_buffer("x_in", x_in)
         self.register_buffer("x_out", x_out)
 
-        tx, Bx, BxT_Bx_L = self._compute_knots_and_basis_matrices(x_in, kx, sx)
+        tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, kx, sx)
         self.register_buffer("tx", tx)
         self.register_buffer("Bx", Bx)
-        self.register_buffer("BxT_Bx_L", BxT_Bx_L)
+        self.register_buffer("BxT_Bx_L", torch.linalg.cholesky(BxT_Bx))
 
         if self.x_out is not None:
             x_clamped = torch.clamp(x_out, tx[kx], tx[-kx - 1])
@@ -402,15 +401,15 @@ class SplineInterpolate2D(SplineInterpolateBase):
         self.register_buffer("x_out", x_out)
         self.register_buffer("y_out", y_out)
 
-        tx, Bx, BxT_Bx_L = self._compute_knots_and_basis_matrices(x_in, kx, sx)
+        tx, Bx, BxT_Bx = self._compute_knots_and_basis_matrices(x_in, kx, sx)
         self.register_buffer("tx", tx)
         self.register_buffer("Bx", Bx)
-        self.register_buffer("BxT_Bx_L", BxT_Bx_L)
+        self.register_buffer("BxT_Bx", BxT_Bx)
 
-        ty, By, ByT_By_L = self._compute_knots_and_basis_matrices(y_in, ky, sy)
+        ty, By, ByT_By = self._compute_knots_and_basis_matrices(y_in, ky, sy)
         self.register_buffer("ty", ty)
         self.register_buffer("By", By)
-        self.register_buffer("ByT_By_L", ByT_By_L)
+        self.register_buffer("ByT_By", ByT_By)
 
         if self.x_out is not None:
             x_clamped = torch.clamp(x_out, tx[kx], tx[-kx - 1])
@@ -425,13 +424,13 @@ class SplineInterpolate2D(SplineInterpolateBase):
         # ByT @ Z @ Bx, handling batch/channel dimensions
         ByT_Z_Bx = torch.einsum("ij,bcik,kl->bcjl", self.By, Z, self.Bx)
         # Solve (ByT @ By) E = ByT @ Z @ Bx  ->  E = By^-1 @ Z @ Bx
-        E = torch.cholesky_solve(ByT_Z_Bx, self.ByT_By_L)
+        E = torch.linalg.solve(self.ByT_By, ByT_Z_Bx)
         # Solve (BxT @ Bx) CT = ET  ->  C = By^-1 @ Z @ Bx^-T
-        # Make E.mT contiguous to avoid an implicit copy
-        # and free E to reduce peak memory.
+        # Make E.mT contiguous to avoid an implicit copy and free E to
+        # reduce peak memory.
         E_T = E.mT.contiguous()
         del E
-        C_T = torch.cholesky_solve(E_T, self.BxT_Bx_L)
+        C_T = torch.linalg.solve(self.BxT_Bx, E_T)
         del E_T
         return C_T.mT
 

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -77,6 +77,11 @@ def unfold_windows(
         )
 
     unfolded = x.unfold(-1, window_size, stride)
+    # The unfold operation makes the targetted dimension the window dimension
+    # and appends a new dimension for the windows at the end of the tensor.
+    # We want the window dimension to be the first dimension, so we permute
+    # so that the second-to-last dimension becomes the first dimension,
+    # and the order of the other dimensions is preserved.
     if x.ndim == 2:
         unfolded = unfolded.permute(1, 0, 2)
     elif x.ndim == 3:

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -8,7 +8,6 @@ windows.
 import torch
 from jaxtyping import Float, Int64
 from torch import Tensor
-from torch.nn.functional import unfold
 
 from ..types import TimeSeries1d, TimeSeries1to3d, TimeSeries2d, TimeSeries3d
 
@@ -69,22 +68,15 @@ def unfold_windows(
             x, [x.shape[-1] - remainder, remainder], dim=-1
         )
 
-    reshape = list(x.shape[:-1])
-    if x.ndim == 1:
-        x = x[None, None, None, :]
-    elif x.ndim == 2:
-        x = x[None, :, None, :]
+    unfolded = x.unfold(-1, window_size, stride)
+    if x.ndim == 2:
+        unfolded = unfolded.permute(1, 0, 2)
     elif x.ndim == 3:
-        x = x[:, :, None, :]
-
-    x = unfold(x, (1, num_windows), dilation=(1, stride))
-    reshape += [num_windows, -1]
-    x = x.reshape(*reshape)
-    x = x.transpose(1, -2).transpose(0, 1)
+        unfolded = unfolded.permute(2, 0, 1, 3)
 
     if not drop_last:
-        return x, remainder[None]
-    return x
+        return unfolded, remainder[None]
+    return unfolded
 
 
 def slice_kernels(

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -51,6 +51,14 @@ def unfold_windows(
        If ``drop_last`` is false, returns the remainder of the
        timeseries, shaped to be compatible with the returned
        unfolded tensor
+
+    .. note::
+       The returned tensor is a strided view of the input, not a copy.
+       When ``stride < window_size``, adjacent windows share overlapping
+       memory. In-place operations on the result are unsafe in that case:
+       elements in the overlap region will be written multiple times,
+       producing incorrect values. Use out-of-place operations if the
+       result needs to be modified.
     """
 
     num_windows = (x.shape[-1] - window_size) // stride + 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ addopts = [
     "--benchmark-warmup=on",
     "--benchmark-warmup-iterations=5",
     "--benchmark-sort=mean",
+    "--benchmark-max-time=2.0",
 ]
 
 [tool.coverage.run]

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -2,10 +2,8 @@ import numpy as np
 import pytest
 import torch
 from gwpy.signal.qtransform import QPlane, QTiling
-from gwpy.signal.qtransform import QTile as gwpy_QTile
 
 from ml4gw.transforms import QScan, SingleQTransform
-from ml4gw.transforms.qtransform import QTile
 
 
 @pytest.fixture(params=[1])
@@ -38,56 +36,9 @@ def mismatch(request):
     return request.param
 
 
-@pytest.fixture(params=[128])
-def frequency(request):
-    return request.param
-
-
 @pytest.fixture(params=["bilinear", "bicubic", "spline"])
 def interpolation_method(request):
     return request.param
-
-
-def test_qtile(
-    q,
-    frequency,
-    duration,
-    sample_rate,
-    mismatch,
-    norm,
-):
-    X = torch.randn(int(duration * sample_rate))
-    X = torch.fft.rfft(X, norm="forward")
-    X[..., 1:] *= 2
-
-    torch_qtile = QTile(q, frequency, duration, sample_rate, mismatch)
-    gwpy_qtile = gwpy_QTile(q, frequency, duration, sample_rate, mismatch)
-
-    assert torch_qtile.ntiles() == gwpy_qtile.ntiles
-    assert np.allclose(
-        torch_qtile.get_window().numpy(), gwpy_qtile.get_window()
-    )
-    assert (
-        torch_qtile.get_data_indices().numpy() == gwpy_qtile.get_data_indices()
-    ).all()
-    assert np.allclose(
-        torch_qtile(X, norm).numpy(),
-        gwpy_qtile.transform(X, norm, 0),
-        rtol=1e-3,
-    )
-
-    X = torch.randn(2, 2, 2, int(sample_rate * duration))
-    with pytest.raises(ValueError):
-        torch_qtile(X)
-
-
-def test_qtile_invalid_norm():
-    X = torch.randn(1024)
-    X = torch.fft.rfft(X, norm="forward")
-    X[..., 1:] *= 2
-    qtile = QTile(12, 128, 1, 1024, 0.2)
-    with pytest.raises(ValueError, match="Invalid normalisation"):
-        qtile(X, norm="bogus")
 
 
 def test_singleqtransform(

--- a/tests/transforms/test_qtransform.py
+++ b/tests/transforms/test_qtransform.py
@@ -113,6 +113,24 @@ def test_singleqtransform(
     assert list(transformed.shape[-2:]) == spectrogram_shape
 
 
+def test_compute_qtiles_invalid_norm():
+    qtransform = SingleQTransform(
+        1, 1024, [64, 64], 12, frange=[0, torch.inf], mismatch=0.2
+    )
+    X = torch.randn(1024)
+    with pytest.raises(ValueError, match="Invalid normalisation"):
+        qtransform.compute_qtiles(X, norm="invalid")
+
+
+def test_compute_qtiles_2d_input():
+    qtransform = SingleQTransform(
+        1, 1024, [64, 64], 12, frange=[0, torch.inf], mismatch=0.2
+    )
+    X = torch.randn(2, 1024)
+    qtransform.compute_qtiles(X, norm=None)
+    assert all(t.shape[0] == 1 and t.shape[1] == 2 for t in qtransform.qtiles)
+
+
 def test_get_max_energy_invalid_dimension():
     qtransform = SingleQTransform(
         1, 1024, [64, 64], 12, frange=[0, torch.inf], mismatch=0.2


### PR DESCRIPTION
Made a number of optimizations to some of the slower transforms. @deepchatterjeeligo The scope of this PR expanded a bit beyond my original intention, so I'm happy to split this into multiple PRs if you'd prefer to review it that way.

The only real change to the public-facing API is that the return value of `unfold_windows` is now a view, rather than a copy. This means that some care needs to be taken with in-place operations. The benefit is that there's no intermediate 4-D tensor created. I've added a note to the function and confirmed that this doesn't affect anything in Aframe.

### Benchmarks (A100)

| Benchmark                                                     |  Baseline |   Current | Delta             |
|---------------------------------------------------------------|-----------|-----------|-------------------|
| test_spline_1d_forward[batch_32-num_points_128]               | 633.33 μs | 338.71 μs | Improved (-46.5%) |
| test_spline_1d_forward[batch_32-num_points_512]               |   2.40 ms | 860.23 μs | Improved (-64.2%) |
| test_spline_1d_forward[batch_128-num_points_128]              | 638.83 μs | 328.01 μs | Improved (-48.7%) |
| test_spline_1d_forward[batch_128-num_points_512]              |   2.76 ms |   1.07 ms | Improved (-61.2%) |
| test_spline_1d_forward[batch_512-num_points_128]              | 715.05 μs | 388.40 μs | Improved (-45.7%) |
| test_spline_1d_forward[batch_512-num_points_512]              |   4.42 ms |   1.54 ms | Improved (-65.1%) |
| test_single_qtransform_compute_qtiles[batch_32-sr_1024_q_12]  |   6.63 ms |   1.22 ms | Improved (-81.5%) |
| test_single_qtransform_compute_qtiles[batch_32-sr_4096_q_12]  |  13.28 ms |   1.98 ms | Improved (-85.1%) |
| test_single_qtransform_compute_qtiles[batch_32-sr_4096_q_64]  |  32.61 ms |   1.36 ms | Improved (-95.8%) |
| test_single_qtransform_compute_qtiles[batch_128-sr_1024_q_12] |   6.68 ms |   1.22 ms | Improved (-81.7%) |
| test_single_qtransform_compute_qtiles[batch_128-sr_4096_q_12] |  13.22 ms |   2.17 ms | Improved (-83.6%) |
| test_single_qtransform_compute_qtiles[batch_128-sr_4096_q_64] |  32.54 ms |   1.86 ms | Improved (-94.3%) |
| test_single_qtransform_compute_qtiles[batch_512-sr_1024_q_12] |   6.65 ms |   1.63 ms | Improved (-75.5%) |
| test_single_qtransform_compute_qtiles[batch_512-sr_4096_q_12] |  13.51 ms |   5.45 ms | Improved (-59.7%) |
| test_single_qtransform_compute_qtiles[batch_512-sr_4096_q_64] |  32.48 ms |   5.81 ms | Improved (-82.1%) |
| test_single_qtransform_forward[batch_32-sr_1024_q_12]         |   7.20 ms |   1.72 ms | Improved (-76.1%) |
| test_single_qtransform_forward[batch_32-sr_4096_q_12]         |  14.47 ms |   3.35 ms | Improved (-76.8%) |
| test_single_qtransform_forward[batch_32-sr_4096_q_64]         |  34.56 ms |   3.77 ms | Improved (-89.1%) |
| test_single_qtransform_forward[batch_128-sr_1024_q_12]        |   8.16 ms |   3.11 ms | Improved (-61.9%) |
| test_single_qtransform_forward[batch_128-sr_4096_q_12]        |  18.08 ms |   6.91 ms | Improved (-61.8%) |
| test_single_qtransform_forward[batch_128-sr_4096_q_64]        |  41.03 ms |  10.43 ms | Improved (-74.6%) |
| test_single_qtransform_forward[batch_512-sr_1024_q_12]        |  14.46 ms |   9.25 ms | Improved (-36.1%) |
| test_single_qtransform_forward[batch_512-sr_4096_q_12]        |  31.93 ms |  23.96 ms | Improved (-25.0%) |
| test_single_qtransform_forward[batch_512-sr_4096_q_64]        |  66.27 ms |  40.28 ms | Improved (-39.2%) |
| test_qscan_forward[batch_32-sr_1024]                          |  32.43 ms |  10.58 ms | Improved (-67.4%) |
| test_qscan_forward[batch_32-sr_4096]                          |  79.80 ms |  18.96 ms | Improved (-76.2%) |
| test_qscan_forward[batch_128-sr_1024]                         |  33.68 ms |  11.46 ms | Improved (-66.0%) |
| test_qscan_forward[batch_128-sr_4096]                         |  82.68 ms |  20.67 ms | Improved (-75.0%) |
| test_qscan_forward[batch_512-sr_1024]                         |  36.59 ms |  15.34 ms | Improved (-58.1%) |
| test_qscan_forward[batch_512-sr_4096]                         |  89.34 ms |  41.53 ms | Improved (-53.5%) |
| test_decimator_split_forward[batch_32]                        | 167.71 μs |  38.76 μs | Improved (-76.9%) |
| test_decimator_split_forward[batch_128]                       | 170.06 μs |  38.92 μs | Improved (-77.1%) |
| test_decimator_split_forward[batch_512]                       | 170.06 μs |  38.64 μs | Improved (-77.3%) |
| test_tophat_integrator_forward[batch_32]                      | 381.37 μs | 115.56 μs | Improved (-69.7%) |
| test_tophat_integrator_forward[batch_128]                     | 840.62 μs | 119.44 μs | Improved (-85.8%) |
| test_tophat_integrator_forward[batch_512]                     |   2.95 ms | 233.29 μs | Improved (-92.1%) |
| test_shifted_pearson_forward[batch_32]                        |   2.42 ms | 443.87 μs | Improved (-81.7%) |
| test_shifted_pearson_forward[batch_128]                       |   9.18 ms | 443.24 μs | Improved (-95.2%) |
| test_shifted_pearson_forward[batch_512]                       |  36.21 ms | 620.51 μs | Improved (-98.3%) |
| test_spectral_density_forward[batch_32-mean]                  | 387.53 μs | 384.77 μs | Stable (-0.7%)    |
| test_spectral_density_forward[batch_32-median]                | 638.91 μs | 559.45 μs | Improved (-12.4%) |
| test_spectral_density_forward[batch_128-mean]                 |   1.46 ms |   1.46 ms | Stable (-0.2%)    |
| test_spectral_density_forward[batch_128-median]               |   1.92 ms |   1.92 ms | Stable (-0.3%)    |
| test_spectral_density_forward[batch_512-mean]                 |   5.84 ms |   5.84 ms | Stable (-0.1%)    |
| test_spectral_density_forward[batch_512-median]               |   7.58 ms |   7.57 ms | Stable (-0.2%)    |
| test_snapshotter_forward                                      |  90.74 μs |  43.17 μs | Improved (-52.4%) |
| test_online_averager_forward                                  | 201.28 μs | 156.08 μs | Improved (-22.5%) |