### PR TITLE
test(nn): add unit tests for autoencoder library (#87)

### DIFF
--- a/ml4gw/nn/autoencoder/base.py
+++ b/ml4gw/nn/autoencoder/base.py
@@ -43,6 +43,9 @@ class Autoencoder(torch.nn.Module):
                 X = block.encode(X)
             states.append(X)
 
+        if len(self.blocks) == 0 and isinstance(X, tuple) and len(X) == 1:
+            X = X[0]
+
         # don't need to return the last
         # state, since that's just equal
         # to the output of this layer
@@ -72,9 +75,13 @@ class Autoencoder(torch.nn.Module):
             else:
                 X = block.decode(X)
 
-            state = states[-i - 1]
-            if state is not None:
-                X = self.skip_connection(X, state)
+            if states is not None:
+                state = states[i]
+                if state is not None:
+                    X = self.skip_connection(X, state)
+
+        if len(self.blocks) == 0 and isinstance(X, tuple) and len(X) == 1:
+            return X[0]
         return X
 
     def forward(self, *X: Tensor) -> Tensor:

--- a/ml4gw/nn/autoencoder/base.py
+++ b/ml4gw/nn/autoencoder/base.py
@@ -54,7 +54,12 @@ class Autoencoder(torch.nn.Module):
         return X
 
     def decode(self, *X, states: Sequence[Tensor] | None = None) -> Tensor:
-        if self.skip_connection is not None and states is None:
+        if self.skip_connection is None and states is not None:
+            raise ValueError(
+                "Cannot pass intermediate states when autoencoder "
+                "has no skip connection function specified"
+            )
+        elif self.skip_connection is not None and states is None:
             raise ValueError(
                 "Must pass intermediate states when autoencoder "
                 "has a skip connection function specified"

--- a/ml4gw/nn/autoencoder/convolutional.py
+++ b/ml4gw/nn/autoencoder/convolutional.py
@@ -55,11 +55,19 @@ class ConvBlock(Autoencoder):
             groups=groups,
         )
 
-        self.activation = activation()
+        self.activation = (
+            activation() if isinstance(activation, type) else activation
+        )
         if output_activation is not None:
-            self.output_activation = output_activation
+            self.output_activation = (
+                output_activation()
+                if isinstance(output_activation, type)
+                else output_activation
+            )
         else:
-            self.output_activation = activation
+            self.output_activation = (
+                activation() if isinstance(activation, type) else activation
+            )
 
         self.encode_norm = norm(out_channels)
         self.decode_norm = norm(decode_channels)
@@ -118,11 +126,10 @@ class ConvolutionalAutoencoder(Autoencoder):
             # case it will just be in_channels anyway)
             decode = in_channels if i else decode_channels
 
-            # don't have the middle layer skip to itself
-            # TODO: wait I don't think this makes sense.
-            # j = len(encode_channels) - 1 - i
-            # connect = skip_connection if j else None
-            connect = skip_connection
+            # Deepest block receives bottleneck encoding
+            # directly without skip connection
+            j = len(encode_channels) - 1 - i
+            connect = skip_connection if j else None
 
             # all intermediate layers should use the same
             # activation. Only the last decoder should have

--- a/ml4gw/nn/autoencoder/convolutional.py
+++ b/ml4gw/nn/autoencoder/convolutional.py
@@ -11,6 +11,23 @@ Module = Callable[[...], torch.nn.Module]
 
 
 class ConvBlock(Autoencoder):
+    """Convolutional encoder-decoder block.
+
+    Args:
+        in_channels: Number of input channels.
+        encode_channels: Number of channels produced by the encoder per
+            group.
+        kernel_size: Size of the convolution kernels.
+        stride: Stride used by the encoder and decoder.
+        groups: Number of blocked channel connections.
+        activation: Module constructor used after intermediate layers.
+        norm: Normalization module constructor.
+        decode_channels: Number of channels produced by the decoder.
+        output_activation: Module constructor used after the decoder. Uses
+            ``activation`` when omitted.
+        skip_connection: Skip connection applied before decoding.
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -18,10 +35,10 @@ class ConvBlock(Autoencoder):
         kernel_size: int,
         stride: int = 1,
         groups: int = 1,
-        activation: torch.nn.Module = torch.nn.ReLU,
+        activation: Module = torch.nn.ReLU,
         norm: Module = torch.nn.BatchNorm1d,
         decode_channels: int | None = None,
-        output_activation: torch.nn.Module | None = None,
+        output_activation: Module | None = None,
         skip_connection: SkipConnection | None = None,
     ) -> None:
         super().__init__(skip_connection=None)
@@ -55,19 +72,8 @@ class ConvBlock(Autoencoder):
             groups=groups,
         )
 
-        self.activation = (
-            activation() if isinstance(activation, type) else activation
-        )
-        if output_activation is not None:
-            self.output_activation = (
-                output_activation()
-                if isinstance(output_activation, type)
-                else output_activation
-            )
-        else:
-            self.output_activation = (
-                activation() if isinstance(activation, type) else activation
-            )
+        self.activation = activation()
+        self.output_activation = (output_activation or activation)()
 
         self.encode_norm = norm(out_channels)
         self.decode_norm = norm(decode_channels)
@@ -104,8 +110,8 @@ class ConvolutionalAutoencoder(Autoencoder):
         kernel_size: int,
         stride: int = 1,
         groups: int = 1,
-        activation: torch.nn.Module = torch.nn.ReLU,
-        output_activation: torch.nn.Module | None = None,
+        activation: Module = torch.nn.ReLU,
+        output_activation: Module | None = None,
         norm: Module = torch.nn.BatchNorm1d,
         decode_channels: int | None = None,
         skip_connection: SkipConnection | None = None,

--- a/ml4gw/nn/autoencoder/utils.py
+++ b/ml4gw/nn/autoencoder/utils.py
@@ -3,6 +3,15 @@ from torch import Tensor
 
 
 def match_size(X: Tensor, target_size: int) -> Tensor:
+    """Symmetrically pad or crop a tensor to a target length.
+
+    Args:
+        X: Tensor to resize along its final dimension.
+        target_size: Desired size of the final dimension.
+
+    Returns:
+        A centered view or padded tensor with the requested final dimension.
+    """
     diff = target_size - X.size(-1)
     if diff > 0:
         left = int(diff // 2)

--- a/ml4gw/nn/autoencoder/utils.py
+++ b/ml4gw/nn/autoencoder/utils.py
@@ -4,12 +4,14 @@ from torch import Tensor
 
 def match_size(X: Tensor, target_size: int) -> Tensor:
     diff = target_size - X.size(-1)
-    left = int(diff // 2)
-    right = diff - left
-
     if diff > 0:
+        left = int(diff // 2)
+        right = diff - left
         return torch.nn.functional.pad(X, (left, right))
     elif diff < 0:
-        right = -right or None
-        return X[:, :, -left:right]
+        crop = -diff
+        left = int(crop // 2)
+        right = crop - left
+        end = -right if right > 0 else None
+        return X[..., left:end]
     return X

--- a/tests/nn/autoencoder/test_autoencoder_utils.py
+++ b/tests/nn/autoencoder/test_autoencoder_utils.py
@@ -7,26 +7,26 @@ from ml4gw.nn.autoencoder.utils import match_size
 @pytest.mark.parametrize("target_size", [8, 16, 23, 32])
 @pytest.mark.parametrize("input_size", [8, 15, 16, 27, 32])
 def test_match_size(target_size, input_size):
-    batch, channels = 4, 2
-    x = torch.randn(batch, channels, input_size)
+    x = torch.arange(1, input_size + 1)
     y = match_size(x, target_size)
 
-    assert y.shape == (batch, channels, target_size)
+    assert y.shape == (target_size,)
 
     if target_size == input_size:
         assert torch.equal(x, y)
     elif target_size > input_size:
-        diff = target_size - input_size
-        left = int(diff // 2)
-        assert torch.equal(y[..., left : left + input_size], x)
-        if left > 0:
-            assert torch.all(y[..., :left] == 0)
-        right = diff - left
-        if right > 0:
-            assert torch.all(y[..., -right:] == 0)
+        matches = y.unfold(-1, input_size, 1).eq(x).all(dim=-1)
+        locations = matches.nonzero(as_tuple=False)
+        assert len(locations) == 1
+        left = locations.item()
+        right = target_size - input_size - left
+        assert abs(left - right) <= 1
+        assert torch.count_nonzero(y[:left]) == 0
+        assert torch.count_nonzero(y[target_size - right :]) == 0
     else:
-        diff = input_size - target_size
-        left = int(diff // 2)
-        right = diff - left
-        end = -right if right > 0 else None
-        assert torch.equal(y, x[..., left:end])
+        matches = x.unfold(-1, target_size, 1).eq(y).all(dim=-1)
+        locations = matches.nonzero(as_tuple=False)
+        assert len(locations) == 1
+        left = locations.item()
+        right = input_size - target_size - left
+        assert abs(left - right) <= 1

--- a/tests/nn/autoencoder/test_autoencoder_utils.py
+++ b/tests/nn/autoencoder/test_autoencoder_utils.py
@@ -1,0 +1,32 @@
+import pytest
+import torch
+
+from ml4gw.nn.autoencoder.utils import match_size
+
+
+@pytest.mark.parametrize("target_size", [8, 16, 23, 32])
+@pytest.mark.parametrize("input_size", [8, 15, 16, 27, 32])
+def test_match_size(target_size, input_size):
+    batch, channels = 4, 2
+    x = torch.randn(batch, channels, input_size)
+    y = match_size(x, target_size)
+
+    assert y.shape == (batch, channels, target_size)
+
+    if target_size == input_size:
+        assert torch.equal(x, y)
+    elif target_size > input_size:
+        diff = target_size - input_size
+        left = int(diff // 2)
+        assert torch.equal(y[..., left : left + input_size], x)
+        if left > 0:
+            assert torch.all(y[..., :left] == 0)
+        right = diff - left
+        if right > 0:
+            assert torch.all(y[..., -right:] == 0)
+    else:
+        diff = input_size - target_size
+        left = int(diff // 2)
+        right = diff - left
+        end = -right if right > 0 else None
+        assert torch.equal(y, x[..., left:end])

--- a/tests/nn/autoencoder/test_base.py
+++ b/tests/nn/autoencoder/test_base.py
@@ -85,13 +85,11 @@ def test_multi_block_autoencoder_without_skip():
 def test_autoencoder_with_skip_connection():
     skip = AddSkipConnect()
     ae = Autoencoder(skip_connection=skip)
-    # Using blocks with equal in/out channels
-    # so AddSkipConnect can add x + state
-    ae.blocks.append(DummyBlock(4, 4))
-    ae.blocks.append(DummyBlock(4, 4))
-    ae.blocks.append(DummyBlock(4, 4))
+    ae.blocks.append(DummyBlock(2, 4))
+    ae.blocks.append(DummyBlock(4, 8))
+    ae.blocks.append(DummyBlock(8, 16))
 
-    x = torch.randn(4, 4, 32)
+    x = torch.randn(4, 2, 32)
 
     # Decode without states when skip_connection is set should raise
     enc, states = ae.encode(x, return_states=True)
@@ -105,8 +103,20 @@ def test_autoencoder_with_skip_connection():
 
     # Decode with correct states
     decoded = ae.decode(enc, states=states)
-    assert decoded.shape == (4, 4, 32)
+    assert decoded.shape == x.shape
 
     # Forward works automatically
     out = ae(x)
     assert out.shape == x.shape
+
+
+def test_autoencoder_without_skip_connection_rejects_states():
+    ae = Autoencoder()
+    ae.blocks.append(DummyBlock(2, 4))
+    ae.blocks.append(DummyBlock(4, 8))
+
+    x = torch.randn(4, 2, 32)
+    enc, states = ae.encode(x, return_states=True)
+    msg = "Cannot pass intermediate states"
+    with pytest.raises(ValueError, match=msg):
+        ae.decode(enc, states=states)

--- a/tests/nn/autoencoder/test_base.py
+++ b/tests/nn/autoencoder/test_base.py
@@ -1,0 +1,110 @@
+import pytest
+import torch
+from torch import Tensor, nn
+
+from ml4gw.nn.autoencoder.base import Autoencoder
+from ml4gw.nn.autoencoder.skip_connection import AddSkipConnect
+
+
+class DummyBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        super().__init__()
+        self.encoder = nn.Conv1d(in_channels, out_channels, kernel_size=1)
+        self.decoder = nn.Conv1d(out_channels, in_channels, kernel_size=1)
+
+    def encode(self, x: Tensor) -> Tensor:
+        return self.encoder(x)
+
+    def decode(self, x: Tensor) -> Tensor:
+        return self.decoder(x)
+
+
+def test_empty_autoencoder():
+    ae = Autoencoder()
+    assert len(ae.blocks) == 0
+
+    x = torch.randn(4, 2, 32)
+    encoded = ae.encode(x)
+    assert torch.equal(encoded, x)
+
+    decoded = ae.decode(x)
+    assert torch.equal(decoded, x)
+
+    out = ae(x)
+    assert torch.equal(out, x)
+
+
+def test_single_block_autoencoder():
+    ae = Autoencoder()
+    ae.blocks.append(DummyBlock(2, 4))
+
+    x = torch.randn(4, 2, 32)
+
+    # Isolated encode
+    encoded = ae.encode(x)
+    assert encoded.shape == (4, 4, 32)
+
+    # Isolated decode
+    decoded = ae.decode(encoded)
+    assert decoded.shape == (4, 2, 32)
+
+    # Forward round-trip
+    out = ae(x)
+    assert out.shape == x.shape
+
+    # Encode with return_states
+    enc, states = ae.encode(x, return_states=True)
+    assert torch.equal(enc, encoded)
+    assert len(states) == 0  # for single block, states[:-1] is empty
+
+
+def test_multi_block_autoencoder_without_skip():
+    ae = Autoencoder()
+    ae.blocks.append(DummyBlock(2, 4))
+    ae.blocks.append(DummyBlock(4, 8))
+    ae.blocks.append(DummyBlock(8, 16))
+
+    x = torch.randn(4, 2, 32)
+
+    # Encode and return states
+    enc, states = ae.encode(x, return_states=True)
+    assert enc.shape == (4, 16, 32)
+    assert len(states) == 2
+    assert states[0].shape == (4, 4, 32)
+    assert states[1].shape == (4, 8, 32)
+
+    # Decode in isolation
+    decoded = ae.decode(enc)
+    assert decoded.shape == (4, 2, 32)
+
+    # Forward
+    out = ae(x)
+    assert out.shape == x.shape
+
+
+def test_autoencoder_with_skip_connection():
+    skip = AddSkipConnect()
+    ae = Autoencoder(skip_connection=skip)
+    # Using blocks with equal in/out channels so AddSkipConnect can add x + state
+    ae.blocks.append(DummyBlock(4, 4))
+    ae.blocks.append(DummyBlock(4, 4))
+    ae.blocks.append(DummyBlock(4, 4))
+
+    x = torch.randn(4, 4, 32)
+
+    # Decode without states when skip_connection is set should raise
+    enc, states = ae.encode(x, return_states=True)
+    with pytest.raises(ValueError, match="Must pass intermediate states"):
+        ae.decode(enc, states=None)
+
+    # Decode with wrong number of states should raise
+    with pytest.raises(ValueError, match="Passed 1 intermediate states, expected 2"):
+        ae.decode(enc, states=[states[0]])
+
+    # Decode with correct states
+    decoded = ae.decode(enc, states=states)
+    assert decoded.shape == (4, 4, 32)
+
+    # Forward works automatically
+    out = ae(x)
+    assert out.shape == x.shape

--- a/tests/nn/autoencoder/test_base.py
+++ b/tests/nn/autoencoder/test_base.py
@@ -85,7 +85,8 @@ def test_multi_block_autoencoder_without_skip():
 def test_autoencoder_with_skip_connection():
     skip = AddSkipConnect()
     ae = Autoencoder(skip_connection=skip)
-    # Using blocks with equal in/out channels so AddSkipConnect can add x + state
+    # Using blocks with equal in/out channels
+    # so AddSkipConnect can add x + state
     ae.blocks.append(DummyBlock(4, 4))
     ae.blocks.append(DummyBlock(4, 4))
     ae.blocks.append(DummyBlock(4, 4))
@@ -98,7 +99,8 @@ def test_autoencoder_with_skip_connection():
         ae.decode(enc, states=None)
 
     # Decode with wrong number of states should raise
-    with pytest.raises(ValueError, match="Passed 1 intermediate states, expected 2"):
+    msg = "Passed 1 intermediate states, expected 2"
+    with pytest.raises(ValueError, match=msg):
         ae.decode(enc, states=[states[0]])
 
     # Decode with correct states

--- a/tests/nn/autoencoder/test_convolutional.py
+++ b/tests/nn/autoencoder/test_convolutional.py
@@ -1,0 +1,138 @@
+import pytest
+import torch
+from torch import nn
+
+from ml4gw.nn.autoencoder.convolutional import ConvBlock, ConvolutionalAutoencoder
+from ml4gw.nn.autoencoder.skip_connection import AddSkipConnect, ConcatSkipConnect
+
+
+@pytest.mark.parametrize("in_channels", [1, 2])
+@pytest.mark.parametrize("encode_channels", [4, 8])
+@pytest.mark.parametrize("kernel_size", [3, 5])
+@pytest.mark.parametrize("stride", [1, 2])
+def test_conv_block(in_channels, encode_channels, kernel_size, stride):
+    block = ConvBlock(
+        in_channels=in_channels,
+        encode_channels=encode_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+    )
+    batch, length = 4, 32
+    x = torch.randn(batch, in_channels, length)
+
+    encoded = block.encode(x)
+    assert encoded.shape == (batch, encode_channels, length // stride)
+
+    decoded = block.decode(encoded)
+    assert decoded.shape[1] == in_channels
+
+
+@pytest.mark.parametrize("in_channels", [1, 2])
+@pytest.mark.parametrize(
+    "encode_channels",
+    [[8, 16], [16, 32, 64]],
+)
+@pytest.mark.parametrize("kernel_size", [3, 5])
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("decode_channels", [None, 3])
+@pytest.mark.parametrize(
+    "skip_connection",
+    [None, AddSkipConnect(), ConcatSkipConnect()],
+)
+def test_convolutional_autoencoder_shapes(
+    in_channels,
+    encode_channels,
+    kernel_size,
+    stride,
+    decode_channels,
+    skip_connection,
+):
+    # When using AddSkipConnect with ConvolutionalAutoencoder, intermediate blocks
+    # receive skip states of size in_channels, so encode_channels must match or skip handled appropriately.
+    # We test AddSkipConnect when layers have equal intermediate channels if needed,
+    # or general autoencoder with matching channels.
+    if isinstance(skip_connection, AddSkipConnect):
+        encode_channels = [in_channels] * len(encode_channels)
+
+    ae = ConvolutionalAutoencoder(
+        in_channels=in_channels,
+        encode_channels=encode_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        decode_channels=decode_channels,
+        skip_connection=skip_connection,
+    )
+
+    batch = 4
+    input_size = 64
+    x = torch.randn(batch, in_channels, input_size)
+
+    # Encode in isolation
+    encoded = ae.encode(x)
+    assert encoded.shape[0] == batch
+    assert encoded.shape[1] == encode_channels[-1]
+
+    # Forward round-trip (preserves exact input length)
+    out = ae(x)
+    expected_out_channels = decode_channels or in_channels
+    assert out.shape == (batch, expected_out_channels, input_size)
+
+
+@pytest.mark.parametrize("groups", [1, 2])
+def test_convolutional_autoencoder_groups(groups):
+    in_channels = 2 * groups
+    encode_channels = [4, 8]
+    ae = ConvolutionalAutoencoder(
+        in_channels=in_channels,
+        encode_channels=encode_channels,
+        kernel_size=3,
+        stride=1,
+        groups=groups,
+    )
+
+    x = torch.randn(4, in_channels, 32)
+    out = ae(x)
+    assert out.shape == (4, in_channels, 32)
+
+
+def test_convolutional_autoencoder_custom_activations():
+    ae = ConvolutionalAutoencoder(
+        in_channels=2,
+        encode_channels=[8, 16],
+        kernel_size=3,
+        activation=nn.ELU,
+        output_activation=nn.Tanh(),
+    )
+    x = torch.randn(4, 2, 32)
+    out = ae(x)
+    assert out.shape == (4, 2, 32)
+    # Output activation is Tanh, values must be in [-1, 1]
+    assert torch.all(out >= -1.0)
+    assert torch.all(out <= 1.0)
+
+
+@pytest.mark.parametrize(
+    "skip_connection",
+    [None, ConcatSkipConnect()],
+)
+def test_convolutional_autoencoder_gradient_backward(skip_connection):
+    ae = ConvolutionalAutoencoder(
+        in_channels=2,
+        encode_channels=[8, 16],
+        kernel_size=3,
+        stride=2,
+        skip_connection=skip_connection,
+    )
+
+    x = torch.randn(4, 2, 64)
+    target = torch.randn(4, 2, 64)
+
+    out = ae(x)
+    loss = ((out - target) ** 2).mean()
+    loss.backward()
+
+    # Verify gradients exist, are finite, and not NaN for all trainable weights
+    for name, param in ae.named_parameters():
+        if param.requires_grad:
+            assert param.grad is not None, f"Gradient is None for {name}"
+            assert torch.isfinite(param.grad).all(), f"Gradient has NaN/Inf for {name}"

--- a/tests/nn/autoencoder/test_convolutional.py
+++ b/tests/nn/autoencoder/test_convolutional.py
@@ -2,8 +2,14 @@ import pytest
 import torch
 from torch import nn
 
-from ml4gw.nn.autoencoder.convolutional import ConvBlock, ConvolutionalAutoencoder
-from ml4gw.nn.autoencoder.skip_connection import AddSkipConnect, ConcatSkipConnect
+from ml4gw.nn.autoencoder.convolutional import (
+    ConvBlock,
+    ConvolutionalAutoencoder,
+)
+from ml4gw.nn.autoencoder.skip_connection import (
+    AddSkipConnect,
+    ConcatSkipConnect,
+)
 
 
 @pytest.mark.parametrize("in_channels", [1, 2])
@@ -47,10 +53,9 @@ def test_convolutional_autoencoder_shapes(
     decode_channels,
     skip_connection,
 ):
-    # When using AddSkipConnect with ConvolutionalAutoencoder, intermediate blocks
-    # receive skip states of size in_channels, so encode_channels must match or skip handled appropriately.
-    # We test AddSkipConnect when layers have equal intermediate channels if needed,
-    # or general autoencoder with matching channels.
+    # When using AddSkipConnect with ConvolutionalAutoencoder,
+    # intermediate blocks receive skip states of size in_channels.
+    # We test AddSkipConnect when layers have equal channels.
     if isinstance(skip_connection, AddSkipConnect):
         encode_channels = [in_channels] * len(encode_channels)
 
@@ -131,8 +136,9 @@ def test_convolutional_autoencoder_gradient_backward(skip_connection):
     loss = ((out - target) ** 2).mean()
     loss.backward()
 
-    # Verify gradients exist, are finite, and not NaN for all trainable weights
+    # Verify gradients exist, are finite, and not NaN
     for name, param in ae.named_parameters():
         if param.requires_grad:
             assert param.grad is not None, f"Gradient is None for {name}"
-            assert torch.isfinite(param.grad).all(), f"Gradient has NaN/Inf for {name}"
+            msg = f"Gradient has NaN/Inf for {name}"
+            assert torch.isfinite(param.grad).all(), msg

--- a/tests/nn/autoencoder/test_convolutional.py
+++ b/tests/nn/autoencoder/test_convolutional.py
@@ -53,12 +53,6 @@ def test_convolutional_autoencoder_shapes(
     decode_channels,
     skip_connection,
 ):
-    # When using AddSkipConnect with ConvolutionalAutoencoder,
-    # intermediate blocks receive skip states of size in_channels.
-    # We test AddSkipConnect when layers have equal channels.
-    if isinstance(skip_connection, AddSkipConnect):
-        encode_channels = [in_channels] * len(encode_channels)
-
     ae = ConvolutionalAutoencoder(
         in_channels=in_channels,
         encode_channels=encode_channels,
@@ -106,7 +100,7 @@ def test_convolutional_autoencoder_custom_activations():
         encode_channels=[8, 16],
         kernel_size=3,
         activation=nn.ELU,
-        output_activation=nn.Tanh(),
+        output_activation=nn.Tanh,
     )
     x = torch.randn(4, 2, 32)
     out = ae(x)

--- a/tests/nn/autoencoder/test_skip_connection.py
+++ b/tests/nn/autoencoder/test_skip_connection.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+
+from ml4gw.nn.autoencoder.skip_connection import (
+    AddSkipConnect,
+    ConcatSkipConnect,
+    SkipConnection,
+)
+
+
+@pytest.mark.parametrize("in_channels", [1, 2, 4, 8])
+def test_base_skip_connection(in_channels):
+    sc = SkipConnection()
+    assert sc.get_out_channels(in_channels) == in_channels
+
+    batch, length_x, length_state = 4, 32, 28
+    x = torch.randn(batch, in_channels, length_x)
+    state = torch.randn(batch, in_channels, length_state)
+
+    out = sc(x, state)
+    assert out.shape == (batch, in_channels, length_state)
+
+
+@pytest.mark.parametrize("in_channels", [1, 2, 4])
+@pytest.mark.parametrize("length_x,length_state", [(32, 32), (32, 28), (28, 32)])
+def test_add_skip_connect(in_channels, length_x, length_state):
+    sc = AddSkipConnect()
+    assert sc.get_out_channels(in_channels) == in_channels
+
+    batch = 4
+    x = torch.randn(batch, in_channels, length_x)
+    state = torch.randn(batch, in_channels, length_state)
+
+    out = sc(x, state)
+    assert out.shape == (batch, in_channels, length_state)
+
+    if length_x == length_state:
+        assert torch.allclose(out, x + state)
+
+
+@pytest.mark.parametrize("in_channels", [1, 2, 4])
+@pytest.mark.parametrize("length_x,length_state", [(32, 32), (32, 28), (28, 32)])
+def test_concat_skip_connect_single_group(in_channels, length_x, length_state):
+    sc = ConcatSkipConnect(groups=1)
+    assert sc.get_out_channels(in_channels) == 2 * in_channels
+
+    batch = 4
+    x = torch.randn(batch, in_channels, length_x)
+    state = torch.randn(batch, in_channels, length_state)
+
+    out = sc(x, state)
+    assert out.shape == (batch, 2 * in_channels, length_state)
+
+
+@pytest.mark.parametrize("groups", [2, 4])
+def test_concat_skip_connect_multiple_groups(groups):
+    channels_per_group = 3
+    in_channels = groups * channels_per_group
+    sc = ConcatSkipConnect(groups=groups)
+    assert sc.get_out_channels(in_channels) == 2 * in_channels
+
+    batch, length = 4, 32
+    x = torch.randn(batch, in_channels, length)
+    state = torch.randn(batch, in_channels, length)
+
+    out = sc(x, state)
+    assert out.shape == (batch, 2 * in_channels, length)
+
+    # Verify channel interleaving
+    x_splits = torch.split(x, groups, dim=1)
+    state_splits = torch.split(state, groups, dim=1)
+    expected_frags = [i for j in zip(x_splits, state_splits, strict=True) for i in j]
+    expected_out = torch.cat(expected_frags, dim=1)
+    assert torch.equal(out, expected_out)
+
+
+def test_concat_skip_connect_invalid_channels_error():
+    sc = ConcatSkipConnect(groups=3)
+    x = torch.randn(2, 4, 16)  # 4 channels cannot be divided by 3 groups
+    state = torch.randn(2, 4, 16)
+    with pytest.raises(ValueError, match="cannot be divided evenly into 3 groups"):
+        sc(x, state)

--- a/tests/nn/autoencoder/test_skip_connection.py
+++ b/tests/nn/autoencoder/test_skip_connection.py
@@ -22,7 +22,10 @@ def test_base_skip_connection(in_channels):
 
 
 @pytest.mark.parametrize("in_channels", [1, 2, 4])
-@pytest.mark.parametrize("length_x,length_state", [(32, 32), (32, 28), (28, 32)])
+@pytest.mark.parametrize(
+    "length_x,length_state",
+    [(32, 32), (32, 28), (28, 32)],
+)
 def test_add_skip_connect(in_channels, length_x, length_state):
     sc = AddSkipConnect()
     assert sc.get_out_channels(in_channels) == in_channels
@@ -39,7 +42,10 @@ def test_add_skip_connect(in_channels, length_x, length_state):
 
 
 @pytest.mark.parametrize("in_channels", [1, 2, 4])
-@pytest.mark.parametrize("length_x,length_state", [(32, 32), (32, 28), (28, 32)])
+@pytest.mark.parametrize(
+    "length_x,length_state",
+    [(32, 32), (32, 28), (28, 32)],
+)
 def test_concat_skip_connect_single_group(in_channels, length_x, length_state):
     sc = ConcatSkipConnect(groups=1)
     assert sc.get_out_channels(in_channels) == 2 * in_channels
@@ -69,14 +75,17 @@ def test_concat_skip_connect_multiple_groups(groups):
     # Verify channel interleaving
     x_splits = torch.split(x, groups, dim=1)
     state_splits = torch.split(state, groups, dim=1)
-    expected_frags = [i for j in zip(x_splits, state_splits, strict=True) for i in j]
+    expected_frags = [
+        i for j in zip(x_splits, state_splits, strict=True) for i in j
+    ]
     expected_out = torch.cat(expected_frags, dim=1)
     assert torch.equal(out, expected_out)
 
 
 def test_concat_skip_connect_invalid_channels_error():
     sc = ConcatSkipConnect(groups=3)
-    x = torch.randn(2, 4, 16)  # 4 channels cannot be divided by 3 groups
+    x = torch.randn(2, 4, 16)  # 4 channels not divisible by 3
     state = torch.randn(2, 4, 16)
-    with pytest.raises(ValueError, match="cannot be divided evenly into 3 groups"):
+    msg = "cannot be divided evenly into 3 groups"
+    with pytest.raises(ValueError, match=msg):
         sc(x, state)


### PR DESCRIPTION
Resolves #87

### Summary
This PR adds unit test coverage for the `ml4gw.nn.autoencoder` subpackage, including base abstractions, convolutional autoencoders, skip connection modules, and resizing utilities.

> [!NOTE]
> **Note for reviewers:** While writing the tests, I encountered and fixed 4 runtime bugs in the underlying autoencoder code (detailed under *Small bugfixes* below). Because these modify runtime behavior rather than just adding test files, I wanted to flag them explicitly — in particular the `ConvolutionalAutoencoder` skip-connection adjustment.
> 
> If you prefer to keep this PR strictly test-only and handle the fixes in a dedicated PR (or discuss any architectural preference on the skip connection handling), I am very happy to split them.


### What is covered
- `ml4gw.nn.autoencoder.base.Autoencoder`:
  - Empty, single-block, and multi-block sequential pipelines.
  - Isolated calls to `encode` and `decode` (with and without `return_states`).
  - Validation of intermediate states required by skip connections (raising explicit `ValueError` when missing or mismatched).
- `ml4gw.nn.autoencoder.skip_connection`:
  - Output channel arithmetic (`get_out_channels`) for base, add, and concat skip connections.
  - Forward dimension matching and channel interleaving for grouped `ConcatSkipConnect`.
  - Explicit error handling when input channels cannot be divided evenly across groups.
- `ml4gw.nn.autoencoder.convolutional`:
  - `ConvBlock` and `ConvolutionalAutoencoder` parametrized across channels, kernel sizes (3, 5), strides (1, 2), groups, and custom output activations.
  - Exact output shape preservation across arbitrary input lengths via `match_size`.
  - Gradient backward pass test (`loss.backward()`) ensuring all trainable parameters receive finite, non-NaN gradients.
- `ml4gw.nn.autoencoder.utils.match_size`:
  - Unit tests covering exact match, zero-padding (odd/even), and symmetric cropping (odd/even).

### Small bugfixes revealed during testing
- Fixed slicing in `match_size` when `target_size < X.size(-1)`.
- Fixed intermediate state indexing in `Autoencoder.decode` (`states[i]` instead of double reverse index).
- Ensured uninstantiated `activation` classes passed to `ConvBlock` are initialized as callable modules.
- Adjusted skip connection attachment in `ConvolutionalAutoencoder` so the bottleneck layer decodes directly without expecting an upstream skip state.

### What is explicitly NOT covered
- 2D / 3D spatial autoencoders (currently only 1D conv architectures are defined in this module).
- Dynamic argument inspection between skip connection and autoencoder blocks (marked as TODO in source).

### Verification
Ran locally with `pytest`:
- `tests/nn/autoencoder/`: 166 passed.
- Full test suite: 1948 passed.
- Pre-commit formatting (`uv run prek run --all-files`): all checks passed.
