### PR TITLE
fix(slicing): handle full-length kernels (#86)

### DIFF
--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -313,11 +313,7 @@ def sample_kernels(
         )
 
     if X.ndim == 1:
-        max_idx = len(X) - kernel_size
-        if max_idx == 0:
-            idx = torch.zeros(N, dtype=torch.long)
-        else:
-            idx = torch.randint(max_idx, size=(N,))
+        idx = torch.randint(len(X) - kernel_size + 1, size=(N,))
         if return_idx:
             return slice_kernels(X, idx, kernel_size), idx
         return slice_kernels(X, idx, kernel_size)
@@ -326,7 +322,7 @@ def sample_kernels(
 
     if max_center_offset is None:
         # sample uniformly from all of X's time dimension
-        min_val, max_val = 0, X.shape[-1] - kernel_size
+        min_val, max_val = 0, X.shape[-1] - kernel_size + 1
     elif max_center_offset >= 0:
         # a positive max_center_offset means we're allowed
         # to put some space between the center of the timeseries
@@ -368,10 +364,7 @@ def sample_kernels(
         # will require its own sampling index
         shape = (N, len(X))
 
-    if min_val == max_val:
-        idx = torch.full(shape, min_val, dtype=torch.long, device=X.device)
-    else:
-        idx = torch.randint(min_val, max_val, size=shape).to(X.device)
+    idx = torch.randint(min_val, max_val, size=shape).to(X.device)
     if return_idx:
         return slice_kernels(X, idx, kernel_size), idx
     return slice_kernels(X, idx, kernel_size)

--- a/ml4gw/utils/slicing.py
+++ b/ml4gw/utils/slicing.py
@@ -313,7 +313,11 @@ def sample_kernels(
         )
 
     if X.ndim == 1:
-        idx = torch.randint(len(X) - kernel_size, size=(N,))
+        max_idx = len(X) - kernel_size
+        if max_idx == 0:
+            idx = torch.zeros(N, dtype=torch.long)
+        else:
+            idx = torch.randint(max_idx, size=(N,))
         if return_idx:
             return slice_kernels(X, idx, kernel_size), idx
         return slice_kernels(X, idx, kernel_size)
@@ -364,7 +368,10 @@ def sample_kernels(
         # will require its own sampling index
         shape = (N, len(X))
 
-    idx = torch.randint(min_val, max_val, size=shape).to(X.device)
+    if min_val == max_val:
+        idx = torch.full(shape, min_val, dtype=torch.long, device=X.device)
+    else:
+        idx = torch.randint(min_val, max_val, size=shape).to(X.device)
     if return_idx:
         return slice_kernels(X, idx, kernel_size), idx
     return slice_kernels(X, idx, kernel_size)

--- a/tests/utils/test_slicing.py
+++ b/tests/utils/test_slicing.py
@@ -374,3 +374,38 @@ def test_sample_kernels_2d_return_idx():
     result, idx = slicing.sample_kernels(X, kernel_size, N=5, return_idx=True)
     assert result.shape == (5, 3, kernel_size)
     assert idx.shape == (5,)
+
+
+@pytest.mark.parametrize(
+    "shape,N,coincident,expected_shape,expected_idx_shape",
+    [
+        ((10,), 3, True, (3, 10), (3,)),
+        ((2, 10), 3, True, (3, 2, 10), (3,)),
+        ((2, 10), 3, False, (3, 2, 10), (3, 2)),
+        ((3, 2, 10), None, True, (3, 2, 10), (3,)),
+    ],
+)
+def test_sample_kernels_full_length(
+    shape, N, coincident, expected_shape, expected_idx_shape
+):
+    X = torch.arange(np.prod(shape)).reshape(shape)
+
+    result, idx = slicing.sample_kernels(
+        X,
+        kernel_size=shape[-1],
+        N=N,
+        coincident=coincident,
+        return_idx=True,
+    )
+
+    assert result.shape == expected_shape
+    assert idx.shape == expected_idx_shape
+    assert torch.count_nonzero(idx) == 0
+
+    if X.ndim == 1:
+        expected = X.repeat(N, 1)
+    elif X.ndim == 2:
+        expected = X.repeat(N, 1, 1)
+    else:
+        expected = X
+    assert torch.equal(result, expected)

--- a/tests/utils/test_slicing.py
+++ b/tests/utils/test_slicing.py
@@ -172,7 +172,7 @@ def test_sample_kernels_1D(kernel_size, num_channels):
     return_value = 7 * torch.arange(N)
     with patch("torch.randint", return_value=return_value) as mock:
         result = slicing.sample_kernels(x, kernel_size, N)
-    mock.assert_called_once_with(100 - kernel_size, size=(N,))
+    mock.assert_called_once_with(100 - kernel_size + 1, size=(N,))
 
     assert result.shape == (N, kernel_size)
     for i, y in enumerate(result.cpu().numpy()):
@@ -258,7 +258,7 @@ def test_sample_kernels_2D(
     result = result.cpu().numpy()
 
     if max_center_offset is None:
-        min_val, max_val = 0, 100 - kernel_size
+        min_val, max_val = 0, 100 - kernel_size + 1
     elif max_center_offset == 0:
         min_val, max_val = 50 - kernel_size, 50
     elif max_center_offset == -4:
@@ -339,7 +339,7 @@ def test_sample_kernels_3D(kernel_size, num_channels, max_center_offset, N):
     result = result.cpu().numpy()
 
     if max_center_offset is None:
-        min_val, max_val = 0, 100 - kernel_size
+        min_val, max_val = 0, 100 - kernel_size + 1
     elif max_center_offset == 0:
         min_val, max_val = 50 - kernel_size, 50
     elif max_center_offset == -4:


### PR DESCRIPTION
## Summary

- handle the single valid sampling position when the input length equals `kernel_size`
- preserve the existing output and index shapes for 1D, 2D coincident/non-coincident, and 3D inputs
- add regression coverage for each supported input shape

Closes #86

## Verification

- `.venv/Scripts/python.exe -m pytest tests/utils -q`: 128 passed
- `uvx prek run --all-files`: all hooks passed

## AI assistance

I used OpenAI Codex to help investigate, implement, and test this patch. I reviewed the diff and verified the behavior locally.