### PR TITLE
Heterodyne optimization

### DIFF
--- a/ml4gw/transforms/heterodyne.py
+++ b/ml4gw/transforms/heterodyne.py
@@ -122,12 +122,10 @@ class Heterodyne(torch.nn.Module):
                 - If ``return_type="both"`` → `(time, freq)`
         """
 
-        X_fft = torch.fft.rfft(X, dim=-1)
-        X_fft /= self.sample_rate
+        X_fft = torch.fft.rfft(X, dim=-1, norm="forward")
         X_heterodyned = X_fft[:, :, None] * self.heterodyning_phase[None, :, :]
         X_heterodyned[..., 0] = 0
-        X_ifft = torch.fft.irfft(X_heterodyned, dim=-1)
-        X_ifft *= self.sample_rate
+        X_ifft = torch.fft.irfft(X_heterodyned, dim=-1, norm="forward")
 
         if self.return_type == "time":
             return X_ifft


### PR DESCRIPTION
Removing redundant amplitude scaling computation by introducing `norm` argument in the `FFT` operations. This helps speed up the heterodyne computation.

## `Benchmarks on A40`

```
| Benchmark                          |  Baseline |   Current | Delta             |
|------------------------------------|-----------|-----------|-------------------|
| test_heterodyne_forward[batch_32]  | 145.55 μs | 121.24 μs | Improved (-16.7%) |
| test_heterodyne_forward[batch_128] | 175.23 μs | 142.41 μs | Improved (-18.7%) |
| test_heterodyne_forward[batch_512] | 528.28 μs | 341.24 μs | Improved (-35.4%) |
```
