### PR TITLE
feat(transforms): add causal minimum-phase whitening (#246)

### DIFF
--- a/benchmarks/transforms/test_whitening.py
+++ b/benchmarks/transforms/test_whitening.py
@@ -3,7 +3,7 @@
 import torch
 from constants import KERNEL_LEN, NUM_CHANNELS, NUM_SAMPLES, SAMPLE_RATE
 
-from ml4gw.transforms import FixedWhiten, Whiten
+from ml4gw.transforms import FixedWhiten, MinimumPhaseWhiten, Whiten
 
 FDURATION = 0.5
 NUM_SAMPLES_WHITEN = SAMPLE_RATE * 4
@@ -31,5 +31,21 @@ def test_fixed_whiten_forward(benchmark, batch_size, device, maybe_sync):
     bg = torch.randn(NUM_CHANNELS, NUM_SAMPLES)
     whitener.fit(FDURATION, bg[0], bg[1], fftlength=KERNEL_LEN)
     whitener = whitener.to(device)
+    x = torch.randn(batch_size, NUM_CHANNELS, NUM_SAMPLES, device=device)
+    benchmark(maybe_sync(whitener), x)
+
+
+def test_minimum_phase_whiten_forward(
+    benchmark, batch_size, device, maybe_sync
+):
+    whitener = MinimumPhaseWhiten(
+        num_channels=NUM_CHANNELS,
+        kernel_length=FDURATION,
+        sample_rate=SAMPLE_RATE,
+    )
+    num_freqs = int(FDURATION * SAMPLE_RATE) // 2 + 1
+    psd = torch.ones(num_freqs)
+    whitener.fit(*(psd for _ in range(NUM_CHANNELS)))
+    whitener = whitener.float().to(device)
     x = torch.randn(batch_size, NUM_CHANNELS, NUM_SAMPLES, device=device)
     benchmark(maybe_sync(whitener), x)

--- a/docs/examples/transforms.whitening.rst
+++ b/docs/examples/transforms.whitening.rst
@@ -27,3 +27,29 @@ Whitening
    # power spectral density computed using, e.g., the 
    # `SpectralDensity` transform.
    X_whitened = whitener(X, psd)
+
+Minimum-phase whitening
+-----------------------
+
+For online applications, a minimum-phase filter can whiten data without
+depending on future samples. Fit the filter from one background timeseries or
+PSD per channel, then apply it to tensors of any duration:
+
+.. code-block:: python
+
+   from ml4gw.transforms import MinimumPhaseWhiten
+
+   whitener = MinimumPhaseWhiten(
+      num_channels=2,
+      kernel_length=2,
+      sample_rate=2048,
+   )
+
+   # Passing fftlength means the inputs are interpreted as timeseries.
+   whitener.fit(background_h1, background_l1, fftlength=2)
+   X_whitened = whitener(X)
+
+The output has the same shape as the input. The first
+``kernel_length * sample_rate - 1`` samples use zero-valued history; when
+processing consecutive chunks, prepend that many real historical samples and
+discard their outputs.

--- a/docs/examples/transforms.whitening.rst
+++ b/docs/examples/transforms.whitening.rst
@@ -50,6 +50,7 @@ PSD per channel, then apply it to tensors of any duration:
    X_whitened = whitener(X)
 
 The output has the same shape as the input. The first
-``kernel_length * sample_rate - 1`` samples use zero-valued history; when
+``int(kernel_length * sample_rate) - 1`` samples use zero-valued history; when
 processing consecutive chunks, prepend that many real historical samples and
-discard their outputs.
+discard their outputs. Directly supplied PSDs at physical strain scale should
+use double precision to avoid underflow in ``torch.float32``.

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -453,6 +453,8 @@ def minimum_phase_whitening_filter(
         psd:
             A strictly positive, finite one-sided power spectral density.
             Any leading dimensions are treated as batch dimensions.
+            Use double precision for unscaled physical PSDs whose values may
+            fall below the representable range of ``torch.float32``.
         n_fft:
             Length of the desired impulse response. If omitted, an even
             length of ``2 * (psd.size(-1) - 1)`` is inferred.
@@ -465,6 +467,13 @@ def minimum_phase_whitening_filter(
         ValueError:
             If the PSD shape is inconsistent with ``n_fft``, or if it
             contains a non-finite or non-positive value.
+
+    Notes:
+        The folded-cepstrum construction follows the
+        `zlw MPWhiteningFilter implementation`_ at commit ``b81871cd``.
+
+        .. _zlw MPWhiteningFilter implementation:
+            https://git.ligo.org/james.kennington/zlw/-/blob/b81871cdea5769bfb0a3b4ea57debbf6170d0c64/src/zlw/kernels.py
     """
     if psd.ndim == 0:
         raise ValueError("PSD must have a frequency dimension")

--- a/ml4gw/spectral.py
+++ b/ml4gw/spectral.py
@@ -439,6 +439,82 @@ def truncate_inverse_power_spectrum(
     return psd / 2
 
 
+def minimum_phase_whitening_filter(
+    psd: PSDTensor, n_fft: int | None = None
+) -> Tensor:
+    """Construct a causal, minimum-phase whitening filter.
+
+    The filter is obtained by spectral factorization of the inverse power
+    spectral density using a folded real cepstrum. Its one-sided frequency
+    response has magnitude ``1 / sqrt(psd)``, while its phase minimizes the
+    delay of the corresponding impulse response.
+
+    Args:
+        psd:
+            A strictly positive, finite one-sided power spectral density.
+            Any leading dimensions are treated as batch dimensions.
+        n_fft:
+            Length of the desired impulse response. If omitted, an even
+            length of ``2 * (psd.size(-1) - 1)`` is inferred.
+
+    Returns:
+        A real-valued impulse response with the same leading dimensions as
+            ``psd`` and length ``n_fft``.
+
+    Raises:
+        ValueError:
+            If the PSD shape is inconsistent with ``n_fft``, or if it
+            contains a non-finite or non-positive value.
+    """
+    if psd.ndim == 0:
+        raise ValueError("PSD must have a frequency dimension")
+    if psd.size(-1) < 2:
+        raise ValueError("PSD must contain at least two frequency bins")
+    if n_fft is None:
+        n_fft = 2 * (psd.size(-1) - 1)
+    if n_fft < 2 or psd.size(-1) != n_fft // 2 + 1:
+        raise ValueError(
+            "PSD length must equal n_fft // 2 + 1, but found "
+            f"{psd.size(-1)} bins for n_fft={n_fft}"
+        )
+    if not torch.is_floating_point(psd):
+        raise ValueError("PSD must be a floating-point tensor")
+    if not bool(torch.isfinite(psd).all()):
+        raise ValueError("PSD must contain only finite values")
+    if not bool((psd > 0).all()):
+        raise ValueError("PSD must contain only positive values")
+
+    log_amplitude = -0.5 * torch.log(psd)
+    reflection_end = -1 if n_fft % 2 == 0 else None
+    reflected = torch.flip(log_amplitude[..., 1:reflection_end], dims=(-1,))
+    log_amplitude = torch.cat((log_amplitude, reflected), dim=-1)
+
+    cepstrum = torch.fft.ifft(log_amplitude, dim=-1)
+    midpoint = n_fft // 2
+    if n_fft % 2 == 0:
+        folded = torch.cat(
+            (
+                cepstrum[..., :1],
+                2 * cepstrum[..., 1:midpoint],
+                cepstrum[..., midpoint : midpoint + 1],
+                torch.zeros_like(cepstrum[..., midpoint + 1 :]),
+            ),
+            dim=-1,
+        )
+    else:
+        folded = torch.cat(
+            (
+                cepstrum[..., :1],
+                2 * cepstrum[..., 1 : midpoint + 1],
+                torch.zeros_like(cepstrum[..., midpoint + 1 :]),
+            ),
+            dim=-1,
+        )
+
+    response = torch.exp(torch.fft.fft(folded, dim=-1))
+    return torch.fft.irfft(response[..., : psd.size(-1)], n=n_fft, dim=-1)
+
+
 def normalize_by_psd(
     X: WaveformTensor,
     psd: PSDTensor,

--- a/ml4gw/transforms/__init__.py
+++ b/ml4gw/transforms/__init__.py
@@ -16,4 +16,4 @@ from .spectral import SpectralDensity
 from .spectrogram import MultiResolutionSpectrogram
 from .spline_interpolation import SplineInterpolate1D, SplineInterpolate2D
 from .waveforms import WaveformProjector, WaveformSampler
-from .whitening import FixedWhiten, Whiten
+from .whitening import FixedWhiten, MinimumPhaseWhiten, Whiten

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -291,9 +291,10 @@ class MinimumPhaseWhiten(FittableSpectralTransform):
     Unlike :class:`Whiten`, this transform never uses future samples to
     compute an output. The filter is fit once from a background PSD and then
     applied with left padding, which represents zero-valued history. Callers
-    processing consecutive chunks should prepend real input history and
-    discard the corresponding warm-up outputs. The transform does not remove
-    a running mean, since doing so would introduce a future-sample dependency.
+    processing consecutive chunks should prepend
+    ``int(kernel_length * sample_rate) - 1`` real input samples and discard
+    the same number of warm-up outputs. The transform does not remove a
+    running mean, since doing so would introduce a future-sample dependency.
 
     Args:
         num_channels:
@@ -342,7 +343,9 @@ class MinimumPhaseWhiten(FittableSpectralTransform):
             *background:
                 One time- or frequency-domain tensor per channel. Inputs are
                 interpreted as one-sided PSDs when ``fftlength`` is ``None``;
-                otherwise Welch PSDs are estimated from the timeseries.
+                otherwise Welch PSDs are estimated from the timeseries. Use
+                double precision for unscaled physical PSDs whose values may
+                fall below the representable range of ``torch.float32``.
             fftlength:
                 Length in seconds of Welch frames used for time-domain input.
             overlap:

--- a/ml4gw/transforms/whitening.py
+++ b/ml4gw/transforms/whitening.py
@@ -283,3 +283,111 @@ class FixedWhiten(FittableSpectralTransform):
         return spectral.normalize_by_psd(
             X, self.psd, self.sample_rate, pad, crop
         )
+
+
+class MinimumPhaseWhiten(FittableSpectralTransform):
+    """Whiten timeseries with a causal minimum-phase FIR filter.
+
+    Unlike :class:`Whiten`, this transform never uses future samples to
+    compute an output. The filter is fit once from a background PSD and then
+    applied with left padding, which represents zero-valued history. Callers
+    processing consecutive chunks should prepend real input history and
+    discard the corresponding warm-up outputs. The transform does not remove
+    a running mean, since doing so would introduce a future-sample dependency.
+
+    Args:
+        num_channels:
+            Number of channels to whiten.
+        kernel_length:
+            Length of the whitening filter in seconds.
+        sample_rate:
+            Sampling rate of input timeseries in Hz.
+        dtype:
+            Datatype used to store the fitted filter.
+
+    Shape:
+        - Input: ``(B, C, T)``
+        - Output: ``(B, C, T)``
+    """
+
+    def __init__(
+        self,
+        num_channels: int,
+        kernel_length: float,
+        sample_rate: float,
+        dtype: torch.dtype = torch.float64,
+    ) -> None:
+        super().__init__()
+        self.num_channels = num_channels
+        self.kernel_length = kernel_length
+        self.sample_rate = sample_rate
+
+        size = int(kernel_length * sample_rate)
+        if size < 2:
+            raise ValueError(
+                "Whitening filter must contain at least two samples"
+            )
+        kernel = torch.zeros((num_channels, 1, size), dtype=dtype)
+        self.register_buffer("kernel", kernel)
+
+    def fit(
+        self,
+        *background: TimeSeries1d | FrequencySeries1d,
+        fftlength: float | None = None,
+        overlap: float | None = None,
+    ) -> None:
+        """Fit a minimum-phase whitening filter to background data.
+
+        Args:
+            *background:
+                One time- or frequency-domain tensor per channel. Inputs are
+                interpreted as one-sided PSDs when ``fftlength`` is ``None``;
+                otherwise Welch PSDs are estimated from the timeseries.
+            fftlength:
+                Length in seconds of Welch frames used for time-domain input.
+            overlap:
+                Overlap in seconds between Welch frames. Defaults to half of
+                ``fftlength``.
+        """
+        if len(background) != self.num_channels:
+            raise ValueError(
+                f"Expected to fit whitening transform on {self.num_channels} "
+                f"background timeseries, but was passed {len(background)}"
+            )
+
+        num_freqs = self.kernel.size(-1) // 2 + 1
+        psds = [
+            self.normalize_psd(
+                x,
+                self.sample_rate,
+                num_freqs,
+                fftlength,
+                overlap,
+            )
+            for x in background
+        ]
+        psd = torch.stack(psds)
+        kernel = spectral.minimum_phase_whitening_filter(
+            psd, n_fft=self.kernel.size(-1)
+        )
+
+        # ML4GW PSDs are one-sided, so account for folded negative-frequency
+        # power and retain the unit-variance convention used by ``Whiten``.
+        kernel = kernel * (2 / self.sample_rate) ** 0.5
+        self.build(kernel=kernel[:, None])
+
+    def forward(self, X: TimeSeries3d) -> TimeSeries3d:
+        """Apply the fitted causal filter using zero-valued initial history."""
+        if X.ndim != 3 or X.size(1) != self.num_channels:
+            raise ValueError(
+                "Whitening transform expected input with shape "
+                f"(batch, {self.num_channels}, time), but found {X.shape}"
+            )
+
+        kernel = self.kernel.to(X)
+        X = torch.nn.functional.pad(X, (kernel.size(-1) - 1, 0))
+        return torch.nn.functional.conv1d(
+            X,
+            torch.flip(kernel, dims=(-1,)),
+            groups=self.num_channels,
+        )

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -5,7 +5,81 @@ import pytest
 import torch
 from scipy import signal
 
-from ml4gw.spectral import fast_spectral_density, spectral_density, whiten
+from ml4gw.spectral import (
+    fast_spectral_density,
+    minimum_phase_whitening_filter,
+    spectral_density,
+    whiten,
+)
+
+
+class TestMinimumPhaseWhiteningFilter:
+    def test_flat_psd_is_impulse(self):
+        psd = torch.ones(33, dtype=torch.float64)
+        kernel = minimum_phase_whitening_filter(psd)
+
+        expected = torch.zeros(64, dtype=torch.float64)
+        expected[0] = 1
+        torch.testing.assert_close(kernel, expected, rtol=0, atol=1e-12)
+
+    def test_response_has_inverse_asd_magnitude(self):
+        psd = torch.linspace(0.5, 4, 33, dtype=torch.float64).repeat(2, 1)
+        kernel = minimum_phase_whitening_filter(psd)
+        response = torch.fft.rfft(kernel, dim=-1)
+
+        torch.testing.assert_close(
+            response.abs(), psd.rsqrt(), rtol=1e-12, atol=1e-12
+        )
+
+    def test_odd_length_response(self):
+        psd = torch.linspace(0.5, 4, 33, dtype=torch.float64)
+        kernel = minimum_phase_whitening_filter(psd, n_fft=65)
+
+        assert kernel.size(-1) == 65
+        torch.testing.assert_close(
+            torch.fft.rfft(kernel).abs(),
+            psd.rsqrt(),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+    def test_first_order_filter_matches_analytic_response(self):
+        n_fft = 256
+        coefficient = 0.8
+        omega = (
+            2
+            * torch.pi
+            * torch.arange(n_fft // 2 + 1, dtype=torch.float64)
+            / n_fft
+        )
+        expected = 1 - coefficient * torch.exp(-1j * omega)
+        psd = expected.abs().square().reciprocal()
+
+        kernel = minimum_phase_whitening_filter(psd)
+
+        expected_kernel = torch.zeros(n_fft, dtype=torch.float64)
+        expected_kernel[:2] = torch.tensor(
+            [1, -coefficient], dtype=torch.float64
+        )
+        torch.testing.assert_close(kernel, expected_kernel, rtol=0, atol=3e-15)
+
+    @pytest.mark.parametrize(
+        "psd",
+        [
+            torch.tensor(1.0),
+            torch.tensor([1.0]),
+            torch.tensor([1.0, 0.0]),
+            torch.tensor([1.0, torch.inf]),
+            torch.tensor([1, 2]),
+        ],
+    )
+    def test_invalid_psd(self, psd):
+        with pytest.raises(ValueError):
+            minimum_phase_whitening_filter(psd)
+
+    def test_inconsistent_fft_length(self):
+        with pytest.raises(ValueError, match="PSD length"):
+            minimum_phase_whitening_filter(torch.ones(3), n_fft=8)
 
 
 @pytest.fixture(params=[4, 8])

--- a/tests/transforms/test_whitening.py
+++ b/tests/transforms/test_whitening.py
@@ -262,6 +262,63 @@ class TestMinimumPhaseWhiten:
         whitened = transform(X)
         torch.testing.assert_close(whitened, noise, rtol=1e-5, atol=1e-5)
 
+    def test_fit_from_timeseries(self):
+        transform = self.get_transform()
+        generator = torch.Generator().manual_seed(1234)
+        backgrounds = [
+            torch.randn(
+                4 * self.sample_rate,
+                generator=generator,
+                dtype=torch.float64,
+            )
+            for _ in range(self.num_channels)
+        ]
+
+        transform.fit(*backgrounds, fftlength=0.5)
+        X = torch.randn(
+            2,
+            self.num_channels,
+            127,
+            generator=generator,
+            dtype=torch.float64,
+        )
+        whitened = transform(X)
+
+        assert transform.built
+        assert whitened.shape == X.shape
+        assert torch.isfinite(transform.kernel).all()
+        assert torch.isfinite(whitened).all()
+
+    def test_streaming_matches_continuous_input(self):
+        transform = self.get_transform()
+        n_fft = int(self.kernel_length * self.sample_rate)
+        omega = 2 * torch.pi * torch.arange(n_fft // 2 + 1) / n_fft
+        psds = []
+        for coefficient in (0.2, 0.8):
+            response = 1 - coefficient * torch.exp(-1j * omega)
+            psds.append((2 / self.sample_rate) / response.abs().square())
+        transform.fit(*psds)
+
+        generator = torch.Generator().manual_seed(1234)
+        X = torch.randn(
+            1,
+            self.num_channels,
+            1024,
+            generator=generator,
+            dtype=torch.float64,
+        )
+        expected = transform(X)
+
+        split = 600
+        history = transform.kernel.size(-1) - 1
+        first = transform(X[..., :split])
+        second_input = X[..., split - history :]
+        second = transform(second_input)[..., history:]
+        actual = torch.cat((first, second), dim=-1)
+
+        assert not torch.allclose(transform.kernel[0], transform.kernel[1])
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
     def test_validation_and_io(self, tmp_path):
         transform = self.get_transform()
         X = torch.randn(4, self.num_channels, 1024)

--- a/tests/transforms/test_whitening.py
+++ b/tests/transforms/test_whitening.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from ml4gw.spectral import spectral_density
-from ml4gw.transforms import FixedWhiten, Whiten
+from ml4gw.transforms import FixedWhiten, MinimumPhaseWhiten, Whiten
 
 
 class WhitenModuleTest:
@@ -204,3 +204,80 @@ class TestFixedWhiten(WhitenModuleTest):
 
         assert (fresh.fduration == 2).item()
         assert (fresh.psd == transform.psd).all().item()
+
+
+class TestMinimumPhaseWhiten:
+    sample_rate = 256
+    kernel_length = 1
+    num_channels = 2
+
+    def get_transform(self):
+        return MinimumPhaseWhiten(
+            self.num_channels,
+            self.kernel_length,
+            self.sample_rate,
+        )
+
+    def test_flat_psd_is_identity(self):
+        transform = self.get_transform()
+        num_freqs = self.sample_rate // 2 + 1
+        psd = torch.full((num_freqs,), 2 / self.sample_rate)
+        transform.fit(psd, psd)
+
+        X = torch.randn(4, self.num_channels, 1024)
+        whitened = transform(X)
+
+        assert whitened.shape == X.shape
+        torch.testing.assert_close(whitened, X, rtol=1e-6, atol=1e-6)
+
+    def test_filter_is_causal(self):
+        transform = self.get_transform()
+        frequencies = torch.linspace(0, 1, self.sample_rate // 2 + 1)
+        psd = 1 + frequencies**2
+        transform.fit(psd, psd)
+
+        impulse_index = 512
+        X = torch.zeros(1, self.num_channels, 1024)
+        X[..., impulse_index] = 1
+        whitened = transform(X)
+
+        assert torch.count_nonzero(whitened[..., :impulse_index]) == 0
+        assert torch.count_nonzero(whitened[..., impulse_index:]) > 0
+
+    def test_whitens_first_order_colored_noise(self):
+        transform = self.get_transform()
+        coefficient = 0.8
+        n_fft = int(self.kernel_length * self.sample_rate)
+        omega = 2 * torch.pi * torch.arange(n_fft // 2 + 1) / n_fft
+        response = 1 - coefficient * torch.exp(-1j * omega)
+        psd = (2 / self.sample_rate) / response.abs().square()
+        transform.fit(psd, psd)
+
+        noise = torch.randn(4, self.num_channels, 1024)
+        X = torch.zeros_like(noise)
+        X[..., 0] = noise[..., 0]
+        for i in range(1, X.size(-1)):
+            X[..., i] = coefficient * X[..., i - 1] + noise[..., i]
+
+        whitened = transform(X)
+        torch.testing.assert_close(whitened, noise, rtol=1e-5, atol=1e-5)
+
+    def test_validation_and_io(self, tmp_path):
+        transform = self.get_transform()
+        X = torch.randn(4, self.num_channels, 1024)
+
+        with pytest.raises(ValueError, match="Must fit parameters"):
+            transform(X)
+        with pytest.raises(ValueError, match="Expected to fit whitening"):
+            transform.fit(torch.ones(129))
+
+        psd = torch.ones(129)
+        transform.fit(psd, psd)
+        with pytest.raises(ValueError, match="expected input with shape"):
+            transform(X[:, :1])
+
+        path = tmp_path / "minimum-phase-whiten.pt"
+        torch.save(transform.state_dict(), path)
+        fresh = self.get_transform()
+        fresh.load_state_dict(torch.load(path))
+        torch.testing.assert_close(fresh(X), transform(X))

--- a/tests/transforms/test_whitening.py
+++ b/tests/transforms/test_whitening.py
@@ -266,6 +266,9 @@ class TestMinimumPhaseWhiten:
         transform = self.get_transform()
         X = torch.randn(4, self.num_channels, 1024)
 
+        with pytest.raises(ValueError, match="at least two samples"):
+            MinimumPhaseWhiten(1, 1 / self.sample_rate, self.sample_rate)
+
         with pytest.raises(ValueError, match="Must fit parameters"):
             transform(X)
         with pytest.raises(ValueError, match="Expected to fit whitening"):


### PR DESCRIPTION
Closes #246.

## Summary

- add a Torch implementation of minimum-phase whitening filter construction using folded real-cepstrum spectral factorization
- add a fittable `MinimumPhaseWhiten` transform that applies the filter as a grouped causal FIR convolution
- preserve ML4GW's one-sided PSD normalization convention
- support both even- and odd-length impulse responses
- add scientific tests, usage documentation, and a GPU benchmark

## Motivation

The existing whitening transform relies on an acausal frequency-domain filter and therefore requires future samples and symmetric edge cropping.

The new transform fits a minimum-phase FIR kernel from background data or a PSD and applies it using only the current and previous samples. This provides a whitening path suitable for low-latency online inference.

The transform uses zero-valued history at the beginning of each input. Streaming callers can prepend `kernel_length * sample_rate - 1` historical samples and discard the corresponding warm-up outputs.

A running mean is deliberately not removed because that would introduce a future-sample dependency.

## Validation

- full ML4GW test suite: `1965 passed`
- targeted spectral and whitening tests passed on Windows and Linux/WSL
- `ruff`, `prek`, and `git diff --check` passed
- comparison with the reference `zlw` implementation:
  - maximum absolute NumPy difference: `4.8e-17`
  - exact agreement using the Torch backend
- analytical first-order filter validation
- end-to-end AR(1) colored-noise whitening validation
- explicit causality test confirming that an impulse produces no earlier output

## GPU benchmark

Environment:

- NVIDIA GeForce RTX 5070
- PyTorch 2.10.0 with CUDA 12.8

| Batch size | Mean |
| ---: | ---: |
| 32 | 0.262 ms |
| 128 | 0.676 ms |
| 512 | 2.340 ms |

All 9 whitening benchmark configurations passed.

## AI usage disclosure

OpenAI Codex was used substantially to assist with investigation, implementation, test design, documentation, and validation. Its output was checked against the reference `zlw` behavior, analytical test cases, and the complete ML4GW test suite.