### PR TITLE
Fix phenom_p bug with batched waveforms

### DIFF
--- a/ml4gw/waveforms/cbc/phenom_p.py
+++ b/ml4gw/waveforms/cbc/phenom_p.py
@@ -382,12 +382,12 @@ class IMRPhenomPv2(IMRPhenomD):
         diffRDphase = (diff[:, 1:] + diff[:, :-1]) / (
             2 * delta_fRds.unsqueeze(1)
         )
-        # reshape x to have same shape as diffRDphase
-        x = x[1:-1].unsqueeze(0).expand(diffRDphase.shape)
-        # interpolate at x = 1, as thats the same as f = fRD
-        diffRDphase = -self.interpolate(
-            torch.tensor([1], device=x.device), x, diffRDphase
-        )
+        # Evaluate diffRDphase at normalized frequency 1.0 (i.e. f = fRD)
+        # for each batch element. With n_fixed=1000, linspace(0.8, 1.2, 1000)
+        # places 1.0 midway between indices 499 and 500; after the x[1:-1]
+        # trim those become columns 498 and 499 of diffRDphase.
+        # Update these indices if n_fixed changes.
+        diffRDphase = -(diffRDphase[:, 498] + diffRDphase[:, 499]) / 2
         return hPhenom, diffRDphase
 
     # Utility functions

--- a/tests/waveforms/cbc/test_cbc_waveforms.py
+++ b/tests/waveforms/cbc/test_cbc_waveforms.py
@@ -599,3 +599,127 @@ def test_phenom_p_differentiability():
         return out * 1e21
 
     assert gradcheck(h, inputs)
+
+
+def test_taylorf2_batch_consistency():
+    freqs = torch.linspace(20.0, 300.0, 500, dtype=FLOAT64)
+    f_ref = 20.0
+    model = waveforms.TaylorF2()
+
+    _, mcs, qs, chi1s, chi2s, dists, phases, theta_jns = zip(
+        *ALIGNED_TEST_CASES, strict=True
+    )
+    batch_hc, batch_hp = model(
+        freqs,
+        torch.tensor(mcs, dtype=FLOAT64),
+        torch.tensor(qs, dtype=FLOAT64),
+        torch.tensor(chi1s, dtype=FLOAT64),
+        torch.tensor(chi2s, dtype=FLOAT64),
+        torch.tensor(dists, dtype=FLOAT64),
+        torch.tensor(phases, dtype=FLOAT64),
+        torch.tensor(theta_jns, dtype=FLOAT64),
+        f_ref,
+    )
+
+    for i, (_, mc, q, chi1, chi2, dist, phase, theta_jn) in enumerate(
+        ALIGNED_TEST_CASES
+    ):
+        hc, hp = model(
+            freqs,
+            torch.tensor([mc], dtype=FLOAT64),
+            torch.tensor([q], dtype=FLOAT64),
+            torch.tensor([chi1], dtype=FLOAT64),
+            torch.tensor([chi2], dtype=FLOAT64),
+            torch.tensor([dist], dtype=FLOAT64),
+            torch.tensor([phase], dtype=FLOAT64),
+            torch.tensor([theta_jn], dtype=FLOAT64),
+            f_ref,
+        )
+        assert compute_match(batch_hp[i], hp[0]) > TARGET_OVERLAP
+        assert compute_match(batch_hc[i], hc[0]) > TARGET_OVERLAP
+
+
+def test_phenomd_batch_consistency():
+    freqs = torch.linspace(20.0, 300.0, 500, dtype=FLOAT64)
+    f_ref = 20.0
+    model = waveforms.IMRPhenomD()
+
+    _, mcs, qs, chi1s, chi2s, dists, phases, theta_jns = zip(
+        *ALIGNED_TEST_CASES, strict=True
+    )
+    batch_hc, batch_hp = model(
+        freqs,
+        torch.tensor(mcs, dtype=FLOAT64),
+        torch.tensor(qs, dtype=FLOAT64),
+        torch.tensor(chi1s, dtype=FLOAT64),
+        torch.tensor(chi2s, dtype=FLOAT64),
+        torch.tensor(dists, dtype=FLOAT64),
+        torch.tensor(phases, dtype=FLOAT64),
+        torch.tensor(theta_jns, dtype=FLOAT64),
+        f_ref,
+    )
+
+    for i, (_, mc, q, chi1, chi2, dist, phase, theta_jn) in enumerate(
+        ALIGNED_TEST_CASES
+    ):
+        hc, hp = model(
+            freqs,
+            torch.tensor([mc], dtype=FLOAT64),
+            torch.tensor([q], dtype=FLOAT64),
+            torch.tensor([chi1], dtype=FLOAT64),
+            torch.tensor([chi2], dtype=FLOAT64),
+            torch.tensor([dist], dtype=FLOAT64),
+            torch.tensor([phase], dtype=FLOAT64),
+            torch.tensor([theta_jn], dtype=FLOAT64),
+            f_ref,
+        )
+        assert compute_match(batch_hp[i], hp[0]) > TARGET_OVERLAP
+        assert compute_match(batch_hc[i], hc[0]) > TARGET_OVERLAP
+
+
+def test_phenomp_batch_consistency():
+    freqs = torch.linspace(20.0, 300.0, 500, dtype=FLOAT64)
+    f_ref = 20.0
+    model = waveforms.IMRPhenomPv2()
+
+    _, mcs, qs, chi1s, chi2s, dists, phases, theta_jns = zip(
+        *PRECESSING_TEST_CASES, strict=True
+    )
+    chi1x, chi1y, chi1z = zip(*chi1s, strict=True)
+    chi2x, chi2y, chi2z = zip(*chi2s, strict=True)
+    batch_hc, batch_hp = model(
+        freqs,
+        torch.tensor(mcs, dtype=FLOAT64),
+        torch.tensor(qs, dtype=FLOAT64),
+        torch.tensor(chi1x, dtype=FLOAT64),
+        torch.tensor(chi1y, dtype=FLOAT64),
+        torch.tensor(chi1z, dtype=FLOAT64),
+        torch.tensor(chi2x, dtype=FLOAT64),
+        torch.tensor(chi2y, dtype=FLOAT64),
+        torch.tensor(chi2z, dtype=FLOAT64),
+        torch.tensor(dists, dtype=FLOAT64),
+        torch.tensor(phases, dtype=FLOAT64),
+        torch.tensor(theta_jns, dtype=FLOAT64),
+        f_ref,
+    )
+
+    for i, (_, mc, q, chi1, chi2, dist, phase, theta_jn) in enumerate(
+        PRECESSING_TEST_CASES
+    ):
+        hc, hp = model(
+            freqs,
+            torch.tensor([mc], dtype=FLOAT64),
+            torch.tensor([q], dtype=FLOAT64),
+            torch.tensor([chi1[0]], dtype=FLOAT64),
+            torch.tensor([chi1[1]], dtype=FLOAT64),
+            torch.tensor([chi1[2]], dtype=FLOAT64),
+            torch.tensor([chi2[0]], dtype=FLOAT64),
+            torch.tensor([chi2[1]], dtype=FLOAT64),
+            torch.tensor([chi2[2]], dtype=FLOAT64),
+            torch.tensor([dist], dtype=FLOAT64),
+            torch.tensor([phase], dtype=FLOAT64),
+            torch.tensor([theta_jn], dtype=FLOAT64),
+            f_ref,
+        )
+        assert compute_match(batch_hp[i], hp[0]) > TARGET_OVERLAP
+        assert compute_match(batch_hc[i], hc[0]) > TARGET_OVERLAP


### PR DESCRIPTION
@deepchatterjeeligo Found a bug in PhenomPv2 when computing batched waveforms. The `x` passed to `interpolate` has shape `(batch, 998)`, with each row ranging from 0.8 to 1.2. When `flatten` is called during interpolation, the array is no longer sorted, and so `searchsorted` shouldn't be used. Given that we hard-code `n_fixed` anyway, I've just hard-coded the indices that should be used.

I've also added tests to cover this behavior.